### PR TITLE
Remove ForwardDiff dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.5
 CRlibm 0.5
 StaticArrays 0.3
-ForwardDiff 0.2
 RecipesBase

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -6,7 +6,7 @@ module IntervalArithmetic
 
 import CRlibm
 using StaticArrays
-using ForwardDiff
+
 
 import Base:
     +, -, *, /, //, fma,

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -80,8 +80,8 @@ end
 
 # Promotion and conversion, and other constructors
 
-promote_rule{T<:Real, N, R<:Real}(::Type{DecoratedInterval{T}},
-    ::Type{ForwardDiff.Dual{N,R}}) = ForwardDiff.Dual{N, DecoratedInterval{promote_type(T,R)}}
+# promote_rule{T<:Real, N, R<:Real}(::Type{DecoratedInterval{T}},
+#     ::Type{ForwardDiff.Dual{N,R}}) = ForwardDiff.Dual{N, DecoratedInterval{promote_type(T,R)}}
 
 promote_rule{T<:Real, S<:Real}(::Type{DecoratedInterval{T}}, ::Type{S}) =
     DecoratedInterval{promote_type(T, S)}

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -4,8 +4,8 @@
 
 # Avoid ambiguity with ForwardDiff:
 
-promote_rule{T<:Real, N, R<:Real}(::Type{Interval{T}},
-    ::Type{ForwardDiff.Dual{N,R}}) = ForwardDiff.Dual{N, Interval{promote_type(T,R)}}
+# promote_rule{T<:Real, N, R<:Real}(::Type{Interval{T}},
+#     ::Type{ForwardDiff.Dual{N,R}}) = ForwardDiff.Dual{N, Interval{promote_type(T,R)}}
 
 
 promote_rule{T<:Real, S<:Real}(::Type{Interval{T}}, ::Type{Interval{S}}) =


### PR DESCRIPTION
These were ambiguous on 0.4. They don't seem to be required any more, but see IntervalRootFinding tests.