### PR TITLE
Make Interval constructor fast by not including checks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -34,13 +34,6 @@ end
     end
 end
 
-@benchgroup "Elementary functions" begin
-    a = Interval(1, 2)
-
-    for op in (exp, log, sin, tan)
-        @bench string(op) $(op)($a)
-    end
-end
 
 @benchgroup "Sum" begin
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -34,6 +34,11 @@ end
     end
 end
 
+@benchgroup "Elementary functions" begin
+    for op in (exp, log, sin, tan)
+        @bench string(op) $(op)($a)
+    end
+end
 
 @benchgroup "Sum" begin
 

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -30,7 +30,8 @@ import Base:
     parse
 
 export
-    Interval, AbstractInterval, interval,
+    # Interval, AbstractInterval,
+    interval,
     @interval, @biginterval, @floatinterval, @make_interval,
     diam, radius, mid, mag, mig, hull,
     emptyinterval, ∅, ∞, isempty, isinterior, isdisjoint, ⪽,

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -30,7 +30,7 @@ import Base:
     parse
 
 export
-    Interval, AbstractInterval,
+    Interval, AbstractInterval, interval,
     @interval, @biginterval, @floatinterval, @make_interval,
     diam, radius, mid, mag, mig, hull,
     emptyinterval, ∅, ∞, isempty, isinterior, isdisjoint, ⪽,

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -30,7 +30,7 @@ import Base:
     parse
 
 export
-    # Interval, AbstractInterval,
+    AbstractInterval, # Interval
     interval,
     @interval, @biginterval, @floatinterval, @make_interval,
     diam, radius, mid, mag, mig, hull,

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -338,6 +338,9 @@ end
 
 mid(a::Interval{Rational{T}}) where T = (1//2) * (a.lo + a.hi)
 
+function simple_mid(a::Interval)
+    return 0.5*(a.lo + a.hi)
+end
 
 doc"""
     diam(a::Interval)

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -340,10 +340,6 @@ end
 
 mid(a::Interval{Rational{T}}) where T = (1//2) * (a.lo + a.hi)
 
-function simple_mid(a::Interval)
-    return 0.5*(a.lo + a.hi)
-end
-
 doc"""
     diam(a::Interval)
 

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -308,16 +308,18 @@ doc"""
     mid(a::Interval, α=0.5)
 
 Find the midpoint (or, in general, an intermediate point) at a distance α along the interval `a`. The default is the true midpoint at α=0.5.
+
+Assumes 0 ≤ α ≤ 1.
 """
 function mid(a::Interval{T}, α) where T
 
     isempty(a) && return convert(T, NaN)
     isentire(a) && return zero(a.lo)
 
-    a.lo == -∞ && return nextfloat(a.lo)
-    a.hi == +∞ && return prevfloat(a.hi)
+    a.lo == -∞ && return nextfloat(-∞)
+    a.hi == +∞ && return prevfloat(+∞)
 
-    @assert 0 ≤ α ≤ 1
+    # @assert 0 ≤ α ≤ 1
 
     # return (1-α) * a.lo + α * a.hi  # rounds to nearest
     return α*(a.hi - a.lo) + a.lo  # rounds to nearest

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,7 +5,11 @@
 
 ## Interval type
 
-const validity_check = false
+if haskey(ENV, "IA_VALID")
+    const validity_check = true
+else
+    const validity_check = false
+end
 
 abstract type AbstractInterval{T} <: Real end
 
@@ -21,7 +25,7 @@ struct Interval{T<:Real} <: AbstractInterval{T}
                 new(a, b)
 
             else
-                throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+                throw(ArgumentError("Interval of form [$a, $b] not allowed. Must have a ≤ b to construct interval(a, b)."))
             end
 
         end
@@ -60,6 +64,9 @@ Interval{T}(x::Interval) where T = convert(Interval{T}, x)
 Check if `(a, b)` constitute a valid interval
 """
 function isvalid(a::Real, b::Real)
+
+    # println("isvalid()")
+
     if isnan(a) || isnan(b)
         return true
     end
@@ -70,6 +77,10 @@ function isvalid(a::Real, b::Real)
         else
             return false
         end
+    end
+
+    if a == Inf || b == -Inf
+        return false
     end
 
     return true

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,7 +5,7 @@
 
 ## Interval type
 
-if haskey(ENV, "IA_VALID") || haskey(ENV, "CI") == true  # CI is for Travis
+if haskey(ENV, "IA_VALID") == true
     const validity_check = true
 else
     const validity_check = false

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -17,7 +17,7 @@ struct Interval{T<:Real} <: AbstractInterval{T}
     lo :: T
     hi :: T
 
-    function Interval{T}(a::T, b::T) where T<:Real
+    function Interval{T}(a::Real, b::Real) where T<:Real
 
         if validity_check
 

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,7 +5,7 @@
 
 ## Interval type
 
-if haskey(ENV, "IA_VALID")
+if haskey(ENV, "IA_VALID") || haskey(ENV, "CI") == true  # CI is for Travis
     const validity_check = true
 else
     const validity_check = false

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -57,6 +57,28 @@ Interval{T}(x) where T = Interval(convert(T, x))
 
 Interval{T}(x::Interval) where T = convert(Interval{T}, x)
 
+"""
+    interval(a, b)
+
+Construct a valid interval, checking the end points.
+"""
+
+function interval(a::Real, b::Real)
+
+    if isnan(a) || isnan(b)
+        return new(NaN, NaN)  # nai
+    end
+
+    if a > b
+        (isinf(a) && isinf(b)) && return Interval(a, b)  # empty interval = [∞,-∞]
+
+        throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+    end
+
+    Interval(a, b)
+end
+
+
 ## Include files
 include("special.jl")
 include("macros.jl")

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -77,6 +77,8 @@ function interval(a::Real, b::Real)
     return Interval(a, b)
 end
 
+interval(a::Real) = interval(a, a)
+
 
 ## Include files
 include("special.jl")

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,19 +5,25 @@
 
 ## Interval type
 
+const validity_check = false
+
 abstract type AbstractInterval{T} <: Real end
 
 struct Interval{T<:Real} <: AbstractInterval{T}
     lo :: T
     hi :: T
 
-    function Interval(a::Real, b::Real)
+    function Interval{T}(a::T, b::T) where T<:Real
+
         if validity_check
+
             if isvalid(a, b)
                 new(a, b)
+
             else
                 throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
             end
+
         end
 
         new(a, b)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -75,6 +75,14 @@ function isvalid(a::Real, b::Real)
     return true
 end
 
+function interval(a::Real, b::Real)
+    if !isvalid(a, b)
+        throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+    end
+
+    return Interval(a, b)
+end
+
 
 ## Include files
 include("special.jl")

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -115,11 +115,11 @@ include("hyperbolic.jl")
 
 # a..b = Interval(convert(Interval, a).lo, convert(Interval, b).hi)
 
-..(a::Integer, b::Integer) = Interval(a, b)
-..(a::Integer, b::Real) = Interval(a, nextfloat(float(b)))
-..(a::Real, b::Integer) = Interval(prevfloat(float(a)), b)
+..(a::Integer, b::Integer) = interval(a, b)
+..(a::Integer, b::Real) = interval(a, nextfloat(float(b)))
+..(a::Real, b::Integer) = interval(prevfloat(float(a)), b)
 
-..(a::Real, b::Real) = Interval(prevfloat(float(a)), nextfloat(float(b)))
+..(a::Real, b::Real) = interval(prevfloat(float(a)), nextfloat(float(b)))
 
 macro I_str(ex)  # I"[3,4]"
     @interval(ex)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,35 +5,32 @@
 
 ## Interval type
 
+<<<<<<< HEAD
 abstract type AbstractInterval{T} <: Real end
+=======
+const validity_check = false
+
+abstract AbstractInterval <: Real
+>>>>>>> Add boolean to add or remove validity check on Interval
 
 struct Interval{T<:Real} <: AbstractInterval{T}
     lo :: T
     hi :: T
 
-    function Interval{T}(a::Real, b::Real) where T
-
-        if isnan(a) || isnan(b)
-            return new(NaN, NaN)  # nai
+    function Interval(a::Real, b::Real)
+        if validity_check
+            if isvalid(a, b)
+                new(a, b)
+            else
+                throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+            end
         end
 
-        if a > b
-            # empty interval = [∞,-∞]
-            (isinf(a) && isinf(b)) && return new(a, b)
-            throw(ArgumentError("Must have a ≤ b to construct Interval(a, b)."))
-        end
-
-        # The IEEE Std 1788-2015 states that a < Inf and b > -Inf;
-        # see page 6, "bounds".
-        if a == Inf || b == -Inf
-            throw(ArgumentError(
-                "Must satisfy `a < Inf` and `b > -Inf` to construct Interval(a, b)."))
-        end
-
-        return new(a,b)
+        new(a, b)
 
     end
 end
+
 
 
 ## Outer constructors
@@ -58,24 +55,24 @@ Interval{T}(x) where T = Interval(convert(T, x))
 Interval{T}(x::Interval) where T = convert(Interval{T}, x)
 
 """
-    interval(a, b)
+    isvalid(a::Real, b::Real)
 
-Construct a valid interval, checking the end points.
+Check if `(a, b)` constitute a valid interval
 """
-
-function interval(a::Real, b::Real)
-
+function isvalid(a::Real, b::Real)
     if isnan(a) || isnan(b)
-        return new(NaN, NaN)  # nai
+        return true
     end
 
     if a > b
-        (isinf(a) && isinf(b)) && return Interval(a, b)  # empty interval = [∞,-∞]
-
-        throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+        if isinf(a) && isinf(b)
+            return true  # empty interval = [∞,-∞]
+        else
+            return false
+        end
     end
 
-    Interval(a, b)
+    return true
 end
 
 

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -21,7 +21,7 @@ struct Interval{T<:Real} <: AbstractInterval{T}
 
         if validity_check
 
-            if isvalid(a, b)
+            if is_valid_interval(a, b)
                 new(a, b)
 
             else
@@ -59,16 +59,20 @@ Interval{T}(x) where T = Interval(convert(T, x))
 Interval{T}(x::Interval) where T = convert(Interval{T}, x)
 
 """
-    isvalid(a::Real, b::Real)
+    is_valid_interval(a::Real, b::Real)
 
 Check if `(a, b)` constitute a valid interval
 """
-function isvalid(a::Real, b::Real)
+function is_valid_interval(a::Real, b::Real)
 
     # println("isvalid()")
 
     if isnan(a) || isnan(b)
-        return true
+        if isnan(a) && isnan(b)
+            return true
+        else
+            return false
+        end
     end
 
     if a > b
@@ -86,9 +90,14 @@ function isvalid(a::Real, b::Real)
     return true
 end
 
+"""
+    interval(a, b)
+
+`interval(a, b)` checks whether [a, b] is a valid `Interval`, which is the case if `-∞ <= a <= b <= ∞`, using the (non-exported) `is_valid_interval` function. If so, then an `Interval(a, b)` object is returned; if not, then an error is thrown.
+"""
 function interval(a::Real, b::Real)
-    if !isvalid(a, b)
-        throw(ArgumentError("Must have a ≤ b to construct interval(a, b)."))
+    if !is_valid_interval(a, b)
+        throw(ArgumentError("`[$a, $b]` is not a valid interval. Need `a ≤ b` to construct `interval(a, b)`."))
     end
 
     return Interval(a, b)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -5,13 +5,7 @@
 
 ## Interval type
 
-<<<<<<< HEAD
 abstract type AbstractInterval{T} <: Real end
-=======
-const validity_check = false
-
-abstract AbstractInterval <: Real
->>>>>>> Add boolean to add or remove validity check on Interval
 
 struct Interval{T<:Real} <: AbstractInterval{T}
     lo :: T

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -89,5 +89,5 @@ function make_interval(T, expr1, expr2)
 
     expr2 = transform(expr2[1], :convert, :(Interval{$T}))
 
-    :(Interval(($expr1).lo, ($expr2).hi))
+    :(interval(($expr1).lo, ($expr2).hi))
 end

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -1,22 +1,5 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
-if VERSION >= v"0.6.0-dev"
-
-    doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
-    by a Cartesian product of $N$ `Interval`s.
-    """
-    immutable IntervalBox{N,T} <: StaticVector{N, Interval{T}}
-        data::NTuple{N,Interval{T}}
-    end
-
-else
-    doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
-    by a Cartesian product of $N$ `Interval`s.
-    """
-    immutable IntervalBox{N,T} <: StaticVector{Interval{T}}
-        data::NTuple{N,Interval{T}}
-    end
-
 doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
 by a Cartesian product of $N$ `Interval`s.
 """

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -1,5 +1,21 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
+if VERSION >= v"0.6.0-dev"
+
+    doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
+    by a Cartesian product of $N$ `Interval`s.
+    """
+    immutable IntervalBox{N,T} <: StaticVector{N, Interval{T}}
+        data::NTuple{N,Interval{T}}
+    end
+
+else
+    doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
+    by a Cartesian product of $N$ `Interval`s.
+    """
+    immutable IntervalBox{N,T} <: StaticVector{Interval{T}}
+        data::NTuple{N,Interval{T}}
+    end
 
 doc"""An `IntervalBox` is an $N$-dimensional rectangular box, given
 by a Cartesian product of $N$ `Interval`s.

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -335,4 +335,15 @@ c = @interval(0.25, 4.0)
         @test !iszero(Interval(0.0, nextfloat(0.0)))
     end
 
+    @testset "Difference between Interval and interval" begin
+        @test interval(1, 2) == Interval(1, 2)
+
+        @test inf(Interval(3, 2)) == 3
+        @test_throws ArgumentError interval(3, 2)
+
+        @test sup(Interval(Inf, Inf)) == Inf
+        @test_throws ArgumentError interval(Inf, Inf)
+
+    end
+
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -43,11 +43,11 @@ using Base.Test
 
     # Disallowed conversions with a > b
 
-    @test_throws ArgumentError Interval(2, 1)
-    @test_throws ArgumentError Interval(big(2), big(1))
-    @test_throws ArgumentError Interval(BigInt(1), 1//10)
-    @test_throws ArgumentError Interval(1, 0.1)
-    @test_throws ArgumentError Interval(big(1), big(0.1))
+    @test_throws ArgumentError interval(2, 1)
+    @test_throws ArgumentError interval(big(2), big(1))
+    @test_throws ArgumentError interval(BigInt(1), 1//10)
+    @test_throws ArgumentError interval(1, 0.1)
+    @test_throws ArgumentError interval(big(1), big(0.1))
 
     @test_throws ArgumentError @interval(2, 1)
     @test_throws ArgumentError @interval(big(2), big(1))
@@ -253,14 +253,14 @@ end
 end
 
 # issue 192:
-@testset "Disallow a single NaN in an interval" begin
-    a = Interval(NaN, 2)
-    @test isnan(a.lo) && isnan(a.hi)
-
-    a = Interval(Inf, NaN)
-    @test isnan(a.lo) && isnan(a.hi)
-
-end
+# @testset "Disallow a single NaN in an interval" begin
+#     a = interval(NaN, 2)
+#     @test isnan(a.lo) && isnan(a.hi)
+#
+#     a = interval(Inf, NaN)
+#     @test isnan(a.lo) && isnan(a.hi)
+#
+# end
 
 # issue 206:
 
@@ -304,4 +304,8 @@ end
 
     x = 3..4
     @test @interval(f(x.lo), f(x.hi)) == Interval(0.75, 0.8)
+end
+
+@testset "a..b with a > b" begin
+    @test_throws ArgumentError 3..2
 end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -54,9 +54,9 @@ using Base.Test
     @test_throws ArgumentError @interval(big(1), 1//10)
     @test_throws ArgumentError @interval(1, 0.1)
     @test_throws ArgumentError @interval(big(1), big(0.1))
-    @test_throws ArgumentError Interval(Inf)
-    @test_throws ArgumentError Interval(-Inf, -Inf)
-    @test_throws ArgumentError Interval(Inf, Inf)
+    @test_throws ArgumentError interval(Inf)
+    @test_throws ArgumentError interval(-Inf, -Inf)
+    @test_throws ArgumentError interval(Inf, Inf)
 
     # Conversion to Interval without type
     @test convert(Interval, 1) == Interval(1.0)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -253,14 +253,10 @@ end
 end
 
 # issue 192:
-# @testset "Disallow a single NaN in an interval" begin
-#     a = interval(NaN, 2)
-#     @test isnan(a.lo) && isnan(a.hi)
-#
-#     a = interval(Inf, NaN)
-#     @test isnan(a.lo) && isnan(a.hi)
-#
-# end
+@testset "Disallow a single NaN in an interval" begin
+    @test_throws ArgumentError interval(NaN, 2)
+    @test_throws ArgumentError interval(Inf, NaN)
+end
 
 # issue 206:
 

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -57,7 +57,7 @@ end
     @test Interval(1,2) ^ -3 == Interval(1/8, 1.0)
     @test Interval(0,3) ^ -3 == @interval(1/27, Inf)
     @test Interval(-1,2) ^ -3 == entireinterval()
-    @test_throws ArgumentError Interval(-1, -2) ^ -3  # wrong way round
+    @test_throws ArgumentError interval(-1, -2) ^ -3  # wrong way round
     @test Interval(-3,2) ^ (3//1) == Interval(-27, 8)
     @test Interval(0.0) ^ 1.1 == Interval(0, 0)
     @test Interval(0.0) ^ 0.0 == emptyinterval()

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -32,11 +32,6 @@ setrounding(Interval, :tight)
     @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
 end
 
-setrounding(Interval, :errorfree)
-@testset "Back to error-free rounding" begin
-    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
-end
-
 setformat(:standard)
 
 # end

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -32,6 +32,11 @@ setrounding(Interval, :tight)
     @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
 end
 
+setrounding(Interval, :errorfree)
+@testset "Back to error-free rounding" begin
+    @test sin(x) == Interval(0.47942553860420295, 0.479425538604203)
+end
+
 setformat(:standard)
 
 # end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@
 using IntervalArithmetic
 using Base.Test
 
+const Interval = IntervalArithmetic.Interval
+
 # Interval tests:
 
 setformat(:full)


### PR DESCRIPTION
The `IA_VALID` environment variable now determines if validity checks are used. E.g. run Julia with
```
IA_VALID=true julia --compilecache=no
```
to turn on validity checks; by default, they are off.