### PR TITLE
Refactor Interval{Float64}^x

### DIFF
--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -391,9 +391,6 @@ function cancelminus{T<:Real}(a::Interval{T}, b::Interval{T})
 
     c_lo > c_hi && return entireinterval(T)
 
-    c_lo == Inf && return Interval(prevfloat(c_lo), c_hi)
-    c_hi == -Inf && return Interval(c_lo, nextfloat(c_hi))
-
     a_lo = @round_down(b.lo + c_lo)
     a_hi = @round_up(b.hi + c_hi)
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -64,12 +64,12 @@ function ^(a::Interval{Float64}, n::Integer)
             if a.lo ≥ 0
                 c_lo = @round_down(a.hi^n)
                 c_hi = @round_up(a.lo^n)
-                iszero(c_hi) && return Interval(c_lo, nextfloat(c_hi))
+                c_hi == 0 && return Interval(c_lo, nextfloat(c_hi))
                 return Interval(c_lo, c_hi)
             elseif a.hi ≤ 0
                 c_lo = @round_down(a.lo^n)
                 c_hi = @round_up(a.hi^n)
-                iszero(c_hi) && return Interval(c_lo, nextfloat(c_hi))
+                c_hi == 0 && return Interval(c_lo, nextfloat(c_hi))
                 return Interval(c_lo, c_hi)
             else
                 return @round(mag(a)^n, mig(a)^n)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -23,7 +23,12 @@ immutable Interval{T<:Real} <: AbstractInterval
             throw(ArgumentError("Must have a ≤ b to construct Interval(a, b)."))
         end
 
-
+        # See Page 6 of ITF-1788, definition of "bounds"
+        if a == Inf
+            return new(prevfloat(a), b)
+        elseif b == -Inf
+            return new(a, nextfloat(b))
+        end
 
         new(a, b)
     end


### PR DESCRIPTION
This PR uses only `Float64` arithmetic to implement a method for `^(a::Interval{Float}, n::Integer)`, i.e., avoids using `big53`.