### PR TITLE
Speed up multiplication and division

### DIFF
--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -113,7 +113,7 @@ function /(a::Interval{T}, b::Interval{T}) where T<:Real
 
     S = typeof(a.lo / b.lo)
     (isempty(a) || isempty(b)) && return emptyinterval(S)
-    b == zero(b) && return emptyinterval(S)
+    iszero(b) && return emptyinterval(S)
 
     if b.lo > zero(T) # b strictly positive
 
@@ -129,15 +129,15 @@ function /(a::Interval{T}, b::Interval{T}) where T<:Real
 
     else   # b contains zero, but is not zero(b)
 
-        a == zero(a) && return zero(Interval{S})
+        iszero(a) && return zero(Interval{S})
 
-        if b.lo == zero(T)
+        if iszero(b.lo)
 
             a.lo >= zero(T) && return @round(a.lo/b.hi, Inf)
             a.hi <= zero(T) && return @round(-Inf, a.hi/b.hi)
             return entireinterval(S)
 
-        elseif b.hi == zero(T)
+        elseif iszero(b.hi)
 
             a.lo >= zero(T) && return @round(-Inf, a.lo/b.lo)
             a.hi <= zero(T) && return @round(a.hi/b.lo, Inf)

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -78,8 +78,6 @@ end
 function *(a::Interval{T}, b::Interval{T}) where T<:Real
     (isempty(a) || isempty(b)) && return emptyinterval(T)
 
-    (a == zero(a) || b == zero(b)) && return zero(a)
-
     if b.lo >= zero(T)
         a.lo >= zero(T) && return @round(a.lo*b.lo, a.hi*b.hi)
         a.hi <= zero(T) && return @round(a.lo*b.hi, a.hi*b.lo)

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -78,6 +78,8 @@ end
 function *(a::Interval{T}, b::Interval{T}) where T<:Real
     (isempty(a) || isempty(b)) && return emptyinterval(T)
 
+    (iszero(a) || iszero(b)) && return zero(Interval{T})
+
     if b.lo >= zero(T)
         a.lo >= zero(T) && return @round(a.lo*b.lo, a.hi*b.hi)
         a.hi <= zero(T) && return @round(a.lo*b.hi, a.hi*b.lo)

--- a/src/intervals/special.jl
+++ b/src/intervals/special.jl
@@ -75,6 +75,8 @@ This occurs when the interval is empty, or when the upper bound equals the lower
 """
 isatomic(x::Interval) = isempty(x) || (x.hi == x.lo) || (x.hi == nextfloat(x.lo))
 
+Base.iszero(x::Interval) = iszero(x.lo) && iszero(x.hi)
+
 # doc"""
 #     widen(x)
 #

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -326,7 +326,7 @@ c = @interval(0.25, 4.0)
 
     @testset "iszero" begin
         @test iszero(Interval(0))
-        @test iszero(Interval(0//0))
+        @test iszero(Interval(0//1))
         @test iszero(Interval(big(0)))
         @test iszero(Interval(-0.0))
         @test iszero(Interval(-0.0, 0.0))

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -324,4 +324,15 @@ c = @interval(0.25, 4.0)
 
     end
 
+    @testset "iszero" begin
+        @test iszero(Interval(0))
+        @test iszero(Interval(0//0))
+        @test iszero(Interval(big(0)))
+        @test iszero(Interval(-0.0))
+        @test iszero(Interval(-0.0, 0.0))
+
+        @test !iszero(1..2)
+        @test !iszero(Interval(0.0, nextfloat(0.0)))
+    end
+
 end


### PR DESCRIPTION
This change makes multiplication of 2 intervals almost twice as fast! And division 30% faster (24 ns instead of 35).