### PR TITLE
[WIP] force inlining along method chains of simple arithmetic ops

### DIFF
--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -74,7 +74,7 @@ for (op, f) in ( (:+, :add), (:-, :sub), (:*, :mul), (:/, :div) )
 
             mode2 = Symbol("Round", mode)
 
-            @eval $op(::IntervalRounding{:tight},
+            @eval @inline $op(::IntervalRounding{:tight},
                                 a::$T, b::$T, $mode1) = $ff(a, b, $mode2)
         end
     end
@@ -91,9 +91,9 @@ for T in (Float32, Float64)
         @eval inv(::IntervalRounding{:tight},
                             a::$T, $mode1) = inv_round(a, $mode2)
 
-                @eval sqrt(::IntervalRounding{:tight},
-                            a::$T, $mode1) = sqrt_round(a, $mode2)
-        end
+        @eval sqrt(::IntervalRounding{:tight},
+                    a::$T, $mode1) = sqrt_round(a, $mode2)
+    end
 end
 
 
@@ -214,7 +214,7 @@ function _setrounding(::Type{Interval}, rounding_type::Symbol)
 
     # binary functions:
     for f in (:+, :-, :*, :/)
-        @eval $f{T<:AbstractFloat}(a::T, b::T, r::RoundingMode) = $f($roundtype, a, b, r)
+        @eval @inline $f{T<:AbstractFloat}(a::T, b::T, r::RoundingMode) = $f($roundtype, a, b, r)
     end
 
     if rounding_type == :tight   # for remaining functions, use CRlibm


### PR DESCRIPTION
Some short methods in the chains defining simple arithmetic operations were not inlining automagically. This pull request forces inlining of the relevant methods. Among the ops I've checked (`+`, `-`, `*`, and `/` for `Float64` intervals), these changes yield better performance for `+`, `-`, and `*`, and perhaps slightly worse performance for `/` (benchmarks below); these changes could be applied selectively to avoid the regression on `/`. This treatment may also be beneficial for the methods on which other operations depend. Best!

On
```julia
julia> versioninfo()
Julia Version 0.7.0-DEV.796
Commit 2c85595 (2017-06-29 16:32 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin15.6.0)
  CPU: Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, ivybridge)
Environment:
  JULIA_EDITOR = mate
```
these changes yield approximately 1.25x speedup for `+` and `-`, approximately `1.1x` speedup for `*`, and approximately `0.98x` speedup for `/`.

Benchmark details, without these changes
```julia
  julia> randinterval() = interval(rand() - 1.0, rand())
  randinterval (generic function with 1 method)

  julia> @benchmark +(a, b) setup=(a = randinterval(); b = randinterval())
  BenchmarkTools.Trial:
    memory estimate:  0 bytes
    allocs estimate:  0
    --------------
    minimum time:     11.168 ns (0.00% GC)
    median time:      11.828 ns (0.00% GC)
    mean time:        12.880 ns (0.00% GC)
    maximum time:     72.901 ns (0.00% GC)
    --------------
    samples:          10000
    evals/sample:     998

  julia> @benchmark -(a, b) setup=(a = randinterval(); b = randinterval())
  BenchmarkTools.Trial:
    memory estimate:  0 bytes
    allocs estimate:  0
    --------------
    minimum time:     11.167 ns (0.00% GC)
    median time:      11.170 ns (0.00% GC)
    mean time:        12.025 ns (0.00% GC)
    maximum time:     167.797 ns (0.00% GC)
    --------------
    samples:          10000
    evals/sample:     998

  julia> @benchmark *(a, b) setup=(a = randinterval(); b = randinterval())
  BenchmarkTools.Trial:
    memory estimate:  0 bytes
    allocs estimate:  0
    --------------
    minimum time:     71.138 ns (0.00% GC)
    median time:      85.300 ns (0.00% GC)
    mean time:        90.461 ns (0.00% GC)
    maximum time:     385.947 ns (0.00% GC)
    --------------
    samples:          10000
    evals/sample:     974

  julia> @benchmark /(a, b) setup=(a = randinterval(); b = randinterval())
  BenchmarkTools.Trial:
    memory estimate:  0 bytes
    allocs estimate:  0
    --------------
    minimum time:     9.772 ns (0.00% GC)
    median time:      9.775 ns (0.00% GC)
    mean time:        11.271 ns (0.00% GC)
    maximum time:     68.585 ns (0.00% GC)
    --------------
    samples:          10000
    evals/sample:     999
```
and with these changes
```julia
julia> randinterval() = interval(rand() - 1.0, rand())
randinterval (generic function with 1 method)

julia> @benchmark +(a, b) setup=(a = randinterval(); b = randinterval())
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.217 ns (0.00% GC)
  median time:      9.220 ns (0.00% GC)
  mean time:        10.318 ns (0.00% GC)
  maximum time:     97.288 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> @benchmark -(a, b) setup=(a = randinterval(); b = randinterval())
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     9.218 ns (0.00% GC)
  median time:      9.220 ns (0.00% GC)
  mean time:        10.129 ns (0.00% GC)
  maximum time:     69.416 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     999

julia> @benchmark *(a, b) setup=(a = randinterval(); b = randinterval())
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     66.629 ns (0.00% GC)
  median time:      76.423 ns (0.00% GC)
  mean time:        81.739 ns (0.00% GC)
  maximum time:     293.331 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     978

julia> @benchmark /(a, b) setup=(a = randinterval(); b = randinterval())
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     10.051 ns (0.00% GC)
  median time:      10.071 ns (0.00% GC)
  mean time:        11.501 ns (0.00% GC)
  maximum time:     139.285 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998
```
