### PR TITLE
catch missing prev_float

### DIFF
--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -24,6 +24,8 @@ setrounding(Interval, :none)
 @testset "No rounding" begin
     @test rounding(Interval) == :none
     @test sin(x) == Interval(0.479425538604203, 0.479425538604203)
+    w = 0 ± big(1)
+    @test isa(w+w, Interval)
 end
 
 setrounding(Interval, :tight)


### PR DESCRIPTION
Following https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/72