### PR TITLE
Reexport Interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ julia:
   - 0.6
   - nightly
 
-# matrix:
-#   allow_failures:
-#     - julia: nightly
+matrix:
+   allow_failures:
+     - julia: nightly
 
 notifications:
   email: false

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -30,7 +30,7 @@ import Base:
     parse
 
 export
-    AbstractInterval, # Interval
+    AbstractInterval, Interval,
     interval,
     @interval, @biginterval, @floatinterval, @make_interval,
     diam, radius, mid, mag, mig, hull,


### PR DESCRIPTION
It is too annoying not to have `Interval` exported.