### PR TITLE
Introduce `closure` function, extracted out of `convert`

### DIFF
--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -112,7 +112,7 @@ convert(::Type{DecoratedInterval{T}}, x::S) where {T<:Real, S<:Integer} =
 # end
 function convert(::Type{DecoratedInterval{T}}, xx::DecoratedInterval) where T<:Real
     x = interval_part(xx)
-    x = closure(Interval{T},x)
+    x = atomic(Interval{T},x)
     DecoratedInterval( x, decoration(xx) )
 end
 

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -112,7 +112,7 @@ convert(::Type{DecoratedInterval{T}}, x::S) where {T<:Real, S<:Integer} =
 # end
 function convert(::Type{DecoratedInterval{T}}, xx::DecoratedInterval) where T<:Real
     x = interval_part(xx)
-    x = convert(Interval{T},x)
+    x = closure(Interval{T},x)
     DecoratedInterval( x, decoration(xx) )
 end
 

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -22,6 +22,52 @@ convert(::Type{Interval}, x) = closure(Interval, x)
 convert(::Type{Interval}, x::Real) = (T = typeof(float(x)); convert(Interval{T}, x))
 convert(::Type{Interval}, x::Interval) = x
 
+"""
+    closure(::Type{<:Interval}, x)
+
+Construct the tightest interval of a given type that contains the value `x`.
+
+If `x` is an `AbstractString`, the interval will be created by calling `parse`.
+
+# Examples
+
+Construct an `Interval{Float64}` containing a given `BigFloat`:
+
+```julia
+julia> x = big"0.1"
+1.000000000000000000000000000000000000000000000000000000000000000000000000000002e-01
+
+julia> i = IntervalArithmetic.closure(Interval{Float64}, x)
+[0.0999999, 0.100001]
+
+julia> i isa Interval{Float64}
+true
+
+julia> i.lo <= x <= i.hi
+true
+
+julia> i.hi === nextfloat(i.lo)
+true
+```
+
+Construct an `Interval{Float32}` containing a the real number 0.1 in two ways:
+
+```julia
+julia> i1 = IntervalArithmetic.closure(Interval{Float32}, "0.1")
+[0.0999999, 0.100001]
+
+julia> i2 = IntervalArithmetic.closure(Interval{Float32}, 1//10)
+[0.0999999, 0.100001]
+
+julia> i1 === i2
+true
+
+julia> i.lo <= 1//10 <= i.hi
+true
+```
+"""
+function closure end
+
 # Integer intervals:
 closure(::Type{Interval{T}}, x::T) where {T<:Integer} = Interval{T}(x)
 

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -18,7 +18,6 @@ convert(::Type{Interval{T}}, x::T) where {T} = Interval{T}(x)
 convert(::Type{Interval{T}}, x::Interval{T}) where {T} = x
 convert(::Type{Interval{T}}, x::Interval) where {T} = closure(Interval{T}, x)
 
-convert(::Type{Interval}, x) = closure(Interval, x)
 convert(::Type{Interval}, x::Real) = (T = typeof(float(x)); convert(Interval{T}, x))
 convert(::Type{Interval}, x::Interval) = x
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -7,7 +7,7 @@
 
 # Write explicitly like this to avoid ambiguity warnings:
 for T in (:Integer, :Rational, :Float64, :BigFloat, :Interval)
-    @eval ^(a::Interval{Float64}, x::$T) = closure(Interval{Float64}, big53(a)^x)
+    @eval ^(a::Interval{Float64}, x::$T) = atomic(Interval{Float64}, big53(a)^x)
 end
 
 
@@ -98,7 +98,7 @@ function ^(a::Interval{BigFloat}, x::BigFloat)
     a = a ∩ domain
     (isempty(x) || isempty(a)) && return emptyinterval(a)
 
-    xx = closure(Interval{BigFloat}, x)
+    xx = atomic(Interval{BigFloat}, x)
 
     # @round() can't be used directly, because both arguments may
     # Inf or -Inf, which throws an error
@@ -135,7 +135,7 @@ end
 function ^(a::Interval{Rational{T}}, x::AbstractFloat) where T<:Integer
     a = Interval(a.lo.num/a.lo.den, a.hi.num/a.hi.den)
     a = a^x
-    closure(Interval{Rational{T}}, a)
+    atomic(Interval{Rational{T}}, a)
 end
 
 # Rational power
@@ -149,13 +149,13 @@ function ^(a::Interval{BigFloat}, r::Rational{S}) where S<:Integer
         return emptyinterval(a)
     end
 
-    isinteger(r) && return closure(Interval{T}, a^round(S,r))
+    isinteger(r) && return atomic(Interval{T}, a^round(S,r))
     r == one(S)//2 && return sqrt(a)
 
     a = a ∩ domain
     (isempty(r) || isempty(a)) && return emptyinterval(a)
 
-    y = closure(Interval{BigFloat}, r)
+    y = atomic(Interval{BigFloat}, r)
 
     a^y
 end
@@ -245,7 +245,7 @@ for f in (:exp2, :exp10)
             end
         end
 
-    @eval ($f)(a::Interval{Float64}) = closure(Interval{Float64}, $f(big53(a)))  # no CRlibm version
+    @eval ($f)(a::Interval{Float64}) = atomic(Interval{Float64}, $f(big53(a)))  # no CRlibm version
 
     @eval function ($f)(a::Interval{BigFloat})
             isempty(a) && return a

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -7,7 +7,7 @@
 
 # Write explicitly like this to avoid ambiguity warnings:
 for T in (:Integer, :Rational, :Float64, :BigFloat, :Interval)
-    @eval ^(a::Interval{Float64}, x::$T) = convert(Interval{Float64}, big53(a)^x)
+    @eval ^(a::Interval{Float64}, x::$T) = closure(Interval{Float64}, big53(a)^x)
 end
 
 
@@ -98,7 +98,7 @@ function ^(a::Interval{BigFloat}, x::BigFloat)
     a = a ∩ domain
     (isempty(x) || isempty(a)) && return emptyinterval(a)
 
-    xx = convert(Interval{BigFloat}, x)
+    xx = closure(Interval{BigFloat}, x)
 
     # @round() can't be used directly, because both arguments may
     # Inf or -Inf, which throws an error
@@ -135,7 +135,7 @@ end
 function ^(a::Interval{Rational{T}}, x::AbstractFloat) where T<:Integer
     a = Interval(a.lo.num/a.lo.den, a.hi.num/a.hi.den)
     a = a^x
-    convert(Interval{Rational{T}}, a)
+    closure(Interval{Rational{T}}, a)
 end
 
 # Rational power
@@ -149,13 +149,13 @@ function ^(a::Interval{BigFloat}, r::Rational{S}) where S<:Integer
         return emptyinterval(a)
     end
 
-    isinteger(r) && return convert(Interval{T}, a^round(S,r))
+    isinteger(r) && return closure(Interval{T}, a^round(S,r))
     r == one(S)//2 && return sqrt(a)
 
     a = a ∩ domain
     (isempty(r) || isempty(a)) && return emptyinterval(a)
 
-    y = convert(Interval{BigFloat}, r)
+    y = closure(Interval{BigFloat}, r)
 
     a^y
 end
@@ -245,7 +245,7 @@ for f in (:exp2, :exp10)
             end
         end
 
-    @eval ($f)(a::Interval{Float64}) = convert(Interval{Float64}, $f(big53(a)))  # no CRlibm version
+    @eval ($f)(a::Interval{Float64}) = closure(Interval{Float64}, $f(big53(a)))  # no CRlibm version
 
     @eval function ($f)(a::Interval{BigFloat})
             isempty(a) && return a

--- a/src/intervals/hyperbolic.jl
+++ b/src/intervals/hyperbolic.jl
@@ -64,6 +64,6 @@ for f in (:tanh, :asinh, :acosh, :atanh)
     @eval function ($f)(a::Interval{Float64})
         isempty(a) && return a
 
-        closure(Interval{Float64}, ($f)(big53(a)) )
+        atomic(Interval{Float64}, ($f)(big53(a)) )
     end
 end

--- a/src/intervals/hyperbolic.jl
+++ b/src/intervals/hyperbolic.jl
@@ -64,6 +64,6 @@ for f in (:tanh, :asinh, :acosh, :atanh)
     @eval function ($f)(a::Interval{Float64})
         isempty(a) && return a
 
-        convert(Interval{Float64}, ($f)(big53(a)) )
+        closure(Interval{Float64}, ($f)(big53(a)) )
     end
 end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -56,7 +56,7 @@ Interval(x::Complex) = Interval(real(x)) + im*Interval(imag(x))
 
 Interval{T}(x) where T = Interval(convert(T, x))
 
-Interval{T}(x::Interval) where T = convert(Interval{T}, x)
+Interval{T}(x::Interval) where T = closure(Interval{T}, x)
 
 """
     is_valid_interval(a::Real, b::Real)
@@ -122,7 +122,9 @@ include("hyperbolic.jl")
 
 # Syntax for intervals
 
-a..b = interval(convert(Interval, a).lo, convert(Interval, b).hi)
+function ..(a::T, b::S) where {T, S}
+    interval(closure(Interval{T}, a).lo, closure(Interval{S}, b).hi)
+end
 
 # ..(a::Integer, b::Integer) = interval(a, b)
 # ..(a::Integer, b::Real) = interval(a, nextfloat(float(b)))
@@ -135,3 +137,4 @@ macro I_str(ex)  # I"[3,4]"
 end
 
 a ± b = (a-b)..(a+b)
+±(a::Interval, b) = (a.lo - b)..(a.hi + b)

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -56,7 +56,7 @@ Interval(x::Complex) = Interval(real(x)) + im*Interval(imag(x))
 
 Interval{T}(x) where T = Interval(convert(T, x))
 
-Interval{T}(x::Interval) where T = closure(Interval{T}, x)
+Interval{T}(x::Interval) where T = atomic(Interval{T}, x)
 
 """
     is_valid_interval(a::Real, b::Real)
@@ -123,7 +123,7 @@ include("hyperbolic.jl")
 # Syntax for intervals
 
 function ..(a::T, b::S) where {T, S}
-    interval(closure(Interval{T}, a).lo, closure(Interval{S}, b).hi)
+    interval(atomic(Interval{T}, a).lo, atomic(Interval{S}, b).hi)
 end
 
 # ..(a::Integer, b::Integer) = interval(a, b)

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -81,13 +81,13 @@ by calling `transform`."""
 function make_interval(T, expr1, expr2)
     # @show expr1, expr2
 
-    expr1 = transform(expr1, :closure, :(Interval{$T}))
+    expr1 = transform(expr1, :atomic, :(Interval{$T}))
 
     if isempty(expr2)  # only one argument
         return :(Interval($expr1))
     end
 
-    expr2 = transform(expr2[1], :closure, :(Interval{$T}))
+    expr2 = transform(expr2[1], :atomic, :(Interval{$T}))
 
     :(interval(($expr1).lo, ($expr2).hi))
 end

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -81,13 +81,13 @@ by calling `transform`."""
 function make_interval(T, expr1, expr2)
     # @show expr1, expr2
 
-    expr1 = transform(expr1, :convert, :(Interval{$T}))
+    expr1 = transform(expr1, :closure, :(Interval{$T}))
 
     if isempty(expr2)  # only one argument
         return :(Interval($expr1))
     end
 
-    expr2 = transform(expr2[1], :convert, :(Interval{$T}))
+    expr2 = transform(expr2[1], :closure, :(Interval{$T}))
 
     :(interval(($expr1).lo, ($expr2).hi))
 end

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -18,7 +18,7 @@ const parameters = IntervalParameters()
 doc"`big53` creates an equivalent `BigFloat` interval to a given `Float64` interval."
 function big53(a::Interval{Float64})
     setprecision(Interval, 53) do  # precision of Float64
-        convert(Interval{BigFloat}, a)
+        closure(Interval{BigFloat}, a)
     end
 end
 
@@ -41,7 +41,7 @@ function setprecision(::Type{Interval}, ::Type{T}, prec::Integer) where T<:Abstr
 
     parameters.precision_type = T
     parameters.precision = prec
-    parameters.pi = convert(Interval{BigFloat}, pi)
+    parameters.pi = closure(Interval{BigFloat}, pi)
 
     prec
 end
@@ -69,7 +69,7 @@ setprecision(::Type{Interval}, t::Tuple) = setprecision(Interval, t...)
 precision(::Type{Interval}) = (parameters.precision_type, parameters.precision)
 
 
-const float_interval_pi = convert(Interval{Float64}, pi)  # does not change
+const float_interval_pi = closure(Interval{Float64}, pi)  # does not change
 
 pi_interval(::Type{BigFloat}) = parameters.pi
 pi_interval(::Type{Float64})  = float_interval_pi
@@ -82,6 +82,6 @@ end
 
 
 
-float(x::Interval{T}) where T = convert( Interval{float(T)}, x)  # https://github.com/dpsanders/IntervalArithmetic.jl/issues/174
+float(x::Interval{T}) where T = closure( Interval{float(T)}, x)  # https://github.com/dpsanders/IntervalArithmetic.jl/issues/174
 
-big(x::Interval) = convert(Interval{BigFloat}, x)
+big(x::Interval) = closure(Interval{BigFloat}, x)

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -18,7 +18,7 @@ const parameters = IntervalParameters()
 doc"`big53` creates an equivalent `BigFloat` interval to a given `Float64` interval."
 function big53(a::Interval{Float64})
     setprecision(Interval, 53) do  # precision of Float64
-        closure(Interval{BigFloat}, a)
+        atomic(Interval{BigFloat}, a)
     end
 end
 
@@ -41,7 +41,7 @@ function setprecision(::Type{Interval}, ::Type{T}, prec::Integer) where T<:Abstr
 
     parameters.precision_type = T
     parameters.precision = prec
-    parameters.pi = closure(Interval{BigFloat}, pi)
+    parameters.pi = atomic(Interval{BigFloat}, pi)
 
     prec
 end
@@ -69,7 +69,7 @@ setprecision(::Type{Interval}, t::Tuple) = setprecision(Interval, t...)
 precision(::Type{Interval}) = (parameters.precision_type, parameters.precision)
 
 
-const float_interval_pi = closure(Interval{Float64}, pi)  # does not change
+const float_interval_pi = atomic(Interval{Float64}, pi)  # does not change
 
 pi_interval(::Type{BigFloat}) = parameters.pi
 pi_interval(::Type{Float64})  = float_interval_pi
@@ -82,6 +82,6 @@ end
 
 
 
-float(x::Interval{T}) where T = closure( Interval{float(T)}, x)  # https://github.com/dpsanders/IntervalArithmetic.jl/issues/174
+float(x::Interval{T}) where T = atomic( Interval{float(T)}, x)  # https://github.com/dpsanders/IntervalArithmetic.jl/issues/174
 
-big(x::Interval) = closure(Interval{BigFloat}, x)
+big(x::Interval) = atomic(Interval{BigFloat}, x)

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -19,8 +19,8 @@ This is a rather indirect way to determine if π/2 and 3π/2 are contained
 in the interval; cf. the formula for sine of an interval in
 Tucker, *Validated Numerics*."""
 
-function find_quadrants(x::AbstractFloat)
-    temp = x / half_pi(x)
+function find_quadrants(x::T) where {T<:AbstractFloat}
+    temp = closure(Interval{T}, x) / half_pi(x)
     (floor(temp.lo), floor(temp.hi))
 end
 

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -172,7 +172,7 @@ end
 function atan2(y::Interval{Float64}, x::Interval{Float64})
     (isempty(y) || isempty(x)) && return emptyinterval(Float64)
 
-    convert(Interval{Float64}, atan2(big53(y), big53(x)))
+    closure(Interval{Float64}, atan2(big53(y), big53(x)))
 end
 
 

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -20,7 +20,7 @@ in the interval; cf. the formula for sine of an interval in
 Tucker, *Validated Numerics*."""
 
 function find_quadrants(x::T) where {T<:AbstractFloat}
-    temp = closure(Interval{T}, x) / half_pi(x)
+    temp = atomic(Interval{T}, x) / half_pi(x)
     (floor(temp.lo), floor(temp.hi))
 end
 
@@ -172,7 +172,7 @@ end
 function atan2(y::Interval{Float64}, x::Interval{Float64})
     (isempty(y) || isempty(x)) && return emptyinterval(Float64)
 
-    closure(Interval{Float64}, atan2(big53(y), big53(x)))
+    atomic(Interval{Float64}, atan2(big53(y), big53(x)))
 end
 
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -64,8 +64,8 @@ using Base.Test
     @test convert(Interval, eu) == @interval(eu)
     @test convert(Interval, BigInt(1)) == Interval(BigInt(1))
     @test convert(Interval, 1//10) == @interval(1//10)
-    @test convert(Interval, 0.1) == Interval(0.09999999999999999, 0.1)
-    @test convert(Interval, big"0.1") == big"0.1"..big"0.1"
+    # @test convert(Interval, 0.1) == Interval(0.09999999999999999, 0.1) # This behavior is undesired.
+    # @test convert(Interval, big"0.1") == big"0.1"..big"0.1" # This behavior is undesired.
 
     @test convert(Interval{Rational{Int}}, 0.1) == Interval(1//10)
     # @test convert(Interval{Rational{BigInt}}, pi) == Interval{Rational{BigInt}}(pi)
@@ -73,8 +73,8 @@ using Base.Test
     ## promotion
     @test promote(Interval(2//1,3//1), Interval(1, 2)) ==
         (Interval(2.0,3.0), Interval(1.0,2.0))
-    @test promote(Interval(1.5), parse(BigFloat, "2.1")) ==
-        (Interval(BigFloat(1.5)), big"2.1"..big"2.1")
+    # @test promote(Interval(1.5), parse(BigFloat, "2.1")) ==
+    #     (Interval(BigFloat(1.5)), big"2.1"..big"2.1") # This behavior is undesired.
     @test promote(Interval(1.0), pi) == (Interval(1.0), @interval(pi))
 
     # Constructors from the macros @interval, @floatinterval @biginterval

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -64,6 +64,7 @@ using Base.Test
     @test convert(Interval, eu) == @interval(eu)
     @test convert(Interval, BigInt(1)) == Interval(BigInt(1))
     @test convert(Interval, 1//10) == @interval(1//10)
+    @test convert(Interval, Interval(0.1, 0.2)) === Interval(0.1, 0.2)
 
     @test convert(Interval{Rational{Int}}, 0.1) == Interval(1//10)
     # @test convert(Interval{Rational{BigInt}}, pi) == Interval{Rational{BigInt}}(pi)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -64,8 +64,6 @@ using Base.Test
     @test convert(Interval, eu) == @interval(eu)
     @test convert(Interval, BigInt(1)) == Interval(BigInt(1))
     @test convert(Interval, 1//10) == @interval(1//10)
-    # @test convert(Interval, 0.1) == Interval(0.09999999999999999, 0.1) # This behavior is undesired.
-    # @test convert(Interval, big"0.1") == big"0.1"..big"0.1" # This behavior is undesired.
 
     @test convert(Interval{Rational{Int}}, 0.1) == Interval(1//10)
     # @test convert(Interval{Rational{BigInt}}, pi) == Interval{Rational{BigInt}}(pi)
@@ -73,8 +71,6 @@ using Base.Test
     ## promotion
     @test promote(Interval(2//1,3//1), Interval(1, 2)) ==
         (Interval(2.0,3.0), Interval(1.0,2.0))
-    # @test promote(Interval(1.5), parse(BigFloat, "2.1")) ==
-    #     (Interval(BigFloat(1.5)), big"2.1"..big"2.1") # This behavior is undesired.
     @test promote(Interval(1.0), pi) == (Interval(1.0), @interval(pi))
 
     # Constructors from the macros @interval, @floatinterval @biginterval


### PR DESCRIPTION
This implements https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/104#issuecomment-379126777.

* `closure` essentially does what `convert` did previously.
* `convert` will now avoid calling `closure` when doing so makes sense
* all explicit uses of `convert` in the package are replaced with `closure`

Result:

```julia
julia> x = 0.1..0.2
[0.0999999, 0.200001]

julia> @btime 3.1 + $x
  19.124 ns (0 allocations: 0 bytes)
[3.19999, 3.30001]
```

Fixes https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/104.

I'm not married to the name `closure`, but it kind of works.

~~Tests almost pass, but there's a couple of failures for `tan`; this is the first:~~

https://github.com/JuliaIntervals/IntervalArithmetic.jl/blob/e6375b0bedd097e4efdc590b2ebdc52b9714811f/test/ITF1788_tests/libieeep1788_tests_elem.jl#L3629

~~`lo_quadrant` appears to be wrong. Any idea why that would be the case?~~

Never mind, already fixed it; all tests pass now.
