### PR TITLE
Use BigFloat parsing for Float64 to fix Windows bug.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-CRlibm 0.5
+CRlibm 0.6
 StaticArrays 0.5
 FastRounding 0.0.4
 AdjacentFloats 0.0.5

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -74,12 +74,22 @@ atomic(::Type{Interval{T}}, x::T) where {T<:Integer} = Interval{T}(x)
 atomic(::Type{Interval{T}}, x::AbstractString) where T<:AbstractFloat =
     parse(Interval{T}, x)
 
-function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:Real}
-    isinf(x) && return wideinterval(T(x))
+@static if is_windows()  # Windows cannot round properly
+    function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:Real}
+        isinf(x) && return wideinterval(T(x))
 
-    Interval{T}( T(x, RoundDown), T(x, RoundUp) )
-    # the rounding up could be done as nextfloat of the rounded down one?
-    # use @round_up and @round_down here?
+        Interval{T}( parse(T, string(x), RoundDown),
+                     parse(T, string(x), RoundUp) )
+    end
+
+else
+    function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:Real}
+        isinf(x) && return wideinterval(T(x))
+
+        Interval{T}( T(x, RoundDown), T(x, RoundUp) )
+        # the rounding up could be done as nextfloat of the rounded down one?
+        # use @round_up and @round_down here?
+    end
 end
 
 function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:AbstractFloat}

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -82,7 +82,7 @@ atomic(::Type{Interval{T}}, x::AbstractString) where T<:AbstractFloat =
                      parse(T, string(x), RoundUp) )
     end
 
-    function atomic(::Type{Interval{T}}, x::Irrational) where {T<:AbstractFloat}
+    function atomic(::Type{Interval{T}}, x::Union{Irrational,Rational}) where {T<:AbstractFloat}
         isinf(x) && return wideinterval(T(x))
 
         Interval{T}( T(x, RoundDown), T(x, RoundUp) )

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -82,6 +82,14 @@ atomic(::Type{Interval{T}}, x::AbstractString) where T<:AbstractFloat =
                      parse(T, string(x), RoundUp) )
     end
 
+    function atomic(::Type{Interval{T}}, x::Irrational) where {T<:AbstractFloat}
+        isinf(x) && return wideinterval(T(x))
+
+        Interval{T}( T(x, RoundDown), T(x, RoundUp) )
+        # the rounding up could be done as nextfloat of the rounded down one?
+        # use @round_up and @round_down here?
+    end
+
 else
     function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:Real}
         isinf(x) && return wideinterval(T(x))

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -59,7 +59,7 @@ function parse(::Type{Float64}, s::AbstractString, r::RoundingMode)
             end
         end
 
-    return Float64(a)
+    return Float64(a, r)
 end
 
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -29,32 +29,43 @@ In Julia v0.6 and later (but *not* in Julia v0.5), this automatically redefines 
 """Interval rounding trait type"""
 struct IntervalRounding{T} end
 
+
+
+
 # Functions that are the same for all rounding types:
-@eval begin
-    # unary plus and minus:
-    +(a::T, ::RoundingMode) where {T<:AbstractFloat} =  a  # ignore rounding
-    -(a::T, ::RoundingMode) where {T<:AbstractFloat} = -a  # ignore rounding
 
-    # zero:
-    zero(a::Interval{T}, ::RoundingMode) where {T<:AbstractFloat} = zero(T)
-    zero(::Type{T}, ::RoundingMode) where {T<:AbstractFloat} = zero(T)
+# unary plus and minus:
++(a::T, ::RoundingMode) where {T<:AbstractFloat} =  a  # ignore rounding
+-(a::T, ::RoundingMode) where {T<:AbstractFloat} = -a  # ignore rounding
 
-    convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) =
-        setrounding(BigFloat, rounding_mode) do
-            convert(BigFloat, x)
-        end
+# zero:
+zero(a::Interval{T}, ::RoundingMode) where {T<:AbstractFloat} = zero(T)
+zero(::Type{T}, ::RoundingMode) where {T<:AbstractFloat} = zero(T)
 
-    parse(::Type{T}, x, rounding_mode::RoundingMode) where {T} = setrounding(T, rounding_mode) do
-        parse(T, x)
+convert(::Type{BigFloat}, x, rounding_mode::RoundingMode) =
+    setrounding(BigFloat, rounding_mode) do
+        convert(BigFloat, x)
     end
 
-
-    sqrt(a::T, rounding_mode::RoundingMode) where {T<:Rational} = setrounding(float(T), rounding_mode) do
-        sqrt(float(a))
-    end
-
+parse(::Type{T}, x::AbstractString, rounding_mode::RoundingMode) where {T} = setrounding(T, rounding_mode) do
+    parse(T, x)
 end
 
+# use BigFloat parser to get round issues on Windows:
+function parse(::Type{Float64}, s::AbstractString, r::RoundingMode)
+    a = setprecision(BigFloat, 53) do
+            setrounding(BigFloat, r) do
+                parse(BigFloat, s)   # correctly takes account of rounding mode
+            end
+        end
+
+    return Float64(a)
+end
+
+
+sqrt(a::T, rounding_mode::RoundingMode) where {T<:Rational} = setrounding(float(T), rounding_mode) do
+    sqrt(float(a))
+end
 
 
 # no-ops for rational rounding:

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -106,7 +106,7 @@ using Base.Test
     @test b == @floatinterval(pi)
     @test nextfloat(b.lo) == b.hi
     @test convert(Interval{Float64}, @biginterval(0.1)) == a
-    x = typemax(Int)
+    x = typemax(Int64)
     @test @interval(x) == @floatinterval(x)
     @test isthin(@interval(x)) == false
     x = rand()


### PR DESCRIPTION
Remove unnecessary `@eval`.