### PR TITLE
Fix mid for large floats

### DIFF
--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -374,33 +374,31 @@ the interval `a`. The default is the true midpoint at α=0.5.
 
 Assumes 0 ≤ α ≤ 1.
 
-Unbounded intervals are special cases which respect, for `x` arbitrary
-    - `mid(-∞..x, α) == nextfloat(-∞)` (`α` arbitrary)
-    - `mid(x..+∞, α) == prevfloat(+∞)` (`α` arbitrary)
-    - `mid(-∞..+∞, 0.5) == 0`
-    - `mid(-∞..+∞, α) == nextfloat(-∞)` (`α < 0.5`)
-    - `mid(-∞..+∞, α) == prevfloat(+∞)` (`α > 0.5`)
+The infinite values `-∞` and `+∞` are replaced by respectively `nextfloat(-∞)`
+and `prevfloat(+∞)` for the sake of finding the shifted midpoint of the interval.
 """
 function mid(a::Interval{T}, α) where T
 
     isempty(a) && return convert(T, NaN)
 
-    if isentire(a)
-        α == 0.5 && return zero(a.lo)
-        # Shift center if α != 0.5
-        α < 0.5 && return nextfloat(-∞)
-        α > 0.5 && return prevfloat(+∞)
-    end
+    lo = (a.lo == -∞ ? nextfloat(-∞) : a.lo)
+    hi = (a.hi == +∞ ? prevfloat(+∞) : a.hi)
 
-    a.lo == -∞ && return nextfloat(-∞)
-    a.hi == +∞ && return prevfloat(+∞)
-
-    midpoint = α * (a.hi - a.lo) + a.lo
+    midpoint = α * (hi - lo) + lo
     isfinite(midpoint) && return midpoint
-    # Fallback in case of overflow: a.hi - a.lo == +∞
-    return (1-α) * a.lo + α * a.hi
+    # Fallback in case of overflow: hi - lo == +∞
+    return (1-α) * lo + α * hi
 end
 
+"""
+    mid(a::Interval)
+
+Find the midpoint of interval `a`.
+
+For intervals of the form `[-∞, x]` or `[x, +∞]` where `x` is finite, return
+respectively `nextfloat(-∞)` and `prevfloat(+∞)`. Note that it differs from the
+behavior of `mid(a, α=0.5)`.
+"""
 function mid(a::Interval{T}) where T
 
     isempty(a) && return convert(T, NaN)

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -369,13 +369,15 @@ end
 """
     mid(a::Interval, α=0.5)
 
-Find the midpoint (or, in general, an intermediate point) at a distance α along
-the interval `a`. The default is the true midpoint at α=0.5.
+Find an intermediate point at a relative position `α`` in the interval `a`.
+The default is the true midpoint at `α = 0.5`.
 
 Assumes 0 ≤ α ≤ 1.
 
-The infinite values `-∞` and `+∞` are replaced by respectively `nextfloat(-∞)`
-and `prevfloat(+∞)` for the sake of finding the shifted midpoint of the interval.
+Warning: if the parameter `α = 0.5` is explicitely set, the behavior differs
+from the default case if the provided `Interval` is not finite, since when
+`α` is provided `mid` simply replaces `+∞` (respectively `-∞`) by `prevfloat(+∞)`
+(respecively `nextfloat(-∞)`) for the computation of the intermediate point.
 """
 function mid(a::Interval{T}, α) where T
 
@@ -386,7 +388,10 @@ function mid(a::Interval{T}, α) where T
 
     midpoint = α * (hi - lo) + lo
     isfinite(midpoint) && return midpoint
-    # Fallback in case of overflow: hi - lo == +∞
+    #= Fallback in case of overflow: hi - lo == +∞.
+       This case can not be the default one as it does not pass several
+       IEEE1788-2015 tests for small floats.
+    =#
     return (1-α) * lo + α * hi
 end
 
@@ -409,7 +414,10 @@ function mid(a::Interval{T}) where T
 
     midpoint = 0.5 * (a.lo + a.hi)
     isfinite(midpoint) && return midpoint
-    # Fallback in case of overflow: a.hi + a.lo == +∞ or a.hi + a.lo == -∞
+    #= Fallback in case of overflow: a.hi + a.lo == +∞ or a.hi + a.lo == -∞.
+       This case can not be the default one as it does not pass several
+       IEEE1788-2015 tests for small floats.
+    =#
     return 0.5 * a.lo + 0.5 * a.hi
 end
 

--- a/test/interval_tests/bisect.jl
+++ b/test/interval_tests/bisect.jl
@@ -11,10 +11,12 @@ using Base.Test
 
     X = -∞..∞
     @test bisect(X, 0.5) == (-∞..0, 0..∞)
-    @test bisect(X, 0.75) == (-∞..0, 0..∞)
-
-    X = 1..∞
-    @test bisect(X) == (Interval(1, prevfloat(∞)), Interval(prevfloat(∞), ∞))
+    B = bisect(X, 0.75)
+    @test B[1].hi > 0
+    @test B[1].hi == B[2].lo
+    B = bisect(X, 0.25)
+    @test B[1].hi < 0
+    @test B[1].hi == B[2].lo
 
     X = (0..1) × (0..2)
     @test bisect(X, 0.5) == ( (0..1) × (0..1), (0..1) × (1..2) )
@@ -26,5 +28,5 @@ using Base.Test
                          IntervalBox(0..1, Interval(0.9921875, 2.0)))
 
     X = (-∞..∞) × (-∞..∞)
-    @test bisect(X) == ( (-∞..0) × (-∞..∞), (0..∞) × (-∞..∞))
+    @test bisect(X, 0.5) == ( (-∞..0) × (-∞..∞), (0..∞) × (-∞..∞))
 end

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -192,7 +192,15 @@ c = @interval(0.25, 4.0)
     @testset "mid with parameter" begin
         @test mid(0..1, 0.75) == 0.75
         @test mid(1..∞, 0.75) == prevfloat(∞)
-        @test mid(-∞..∞, 0.75) == 0
+        @test mid(-∞..∞, 0.75) > 0
+        @test mid(-∞..∞, 0.25) < 0
+    end
+
+    @testset "mid with large floats" begin
+        @test mid(0.8e308..1.2e308) == 1e308
+        @test mid(-1e308..1e308) == 0
+        @test isfinite(mid(0.8e308..1.2e308, 0.75))
+        @test isfinite(mid(-1e308..1e308, 0.75))
     end
 
     @testset "diam" begin

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -191,7 +191,7 @@ c = @interval(0.25, 4.0)
 
     @testset "mid with parameter" begin
         @test mid(0..1, 0.75) == 0.75
-        @test mid(1..∞, 0.75) == prevfloat(∞)
+        @test mid(1..∞, 0.75) > 0
         @test mid(-∞..∞, 0.75) > 0
         @test mid(-∞..∞, 0.25) < 0
     end


### PR DESCRIPTION
- Allows to shift the middle point with `mid(-Inf..Inf, α)` with `α != 0.5` (`α` was previously ignored for infinite intervals).
- Change the expression which evaluate the midpoint to avoid that it returns `Inf` or `-Inf`.