### PR TITLE
Add Region and mid(X::IntervalBox, alpha)

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -64,6 +64,9 @@ export
     interval_part, decoration, DecoratedInterval,
     com, dac, def, trv, ill
 
+## Union type
+export
+    Region
 
 
 
@@ -89,5 +92,9 @@ include("plot_recipes/plot_recipes.jl")
 
 include("deprecated.jl")
 
+"""
+    Region{T} = Union{Interval{T}, IntervalBox{T}}
+"""
+Region{T} = Union{Interval{T}, IntervalBox{T}}
 
 end # module IntervalArithmetic

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -95,6 +95,6 @@ include("deprecated.jl")
 """
     Region{T} = Union{Interval{T}, IntervalBox{T}}
 """
-Region{T} = Union{Interval{T}, IntervalBox{T}}
+const Region{T} = Union{Interval{T}, IntervalBox{T}}
 
 end # module IntervalArithmetic

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -23,8 +23,8 @@ Return a vector of the `mid` of each interval composing the `IntervalBox`.
 
 See `mid(X::Interval, α=0.5)` for more informations.
 """
-mid(X::IntervalBox{T}, α) where T = mid.(X, α)
-mid(X::IntervalBox{T}) where T = mid.(X)
+mid(X::IntervalBox{T}, α) where {T} = mid.(X, α)
+mid(X::IntervalBox{T}) where {T} = mid.(X)
 
 
 ## set operations

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -16,8 +16,15 @@ IntervalBox(x::Interval) = IntervalBox( (x,) )  # single interval treated as tup
 
 ## arithmetic operations
 # Note that standard arithmetic operations are implemented automatically by FixedSizeArrays.jl
+"""
+    mid(X::IntervalBox, α=0.5)
 
-mid(X::IntervalBox) = mid.(X)
+Return a vector of the `mid` of each interval composing the `IntervalBox`.
+
+See `mid(X::Interval, α=0.5)` for more informations.
+"""
+mid(X::IntervalBox{T}, α) where T = mid.(X, α)
+mid(X::IntervalBox{T}) where T = mid.(X)
 
 
 ## set operations

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -23,8 +23,8 @@ Return a vector of the `mid` of each interval composing the `IntervalBox`.
 
 See `mid(X::Interval, α=0.5)` for more informations.
 """
-mid(X::IntervalBox{T}, α) where {T} = mid.(X, α)
-mid(X::IntervalBox{T}) where {T} = mid.(X)
+mid(X::IntervalBox, α) = mid.(X, α)
+mid(X::IntervalBox) = mid.(X)
 
 
 ## set operations

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -111,6 +111,8 @@ end
     @test length(Y) == 3
     @test Y == IntervalBox(Interval(0, 2), Interval(3, 5), Interval(4, 8))
     @test diam(Y) == 4
+
+    @test mid(IntervalBox(0..1, 3), 0.75) == [0.75, 0.75, 0.75]
 end
 
 @testset "Constructing multidimensional IntervalBoxes" begin


### PR DESCRIPTION
Small changes that fix #136 and fix #110 . Moreover it appears during the elaboration of the PR that #30 is also fixed now.

I know that it is a bit awkward that the definition of `Region` is in the top file, but I couldn't see anywhere else to put it as it builds over both `interval/interval.jl` and `multidim/multidim.jl`.