### PR TITLE
Broadcast in isinf and contains_zero, with tests

### DIFF
--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -73,12 +73,12 @@ diam(X::IntervalBox) = maximum(diam.(X.v))
 
 emptyinterval(X::IntervalBox{N,T}) where {N,T} = IntervalBox(emptyinterval.(X.v))
 
-isinf(X::IntervalBox) = any(isinf(X))
+isinf(X::IntervalBox) = any(isinf.(X))
 
 isinterior(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} = all(isinterior.(X, Y))
 
-contains_zero(X::SVector) = all(contains_zero(X))
-contains_zero(X::IntervalBox) = all(contains_zero(X))
+contains_zero(X::SVector) = all(contains_zero.(X))
+contains_zero(X::IntervalBox) = all(contains_zero.(X))
 
 import Base.×
 ×(a::Interval...) = IntervalBox(a...)

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -33,6 +33,11 @@ using StaticArrays
     @test isempty(X ∩ Y)
     @test X ∪ Y == IntervalBox(1..4, 3..4)
 
+    @test !contains_zero(X ∩ Y)
+    @test contains_zero( (-1..1) × (-1..1) )
+    @test !isinf( (-1..1) × (0..Inf) )
+    @test isinf( entireinterval() × entireinterval() )
+
     X = IntervalBox(2..4, 3..5)
     Y = IntervalBox(3..5, 4..17)
     @test X ∩ Y == IntervalBox(3..4, 4..5)


### PR DESCRIPTION
In current master `contains_zero( (-1..1)  )` or `isinf( (-1..1) × (-1..1) )` yields a stackoverflow error:
```julia
ERROR: StackOverflowError:
Stacktrace:
 [1] isinf(::IntervalArithmetic.IntervalBox{2,Float64}) at /Users/benet/.julia/v0.6/IntervalArithmetic/src/multidim/intervalbox.jl:0
 [2] isinf(::IntervalArithmetic.IntervalBox{2,Float64}) at /Users/benet/.julia/v0.6/IntervalArithmetic/src/multidim/intervalbox.jl:76 (repeats 79999 times)
```

This PR solves that, adding tests for that.