### PR TITLE
Bump minimum Julia version to 0.7-alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - osx
 
 julia:
-  - 0.6
+  - 0.7
   - nightly
 
 matrix:
@@ -21,6 +21,6 @@ notifications:
   email: false
 
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'import Pkg; Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("IntervalArithmetic")); include(joinpath("docs", "make.jl"))'
   - julia -e 'cd(Pkg.dir("IntervalArithmetic")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 CRlibm 0.6
 StaticArrays 0.5
 FastRounding 0.0.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7-alpha
+julia 0.7
 CRlibm 0.6
 StaticArrays 0.5
 FastRounding 0.0.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -10,15 +10,9 @@ using FastRounding
 using AdjacentFloats
 using Compat
 
-if VERSION <= v"0.7.0-DEV.2004"
-    import Base: ×, dot
-    import Compat.Sys
-    export ⊇
-else
-    using Markdown
-    import Base: ⊇
-    import LinearAlgebra: ×, dot
-end
+using Markdown
+import Base: ⊇
+import LinearAlgebra: ×, dot
 
 
 import Base:
@@ -89,10 +83,6 @@ export
 
 function __init__()
     setrounding(BigFloat, RoundNearest)
-    if VERSION < v"0.7.0-DEV"
-        ## deprecated in 0.7
-        setrounding(Float64, RoundNearest)
-    end
 
     setprecision(Interval, 256)  # set up pi
     setprecision(Interval, Float64)

--- a/src/bisect.jl
+++ b/src/bisect.jl
@@ -21,7 +21,7 @@ end
 Bisect the `IntervalBox` `X` at position α ∈ [0,1] along its longest side.
 """
 function bisect(X::IntervalBox, α=where_bisect)
-    i = indmax(diam.(X))  # find longest side
+    i = argmax(diam.(X))  # find longest side
 
     return bisect(X, i, α)
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -109,7 +109,7 @@ end
 function round_string(x::BigFloat, digits::Int, r::RoundingMode)
 
     lng = digits + Int32(8)
-    @compat buf = Array{UInt8}(undef, lng + 1)
+    buf = Array{UInt8}(undef, lng + 1)
 
     lng = ccall((:mpfr_snprintf,:libmpfr), Int32,
     (Ptr{UInt8}, Culong,  Ptr{UInt8}, Int32, Ref{BigFloat}...),
@@ -117,7 +117,7 @@ function round_string(x::BigFloat, digits::Int, r::RoundingMode)
 
     repr = unsafe_string(pointer(buf))
 
-    @compat repr = replace(repr, "nan" => "NaN")
+    repr = replace(repr, "nan" => "NaN")
 
     return repr
 end
@@ -144,8 +144,8 @@ function basic_representation(a::Interval, format=nothing)
         bb = round_string(a.hi, sigfigs, RoundUp)
 
         output = "[$aa, $bb]"
-        @compat output = replace(output, "inf" => "∞")
-        @compat output = replace(output, "Inf" => "∞")
+        output = replace(output, "inf" => "∞")
+        output = replace(output, "Inf" => "∞")
 
     elseif format == :full
         output = "Interval($(a.lo), $(a.hi))"

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -149,7 +149,7 @@ function ^(a::Interval{BigFloat}, r::Rational{S}) where S<:Integer
         return emptyinterval(a)
     end
 
-    isinteger(r) && return atomic(Interval{T}, a^round(S,r))
+    isinteger(r) && return atomic(Interval{T}, a^round(S, digits=r))
     r == one(S)//2 && return sqrt(a)
 
     a = a ∩ domain

--- a/src/intervals/rounding_macros.jl
+++ b/src/intervals/rounding_macros.jl
@@ -46,7 +46,7 @@ The macro uses the internal `round_expr` function to transform e.g.
 
 The user-facing equivalent is `@interval`, which can handle much more general cases.
 """
-macro round(ex1, ex2)
+macro round(ex1, digits=ex2)
      :(Interval($(round_expr(ex1, RoundDown)), $(round_expr(ex2, RoundUp))))
 end
 

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -41,7 +41,7 @@ Parse a string as an interval. Formats allowed include:
 function parse(::Type{Interval{T}}, s::AbstractString) where T
 
     # Check version!
-    if !(@compat occursin("[", s))  # string like "3.1"
+    if !(occursin("[", s))  # string like "3.1"
 
         m = match(r"(.*)±(.*)", s)
         if m != nothing
@@ -81,8 +81,8 @@ function parse(::Type{Interval{T}}, s::AbstractString) where T
 
     end
 
-    @compat expr1 = Meta.parse(lo)
-    @compat expr2 = Meta.parse(hi)
+    expr1 = Meta.parse(lo)
+    expr2 = Meta.parse(hi)
 
     interval = eval(make_interval(T, expr1, [expr2]))
 

--- a/test/ITF1788_tests/libieeep1788_tests_bool.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_bool.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_cancel.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_cancel.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_elem.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_elem.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_mul_rev.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_mul_rev.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_num.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_num.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_overlap.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_overlap.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_rec_bool.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_rec_bool.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_rev.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_rev.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/ITF1788_tests/libieeep1788_tests_set.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_set.jl
@@ -20,11 +20,7 @@
 #Language imports
 
 #Test library imports
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 #Arithmetic library imports
 using IntervalArithmetic

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 @testset "DecoratedInterval tests" begin
     a = DecoratedInterval(@interval(1, 2), com)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 setprecision(Interval, Float64)
 

--- a/test/interval_tests/bisect.jl
+++ b/test/interval_tests/bisect.jl
@@ -1,5 +1,5 @@
 using IntervalArithmetic
-using Base.Test
+using Test
 
 
 @testset "`bisect` function" begin

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 @testset "Complex interval operations" begin
     a = @interval 1im

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -1,13 +1,8 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-    const eeuler = Base.e
-else
-    using Test
-    const eeuler = Base.MathConstants.e
-end
+using Test
+const eeuler = Base.MathConstants.e
 
 
 @testset "Constructing intervals" begin

--- a/test/interval_tests/hyperbolic.jl
+++ b/test/interval_tests/hyperbolic.jl
@@ -1,11 +1,7 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 
 setprecision(Interval, 128)

--- a/test/interval_tests/linear_algebra.jl
+++ b/test/interval_tests/linear_algebra.jl
@@ -1,10 +1,6 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-    # using LinearAlgebra, SparseArrays
-end
+using Test
+# using LinearAlgebra, SparseArrays
 
 
 

--- a/test/interval_tests/loops.jl
+++ b/test/interval_tests/loops.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 
 @testset "Interval loop tests" begin

--- a/test/interval_tests/non_BigFloat.jl
+++ b/test/interval_tests/non_BigFloat.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 @testset "Tests with rational intervals" begin
 

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -1,11 +1,7 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 setprecision(Interval, Float64)
 # # setrounding(Interval, :narrow)

--- a/test/interval_tests/parsing.jl
+++ b/test/interval_tests/parsing.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 setformat(:standard, decorations=true, sigfigs=6)
 

--- a/test/interval_tests/rounding.jl
+++ b/test/interval_tests/rounding.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 
 setformat(:full)

--- a/test/interval_tests/rounding_macros.jl
+++ b/test/interval_tests/rounding_macros.jl
@@ -1,9 +1,5 @@
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 @test IntervalArithmetic.round_expr(:(a + b), RoundDown) == :($(Expr(:escape, :a)) + $(Expr(:escape, :b)) + $(RoundDown))
 

--- a/test/interval_tests/set_operations.jl
+++ b/test/interval_tests/set_operations.jl
@@ -1,11 +1,7 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 setprecision(Interval, Float64)
 

--- a/test/interval_tests/trig.jl
+++ b/test/interval_tests/trig.jl
@@ -1,11 +1,7 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 setprecision(Interval, 128)
 setprecision(Interval, Float64)

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -1,12 +1,8 @@
 using IntervalArithmetic
 using StaticArrays
 
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-    using LinearAlgebra: dot
-end
+using Test
+using LinearAlgebra: dot
 
 
 @testset "Operations on boxes" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 
 using IntervalArithmetic
-if VERSION < v"0.7.0-DEV.2004"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 const Interval = IntervalArithmetic.Interval
 


### PR DESCRIPTION
FemtoCleaner should run automatically and report output in the `Checks` tab.