### PR TITLE
Added complex sqrt and some complex set functions

### DIFF
--- a/src/intervals/complex.jl
+++ b/src/intervals/complex.jl
@@ -1,0 +1,77 @@
+function ssqs(x::T, y::T,RND::RoundingMode) where T<:AbstractFloat
+    k::Int = 0
+    ρ = +(*(x,x,RND),*(y,y,RND),RND)
+    if !isfinite(ρ) && (isinf(x) || isinf(y))
+        ρ = convert(T, Inf)
+    elseif isinf(ρ) || (ρ==0 && (x!=0 || y!=0)) || ρ<nextfloat(zero(T))/(2*eps(T)^2)
+        m::T = max(abs(x), abs(y))
+        k = m==0 ? m : exponent(m)
+        xk, yk = ldexp(x,-k), ldexp(y,-k)
+        ρ = +(*(xk,xk,RND),*(yk,yk,RND),RND)
+    end
+    ρ, k
+end
+
+function ssqs(x::Interval{T}, y::Interval{T}) where T<:AbstractFloat
+    x = abs(x); y = abs(y)
+    ρl,kl = ssqs(inf(x),inf(y),RoundDown)
+    ρu,ku = ssqs(sup(x),sup(y),RoundUp)
+    ρl, kl, ρu, ku
+end
+
+function sqrt_realpart(x::T, y::T,RND::RoundingMode) where T<:AbstractFloat
+    # @assert x ≥ 0
+    ρ, k = ssqs(x,y,RND)
+    if isfinite(x) ρ = +(ldexp(x,-k),sqrt(ρ,RND),RND) end
+
+    if isodd(k)
+        k = div(k-1,2)
+    else
+        k = div(k,2)-1
+        ρ *= 2
+    end
+    ρ = ldexp(sqrt(ρ,RND),k) #sqrt((abs(z)+abs(x))/2) without over/underflow
+end
+
+function sqrt(z::Complex{Interval{T}}) where T<:AbstractFloat
+    x, y = reim(z)
+
+    (inf(x) < 0 && inf(y) < 0 && sup(y) >= 0) && error("Interval lies across branch cut")
+    x == y == 0 && return Complex(zero(x),y)
+
+    (inf(x) < 0 && sup(x) > 0) && return sqrt((inf(x)..0) + im*y) ∪ sqrt((0..sup(x)) + im*y)
+
+    absx = abs(x)
+
+    absy= abs(y)
+    ρl = sqrt_realpart(inf(absx),inf(absy),RoundDown)
+    ρu = sqrt_realpart(sup(absx),sup(absy),RoundUp)
+
+    ηu = sup(y)
+    if isfinite(ηu)
+        if ηu > 0
+            ηu_re = sqrt_realpart(inf(absx),ηu,RoundDown)
+        else
+            ηu_re = sqrt_realpart(sup(absx),ηu,RoundUp)
+        end
+        ηu = ηu_re > 0 ?  /(ηu,2ηu_re,RoundUp) : zero(T)
+    end
+
+    ηl = inf(y)
+    if ηl > 0
+        ηl_re = sqrt_realpart(sup(absx),ηl,RoundUp)
+    else
+        ηl_re = sqrt_realpart(inf(absx),ηl,RoundDown)
+    end
+    ηl = ηl_re > 0 ? /(ηl,2ηl_re,RoundDown) : zero(T)
+
+    ξ = ρl..ρu
+    η = ηl..ηu
+
+    if mid(x)<0
+        ξ = η*sign(mid(η))
+        η = (ρl..ρu)*sign(mid(y))
+    end
+
+    Complex(ξ,η)
+end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -122,7 +122,7 @@ include("arithmetic.jl")
 include("functions.jl")
 include("trigonometric.jl")
 include("hyperbolic.jl")
-
+include("complex.jl")
 
 # Syntax for intervals
 

--- a/src/intervals/set_operations.jl
+++ b/src/intervals/set_operations.jl
@@ -13,6 +13,8 @@ function in(x::T, a::Interval) where T<:Real
     a.lo <= x <= a.hi
 end
 
+in(x, a::Complex{<:Interval}) = real(x) ∈ real(a) && imag(x) ∈ imag(a)
+
 
 
 """
@@ -52,6 +54,10 @@ function isdisjoint(a::Interval, b::Interval)
     islessprime(b.hi, a.lo) || islessprime(a.hi, b.lo)
 end
 
+function isdisjoint(a::Complex{<:Interval}, b::Complex{<:Interval})
+    isdisjoint(real(a),real(b)) || isdisjoint(imag(a),imag(b))
+end
+
 
 # Intersection
 """
@@ -71,6 +77,14 @@ end
 intersect(a::Interval{T}, b::Interval{S}) where {T,S} =
     intersect(promote(a, b)...)
 
+function intersect(a::Complex{Interval{T}},b::Complex{Interval{T}}) where T
+    isdisjoint(a,b) && return complex(emptyinterval(T),emptyinterval(T)) # for type stability
+
+    complex(intersect(real(a),real(b)),intersect(imag(a),imag(b)))
+end
+intersect(a::Interval{Complex{T}}, b::Interval{Complex{S}}) where {T,S} =
+    intersect(promote(a, b)...)
+
 
 ## Hull
 """
@@ -83,6 +97,8 @@ all of `a` and `b`.
 hull(a::Interval, b::Interval) = Interval(min(a.lo, b.lo), max(a.hi, b.hi))
 #
 # hull{T,S}(a::Interval{T}, b::Interval{S}) = hull(promote(a, b)...)
+hull(a::Complex{<:Interval},b::Complex{<:Interval}) =
+    complex(hull(real(a),real(b)),hull(imag(a),imag(b)))
 
 """
     union(a, b)
@@ -94,6 +110,7 @@ to `hull(a,b)`.
 union(a::Interval, b::Interval) = hull(a, b)
 #
 # union(a::Interval, b::Interval) = union(promote(a, b)...)
+union(a::Complex{<:Interval},b::Complex{<:Interval}) = hull(a, b)
 
 
 """

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -7,6 +7,8 @@ end
 
 @testset "Complex interval operations" begin
     a = @interval 1im
+    b = @interval 4im + 3
+    
     @test typeof(a)== Complex{IntervalArithmetic.Interval{Float64}}
     @test a ==  Interval(0) + Interval(1)*im
     @test a * a == Interval(-1)
@@ -14,10 +16,16 @@ end
     @test a - a == 0
     @test a / a == 1
     @test a^2 == -1
+
+    @test a ∪ b == (@interval 0 3) + (@interval 1 4)*im
+    @test a ∩ b == ∅
+    @test isdisjoint(a,b) == true
 end
 
 @testset "Complex functions" begin
     Z = (3 ± 1e-7) + (4 ± 1e-7)*im
     @test sin(Z) == complex(sin(real(Z))*cosh(imag(Z)),sinh(imag(Z))*cos(real(Z)))
     @test exp(-im * Interval(π)) == Interval(-1.0, -0.9999999999999999) - Interval(1.224646799147353e-16, 1.2246467991473532e-16)*im
+
+    @test sqrt(Z) == Interval(1.9999999699999995,2.0000000300000007) + Interval(2.0000000300000007,1.0000000300000005)*im
 end

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -8,7 +8,7 @@ end
 @testset "Complex interval operations" begin
     a = @interval 1im
     b = @interval 4im + 3
-    
+
     @test typeof(a)== Complex{IntervalArithmetic.Interval{Float64}}
     @test a ==  Interval(0) + Interval(1)*im
     @test a * a == Interval(-1)
@@ -18,7 +18,7 @@ end
     @test a^2 == -1
 
     @test a ∪ b == (@interval 0 3) + (@interval 1 4)*im
-    @test a ∩ b == ∅
+    @test a ∩ b == ∅ + ∅*im
     @test isdisjoint(a,b) == true
 end
 

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -27,5 +27,5 @@ end
     @test sin(Z) == complex(sin(real(Z))*cosh(imag(Z)),sinh(imag(Z))*cos(real(Z)))
     @test exp(-im * Interval(π)) == Interval(-1.0, -0.9999999999999999) - Interval(1.224646799147353e-16, 1.2246467991473532e-16)*im
 
-    @test sqrt(Z) == Interval(1.9999999699999995,2.0000000300000007) + Interval(2.0000000300000007,1.0000000300000005)*im
+    @test sqrt(Z) == Interval(1.99999996999999951619,2.00000003000000070585) + Interval(0.99999996999999984926,1.00000003000000048381)*im
 end


### PR DESCRIPTION
This adds a `sqrt` function for `Complex{Interval{T}}`, and some functions such as `in`, `intersect`, `union`, `hull`. 

(The latter two output a `Complex{Interval{T}}`, i.e., a complex square covering the complex squares being unioned. Thus, for what it's worth `hull` isn't really a convex hull per se.)