### PR TITLE
Speed up trivials.

### DIFF
--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -33,6 +33,9 @@ end
 
 in(x::T, a::DecoratedInterval) where T<:Real = in(x, interval_part(a))
 
+@inline Base.:(==)(xx::DecoratedInterval, yy::Interval) = false
+@inline Base.:(==)(y::Interval, xx::DecoratedInterval) = false
+
 
 ## scalar functions: mig, mag and friends
 scalar_functions = (

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -33,8 +33,8 @@ end
 
 in(x::T, a::DecoratedInterval) where T<:Real = in(x, interval_part(a))
 
-@inline Base.:(==)(xx::DecoratedInterval, yy::Interval) = false
-@inline Base.:(==)(y::Interval, xx::DecoratedInterval) = false
+==(xx::DecoratedInterval, yy::Interval) = false
+==(y::Interval, xx::DecoratedInterval) = false
 
 
 ## scalar functions: mig, mag and friends

--- a/src/intervals/special.jl
+++ b/src/intervals/special.jl
@@ -8,7 +8,7 @@ that this interval is an exception to the fact that the lower bound is
 larger than the upper one."""
 emptyinterval(::Type{T}) where T<:Real = Interval{T}(Inf, -Inf)
 emptyinterval(x::Interval{T}) where T<:Real = emptyinterval(T)
-emptyinterval() = emptyinterval(precision(Interval)[1])
+const emptyinterval() = Interval(Inf,-Inf)
 const ∅ = emptyinterval(Float64)
 
 isempty(x::Interval) = x.lo == Inf && x.hi == -Inf
@@ -19,7 +19,7 @@ const ∞ = Inf
 """`entireinterval`s represent the whole Real line: [-∞, ∞]."""
 entireinterval(::Type{T}) where T<:Real = Interval{T}(-Inf, Inf)
 entireinterval(x::Interval{T}) where T<:Real = entireinterval(T)
-entireinterval() = entireinterval(precision(Interval)[1])
+const entireinterval() = Interval(-Inf,Inf)
 
 isentire(x::Interval) = x.lo == -Inf && x.hi == Inf
 isinf(x::Interval) = isentire(x)
@@ -30,7 +30,7 @@ isunbounded(x::Interval) = x.lo == -Inf || x.hi == Inf
 """`NaI` not-an-interval: [NaN, NaN]."""
 nai(::Type{T}) where T<:Real = Interval{T}(convert(T, NaN), convert(T, NaN))
 nai(x::Interval{T}) where T<:Real = nai(T)
-nai() = nai(precision(Interval)[1])
+const nai() = Interval(NaN,NaN)
 
 isnai(x::Interval) = isnan(x.lo) || isnan(x.hi)
 

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -34,6 +34,12 @@ let b
     # @test_throws ArgumentError DecoratedInterval(BigInt(1), 1//10)
     # @test_throws ArgumentError @decorated(BigInt(1), 1//10)
 
+    #Issue 219
+    @test ==(DecoratedInterval(2,3),Interval(1,2)) == false
+    @test ==(Interval(-1,5), DecoratedInterval(4,5)) == false
+    @test ==(nai(), DecoratedInterval(-1,∞)) == false
+    @test ==(DecoratedInterval(3,4),nai()) == false
+
     # Tests related to powers of decorated Intervals
     @test @decorated(2,3) ^ 2 == DecoratedInterval(4, 9)
     @test @decorated(2,3) ^ -2 == DecoratedInterval(1/9,1/4)


### PR DESCRIPTION
Consider
```
julia> @btime nai()
  46.999 ns (1 allocation: 32 bytes)
[NaN, NaN]
julia> @btime emptyinterval()
  47.715 ns (1 allocation: 32 bytes)
∅
julia> @btime entireinterval()
  45.143 ns (1 allocation: 32 bytes)
[-∞, ∞]
```

versus
```
julia> const zentire() = Interval(-Inf,Inf)
zentire (generic function with 1 method)

julia> @btime zentire()
  1.315 ns (0 allocations: 0 bytes)
[-∞, ∞]

julia> entireinterval() == zentire()
true

julia> const zempty() = Interval(Inf,-Inf)
zempty (generic function with 1 method)

julia> zempty() == ∅

julia> const znai() = Interval(NaN,NaN)
znai (generic function with 1 method)

julia> @btime znai()
  1.352 ns (0 allocations: 0 bytes)
[NaN, NaN]

julia> znai() === nai()
true

julia> @btime zempty()
  1.354 ns (0 allocations: 0 bytes)
∅
```
All tests pass locally and should help speed up testing a bit.