### PR TITLE
🏎️ Speed up trivials

### DIFF
--- a/src/intervals/special.jl
+++ b/src/intervals/special.jl
@@ -8,7 +8,7 @@ that this interval is an exception to the fact that the lower bound is
 larger than the upper one."""
 emptyinterval(::Type{T}) where T<:Real = Interval{T}(Inf, -Inf)
 emptyinterval(x::Interval{T}) where T<:Real = emptyinterval(T)
-emptyinterval() = emptyinterval(precision(Interval)[1])
+const emptyinterval() = Interval(Inf,-Inf)
 const ∅ = emptyinterval(Float64)
 
 isempty(x::Interval) = x.lo == Inf && x.hi == -Inf
@@ -19,7 +19,7 @@ const ∞ = Inf
 """`entireinterval`s represent the whole Real line: [-∞, ∞]."""
 entireinterval(::Type{T}) where T<:Real = Interval{T}(-Inf, Inf)
 entireinterval(x::Interval{T}) where T<:Real = entireinterval(T)
-entireinterval() = entireinterval(precision(Interval)[1])
+const entireinterval() = Interval(-Inf,Inf)
 
 isentire(x::Interval) = x.lo == -Inf && x.hi == Inf
 isinf(x::Interval) = isentire(x)
@@ -30,7 +30,7 @@ isunbounded(x::Interval) = x.lo == -Inf || x.hi == Inf
 """`NaI` not-an-interval: [NaN, NaN]."""
 nai(::Type{T}) where T<:Real = Interval{T}(convert(T, NaN), convert(T, NaN))
 nai(x::Interval{T}) where T<:Real = nai(T)
-nai() = nai(precision(Interval)[1])
+const nai() = Interval(NaN,NaN)
 
 isnai(x::Interval) = isnan(x.lo) || isnan(x.hi)
 


### PR DESCRIPTION
Consider

```
julia> @btime nai()
  46.999 ns (1 allocation: 32 bytes)
[NaN, NaN]
julia> @btime emptyinterval()
  47.715 ns (1 allocation: 32 bytes)
∅
julia> @btime entireinterval()
  45.143 ns (1 allocation: 32 bytes)
[-∞, ∞]
```
versus
```
julia> const zentire() = Interval(-Inf,Inf)
zentire (generic function with 1 method)

julia> @btime zentire()
  1.315 ns (0 allocations: 0 bytes)
[-∞, ∞]

julia> entireinterval() == zentire()
true

julia> const zempty() = Interval(Inf,-Inf)
zempty (generic function with 1 method)

julia> zempty() == ∅
true

julia> @btime zempty()
  1.354 ns (0 allocations: 0 bytes)
∅

julia> const znai() = Interval(NaN,NaN)
znai (generic function with 1 method)

julia> @btime znai()
  1.352 ns (0 allocations: 0 bytes)
[NaN, NaN]

julia> znai() === nai()
true
```