### PR TITLE
Faster trig functions

### DIFF
--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -32,18 +32,63 @@ This is a rather indirect way to determine if π/2 and 3π/2 are contained
 in the interval; cf. the formula for sine of an interval in
 Tucker, *Validated Numerics*.
 """
-# function find_quadrants(x::T) where {T}
-#     temp = atomic(Interval{T}, x) / half_pi(x)
-#
-#     return SVector(floor(temp.lo), floor(temp.hi))
-# end
-#
-# function find_quadrants(x::Float64)
-#     temp = multiply_by_positive_constant(x, one_over_half_pi_interval)
-#     # x / half_pi(Float64)
-#
-#     return SVector(floor(temp.lo), floor(temp.hi))
-# end
+function find_quadrants(x::T) where {T}
+    temp = atomic(Interval{T}, x) / half_pi(x)
+
+    return SVector(floor(temp.lo), floor(temp.hi))
+end
+
+function find_quadrants(x::Float64)
+    temp = multiply_by_positive_constant(x, one_over_half_pi_interval)
+    # x / half_pi(Float64)
+
+    return SVector(floor(temp.lo), floor(temp.hi))
+end
+
+function sin(a::Interval{T}) where T
+    isempty(a) && return a
+
+    whole_range = Interval{T}(-1, 1)
+
+    diam(a) > two_pi(T).lo && return whole_range
+
+    # The following is equiavlent to doing temp = a / half_pi  and
+    # taking floor(a.lo), floor(a.hi)
+    lo_quadrant = minimum(find_quadrants(a.lo))
+    hi_quadrant = maximum(find_quadrants(a.hi))
+
+    if hi_quadrant - lo_quadrant > 4  # close to limits
+        return whole_range
+    end
+
+    lo_quadrant = mod(lo_quadrant, 4)
+    hi_quadrant = mod(hi_quadrant, 4)
+
+    # Different cases depending on the two quadrants:
+    if lo_quadrant == hi_quadrant
+        a.hi - a.lo > pi_interval(T).lo && return whole_range  # in same quadrant but separated by almost 2pi
+        lo = @round(sin(a.lo), sin(a.lo)) # Interval(sin(a.lo, RoundDown), sin(a.lo, RoundUp))
+        hi = @round(sin(a.hi), sin(a.hi)) # Interval(sin(a.hi, RoundDown), sin(a.hi, RoundUp))
+        return hull(lo, hi)
+
+    elseif lo_quadrant==3 && hi_quadrant==0
+        return @round(sin(a.lo), sin(a.hi)) # Interval(sin(a.lo, RoundDown), sin(a.hi, RoundUp))
+
+    elseif lo_quadrant==1 && hi_quadrant==2
+        return @round(sin(a.hi), sin(a.lo)) # Interval(sin(a.hi, RoundDown), sin(a.lo, RoundUp))
+
+    elseif ( lo_quadrant == 0 || lo_quadrant==3 ) && ( hi_quadrant==1 || hi_quadrant==2 )
+        return @round(min(sin(a.lo), sin(a.hi)), 1)
+        # Interval(min(sin(a.lo, RoundDown), sin(a.hi, RoundDown)), one(T))
+
+    elseif ( lo_quadrant == 1 || lo_quadrant==2 ) && ( hi_quadrant==3 || hi_quadrant==0 )
+        return @round(-1, max(sin(a.lo), sin(a.hi)))
+        # Interval(-one(T), max(sin(a.lo, RoundUp), sin(a.hi, RoundUp)))
+
+    else #if( lo_quadrant == 0 && hi_quadrant==3 ) || ( lo_quadrant == 2 && hi_quadrant==1 )
+        return whole_range
+    end
+end
 
 function quadrant(x::Float64)
     x_mod2pi = rem2pi(x, RoundNearest)  # gives result in [-pi, pi]
@@ -56,7 +101,10 @@ function quadrant(x::Float64)
 end
 
 
-function sin(a::Interval{T}) where T
+function sin(a::Interval{Float64})
+
+    T = Float64
+
     isempty(a) && return a
 
     whole_range = Interval{T}(-1, 1)

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -186,6 +186,49 @@ function cos(a::Interval{T}) where T
     end
 end
 
+function cos(a::Interval{Float64})
+
+    T = Float64
+
+    isempty(a) && return a
+
+    whole_range = Interval{Float64}(-one(T), one(T))
+
+    diam(a) > two_pi(T).lo && return whole_range
+
+    lo_quadrant, lo = quadrant(a.lo)
+    hi_quadrant, hi = quadrant(a.hi)
+
+    lo, hi = a.lo, a.hi
+
+    # Different cases depending on the two quadrants:
+    if lo_quadrant == hi_quadrant # Interval limits in the same quadrant
+        a.hi - a.lo > pi_interval(T).lo && return whole_range
+
+        if lo_quadrant == 2 || lo_quadrant == 3
+            # positive slope
+            return @round(cos(lo), cos(hi))
+        else
+            return @round(cos(hi), cos(lo))
+        end
+
+    elseif lo_quadrant == 2 && hi_quadrant==3
+        return @round(cos(a.lo), cos(a.hi))
+
+    elseif lo_quadrant == 0 && hi_quadrant==1
+        return @round(cos(a.hi), cos(a.lo))
+
+    elseif ( lo_quadrant == 2 || lo_quadrant==3 ) && ( hi_quadrant==0 || hi_quadrant==1 )
+        return @round(min(cos(a.lo), cos(a.hi)), 1)
+
+    elseif ( lo_quadrant == 0 || lo_quadrant==1 ) && ( hi_quadrant==2 || hi_quadrant==3 )
+        return @round(-1, max(cos(a.lo), cos(a.hi)))
+
+    else #if ( lo_quadrant == 3 && hi_quadrant==2 ) || ( lo_quadrant == 1 && hi_quadrant==0 )
+        return whole_range
+    end
+end
+
 
 function find_quadrants_tan(x::T) where {T}
     temp = atomic(Interval{T}, x) / half_pi(x)

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -186,6 +186,7 @@ function cos(a::Interval{T}) where T
     end
 end
 
+
 function find_quadrants_tan(x::T) where {T}
     temp = atomic(Interval{T}, x) / half_pi(x)
 
@@ -193,6 +194,38 @@ function find_quadrants_tan(x::T) where {T}
 end
 
 function tan(a::Interval{T}) where T
+    isempty(a) && return a
+
+    diam(a) > pi_interval(T).lo && return entireinterval(a)
+
+    lo_quadrant = minimum(find_quadrants_tan(a.lo))
+    hi_quadrant = maximum(find_quadrants_tan(a.hi))
+
+    lo_quadrant_mod = mod(lo_quadrant, 2)
+    hi_quadrant_mod = mod(hi_quadrant, 2)
+
+    if lo_quadrant_mod == 0 && hi_quadrant_mod == 1
+        # check if really contains singularity:
+        if hi_quadrant * half_pi(T) ⊆ a
+            return entireinterval(a)  # crosses singularity
+        end
+
+    elseif lo_quadrant_mod == hi_quadrant_mod && hi_quadrant > lo_quadrant
+        # must cross singularity
+        return entireinterval(a)
+
+    end
+
+    # @show a.lo, a.hi
+    # @show tan(a.lo), tan(a.hi)
+
+    return @round(tan(a.lo), tan(a.hi))
+end
+
+function tan(a::Interval{Float64})
+
+    T = Float64
+
     isempty(a) && return a
 
     diam(a) > pi_interval(T).lo && return entireinterval(a)
@@ -211,9 +244,6 @@ function tan(a::Interval{T}) where T
         return entireinterval(a)
 
     end
-
-    # @show a.lo, a.hi
-    # @show tan(a.lo), tan(a.hi)
 
     return @round(tan(a.lo), tan(a.hi))
 end

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -149,19 +149,16 @@ function tan(a::Interval{T}) where T
 
     diam(a) > pi_interval(T).lo && return entireinterval(a)
 
-    lo_quadrant = minimum(find_quadrants_tan(a.lo))
-    hi_quadrant = maximum(find_quadrants_tan(a.hi))
+    lo_quadrant, lo = quadrant(a.lo)
+    hi_quadrant, hi = quadrant(a.hi)
 
     lo_quadrant_mod = mod(lo_quadrant, 2)
     hi_quadrant_mod = mod(hi_quadrant, 2)
 
     if lo_quadrant_mod == 0 && hi_quadrant_mod == 1
-        # check if really contains singularity:
-        if hi_quadrant * half_pi(T) ⊆ a
-            return entireinterval(a)  # crosses singularity
-        end
+        return entireinterval(a)  # crosses singularity
 
-    elseif lo_quadrant_mod == hi_quadrant_mod && hi_quadrant > lo_quadrant
+    elseif lo_quadrant_mod == hi_quadrant_mod && hi_quadrant != lo_quadrant
         # must cross singularity
         return entireinterval(a)
 

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -95,7 +95,7 @@ function quadrant(x::Float64)
 
     x_mod2pi < -halfpi && return (2, x_mod2pi)
     x_mod2pi < 0 && return (3, x_mod2pi)
-    x_mod2pi < halfpi && return (0, x_mod2pi)
+    x_mod2pi <= halfpi && return (0, x_mod2pi)
 
     return 1, x_mod2pi
 end

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -38,13 +38,6 @@ function find_quadrants(x::T) where {T}
     return SVector(floor(temp.lo), floor(temp.hi))
 end
 
-function find_quadrants(x::Float64)
-    temp = multiply_by_positive_constant(x, one_over_half_pi_interval)
-    # x / half_pi(Float64)
-
-    return SVector(floor(temp.lo), floor(temp.hi))
-end
-
 function sin(a::Interval{T}) where T
     isempty(a) && return a
 

--- a/src/intervals/trigonometric.jl
+++ b/src/intervals/trigonometric.jl
@@ -114,7 +114,7 @@ function sin(a::Interval{Float64})
     lo_quadrant, lo = quadrant(a.lo)
     hi_quadrant, hi = quadrant(a.hi)
 
-    lo, hi = a.lo, a.hi  # don't use the modulo version of a
+    lo, hi = a.lo, a.hi  # should be able to use the modulo version of a, but doesn't seem to work
 
     # Different cases depending on the two quadrants:
     if lo_quadrant == hi_quadrant

--- a/test/interval_tests/trig.jl
+++ b/test/interval_tests/trig.jl
@@ -183,16 +183,16 @@ end
     @test cos(Interval(-pi/2, 3pi/2)) == Interval(-1, 1)
 end
 
-@testset "Trig with large arguments" begin
-    x = Interval(2.)^1000   # this is a thin interval
-    @test diam(x) == 0.0
-
-    @test sin(x) == -1..1
-    @test cos(x) == -1..1
-    @test_skip tan(x) == Interval(-0.16125837995065806, -0.16125837995065803)
-
-    x = Interval(prevfloat(∞), ∞)
-    @test sin(x) == -1..1
-    @test cos(x) == -1..1
-    @test tan(x) == -∞..∞
-end
+# @testset "Trig with large arguments" begin
+#     x = Interval(2.)^1000   # this is a thin interval
+#     @test diam(x) == 0.0
+#
+#     @test sin(x) == -1..1
+#     @test cos(x) == -1..1
+#     @test_skip tan(x) == Interval(-0.16125837995065806, -0.16125837995065803)
+#
+#     x = Interval(prevfloat(∞), ∞)
+#     @test sin(x) == -1..1
+#     @test cos(x) == -1..1
+#     @test tan(x) == -∞..∞
+# end

--- a/test/interval_tests/trig.jl
+++ b/test/interval_tests/trig.jl
@@ -183,16 +183,16 @@ end
     @test cos(Interval(-pi/2, 3pi/2)) == Interval(-1, 1)
 end
 
-# @testset "Trig with large arguments" begin
-#     x = Interval(2.)^1000   # this is a thin interval
-#     @test diam(x) == 0.0
-#
-#     @test sin(x) == -1..1
-#     @test cos(x) == -1..1
-#     @test_skip tan(x) == Interval(-0.16125837995065806, -0.16125837995065803)
-#
-#     x = Interval(prevfloat(∞), ∞)
-#     @test sin(x) == -1..1
-#     @test cos(x) == -1..1
-#     @test tan(x) == -∞..∞
-# end
+@testset "Trig with large arguments" begin
+    x = Interval(2.)^1000   # this is a thin interval
+    @test diam(x) == 0.0
+
+    @test sin(x) == Interval(-0.15920170308624246, -0.15920170308624243)
+    @test cos(x) == Interval(0.9872460775989135, 0.9872460775989136)
+    @test tan(x) == Interval(-0.16125837995065806, -0.16125837995065803)
+
+    x = Interval(prevfloat(∞), ∞)
+    @test sin(x) == -1..1
+    @test cos(x) == -1..1
+    @test tan(x) == -∞..∞
+end


### PR DESCRIPTION
Use `rem2pi` to speed up quadrant calculation, giving overall 1.6x speedup roughly, and allowing calculations for large values of the argument.

TODO:
- [x] `sin(Interval{BigFloat})` no longer works -- put the previous version back.
- [x] `cos` and `tan`
~- [ ] Use distance from pi/2 to decide which one is bigger?~
