### PR TITLE
Add IntervalBox constructor from vectors giving opposite corners

### DIFF
--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -109,6 +109,12 @@ end
 interval(a::Real) = interval(a, a)
 interval(a::Interval) = a
 
+"Make an interval even if a > b"
+function force_interval(a, b)
+    a > b && return interval(b, a)
+    return interval(a, b)
+end
+
 
 ## Include files
 include("special.jl")

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -27,6 +27,9 @@ end
 
 IntervalBox(lo::AbstractVector, hi::AbstractVector) where {N,T} = IntervalBox(force_interval.(lo, hi))
 
+IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(force_interval.(lo, hi))
+
+
 Base.@propagate_inbounds Base.getindex(X::IntervalBox, i) = X.v[i]
 
 setindex(X::IntervalBox, y, i) = IntervalBox( setindex(X.v, y, i) )

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -17,6 +17,9 @@ IntervalBox(x...) = IntervalBox(x)
 IntervalBox(x) = IntervalBox(x...)
 IntervalBox(X::IntervalBox, n) = foldl(×, Iterators.repeated(X, n))
 
+# construct from two vectors giving bottom and top corners
+IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(interval.(lo, hi))
+
 Base.@propagate_inbounds Base.getindex(X::IntervalBox, i) = X.v[i]
 
 setindex(X::IntervalBox, y, i) = IntervalBox( setindex(X.v, y, i) )

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -17,14 +17,7 @@ IntervalBox(x...) = IntervalBox(x)
 IntervalBox(x) = IntervalBox(x...)
 IntervalBox(X::IntervalBox, n) = foldl(×, Iterators.repeated(X, n))
 
-# construct from two vectors giving bottom and top corners
-
-"Make an interval even if a > b"
-function force_interval(a, b)
-    a > b && return interval(b, a)
-    return interval(a, b)
-end
-
+# construct from two vectors giving bottom and top corners:
 IntervalBox(lo::AbstractVector, hi::AbstractVector) where {N,T} = IntervalBox(force_interval.(lo, hi))
 
 IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(force_interval.(lo, hi))

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -25,7 +25,7 @@ function force_interval(a, b)
     return interval(a, b)
 end
 
-IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(force_interval.(lo, hi))
+IntervalBox(lo::AbstractVector, hi::AbstractVector) where {N,T} = IntervalBox(force_interval.(lo, hi))
 
 Base.@propagate_inbounds Base.getindex(X::IntervalBox, i) = X.v[i]
 

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -18,7 +18,14 @@ IntervalBox(x) = IntervalBox(x...)
 IntervalBox(X::IntervalBox, n) = foldl(×, Iterators.repeated(X, n))
 
 # construct from two vectors giving bottom and top corners
-IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(interval.(lo, hi))
+
+"Make an interval even if a > b"
+function force_interval(a, b)
+    a > b && return interval(b, a)
+    return interval(a, b)
+end
+
+IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(force_interval.(lo, hi))
 
 Base.@propagate_inbounds Base.getindex(X::IntervalBox, i) = X.v[i]
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -340,5 +340,3 @@ import IntervalArithmetic: force_interval
     @test force_interval(Inf, -Inf) == Interval(-Inf, Inf)
     @test_throws ArgumentError force_interval(NaN, 3)
 end
-
-end

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -331,3 +331,14 @@ end
     @test !isequal(hash(x), hash(y))
 
 end
+
+import IntervalArithmetic: force_interval
+@testset "force_interval" begin
+    @test force_interval(4, 3) == Interval(3, 4)
+    @test force_interval(4, Inf) == Interval(4, Inf)
+    @test force_interval(Inf, 4) == Interval(4, Inf)
+    @test force_interval(Inf, -Inf) == Interval(-Inf, Inf)
+    @test_throws ArgumentError force_interval(NaN, 3)
+end
+
+end

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -191,6 +191,10 @@ end
     @test IntervalBox([1:5...]) == IntervalBox(1..1, 2..2, 3..3, 4..4, 5..5)
     @test IntervalBox((1..2) × (2..3), 2) == (1..2) × (2..3) × (1..2) × (2..3)
 
+    # construct from corners:
+    @test IntervalBox(SVector(1, 2), SVector(3, 4)) == (1..3) × (2..4)
+    @test IntervalBox(SVector(3, 4), SVector(1, 2)) == (1..3) × (2..4)
+
 end
 
 @testset "getindex and setindex" begin


### PR DESCRIPTION
Construct an `IntervalBox` from opposite corners, even if those intervals are the wrong way round.

The function `force_interval` that creates an interval even when the endpoints are the wrong way round could be generally useful. It probably needs a better name.