### PR TITLE
Add "in" for IntervalBox

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -28,7 +28,7 @@ import Base:
     union, intersect, isempty,
     convert, promote_rule, eltype, size,
     BigFloat, float, widen, big,
-    ∩, ∪, ⊆, ⊇, eps,
+    ∩, ∪, ⊆, ⊇, ∈, eps,
     floor, ceil, trunc, sign, round,
     expm1, log1p,
     precision,

--- a/src/intervals/complex.jl
+++ b/src/intervals/complex.jl
@@ -1,3 +1,6 @@
+
+⊆(x::Complex{Interval{T}}, y::Complex{Interval{T}}) where T = real(x) ⊆ real(y) && imag(x) ⊆ imag(y)
+
 function ^(x::Complex{Interval{T}}, n::Integer) where {T}
     if n < 0
         return inv(x)^n

--- a/src/intervals/set_operations.jl
+++ b/src/intervals/set_operations.jl
@@ -13,6 +13,8 @@ function in(x::T, a::Interval) where T<:Real
     a.lo <= x <= a.hi
 end
 
+in(x::Interval, y::Interval) = throw(ArgumentError("$x ∈ $y is not defined"))
+
 in(x::T, a::Complex{<:Interval}) where T<:Real = x ∈ real(a) && 0 ∈ imag(a)
 in(x::Complex{T}, a::Complex{<:Interval}) where T<:Real = real(x) ∈ real(a) && imag(x) ∈ imag(a)
 

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -67,6 +67,8 @@ big(X::IntervalBox) = big.(X)
 ∪(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} =
     IntervalBox(X.v .∪ Y.v)
 
+∈(X::SVector{N}, Y::IntervalBox{N,T}) where {N,T} = all(X .∈ Y)
+
 #=
 On Julia 0.6 can now write
 ∩{N,T}(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) = IntervalBox(NTuple{N, Interval{Float64}}( (X[i] ∩ Y[i]) for i in 1:N))

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -67,7 +67,7 @@ big(X::IntervalBox) = big.(X)
 ∪(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} =
     IntervalBox(X.v .∪ Y.v)
 
-∈(X::SVector{N}, Y::IntervalBox{N,T}) where {N,T} = all(X .∈ Y)
+∈(X::AbstractVector, Y::IntervalBox{N,T}) where {N,T} = all(X .∈ Y)
 ∈(X, Y::IntervalBox{N,T}) where {N,T} = throw(ArgumentError("$X ∈ $Y is not defined"))
 
 

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -68,6 +68,8 @@ big(X::IntervalBox) = big.(X)
     IntervalBox(X.v .∪ Y.v)
 
 ∈(X::SVector{N}, Y::IntervalBox{N,T}) where {N,T} = all(X .∈ Y)
+∈(X, Y::IntervalBox{N,T}) where {N,T} = throw(ArgumentError("$X ∈ $Y is not defined"))
+
 
 #=
 On Julia 0.6 can now write

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -83,6 +83,8 @@ setprecision(Interval, Float64)
         @test 0.1 in @interval(0.1)
         @test !(-Inf ∈ entireinterval())
         @test !(Inf ∈ entireinterval())
+
+        @test_throws ArgumentError (3..4) ∈ (3..4)
     end
 
     @testset "Inclusion tests" begin

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -223,6 +223,9 @@ end
     @test mid(X) ∈ X
     @test mid(X, 0.75) ∈ X
 
+    @test (zero(mid(X)) ∈ X) == false
+    @test zero(mid(X)) ∉ X
+    
     @test_throws ArgumentError (3..4) ∈ X
 
 end

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -225,8 +225,10 @@ end
 
     @test (zero(mid(X)) ∈ X) == false
     @test zero(mid(X)) ∉ X
-    
+
     @test_throws ArgumentError (3..4) ∈ X
+
+    @test_throws ArgumentError [3..4, 5..6] ∈ X
 
 end
 

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -223,9 +223,7 @@ end
     @test mid(X) ∈ X
     @test mid(X, 0.75) ∈ X
 
-    @test (3..4) ∉ X
-
-
+    @test_throws ArgumentError (3..4) ∈ X
 
 end
 

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -218,4 +218,15 @@ end
     @test diam.(X) == SVector(diam(X[1]), diam(X[2]))
 end
 
+@testset "∈" begin
+    X = IntervalBox(3..4, 5..6)
+    @test mid(X) ∈ X
+    @test mid(X, 0.75) ∈ X
+
+    @test (3..4) ∉ X
+
+
+
+end
+
 end


### PR DESCRIPTION
Fixes #240.

Defines ` ∈` for `IntervalBox` correctly.

cc @Kolaru 