### PR TITLE
Add n-ary intersection

### DIFF
--- a/src/intervals/set_operations.jl
+++ b/src/intervals/set_operations.jl
@@ -88,6 +88,23 @@ end
 intersect(a::Interval{Complex{T}}, b::Interval{Complex{S}}) where {T,S} =
     intersect(promote(a, b)...)
 
+"""
+    intersect(a::Interval{T}...) where T
+
+Returns the n-ary intersection of its arguments.
+
+This function is applicable to any number of input intervals, as in
+`intersect(a1, a2, a3, a4)` where `ai` is an interval.
+If your use case needs to splat the input, as in `intersect(a...)`, consider
+`reduce(intersect, a)` instead, because you save the cost of splatting.
+"""
+function intersect(a::Interval{T}...) where T
+    low = maximum(broadcast(ai -> ai.lo, a))
+    high = minimum(broadcast(ai -> ai.hi, a))
+
+    !is_valid_interval(low, high) && return emptyinterval(T)
+    return Interval(low, high)
+end
 
 ## Hull
 """

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -146,6 +146,10 @@ setprecision(Interval, Float64)
 
         @test intersect(a, hull(a,b)) == a
         @test union(a,b) == Interval(a.lo, b.hi)
+
+        # n-ary intersection
+        c = intersect(Interval(1.0, 2.0), Interval(-1.0, 5.0), Interval(1.8, 3.0))
+        @test c == Interval(1.8, 2.0)
     end
 
     @testset "Hull and union tests" begin

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -148,8 +148,11 @@ setprecision(Interval, Float64)
         @test union(a,b) == Interval(a.lo, b.hi)
 
         # n-ary intersection
-        c = intersect(Interval(1.0, 2.0), Interval(-1.0, 5.0), Interval(1.8, 3.0))
-        @test c == Interval(1.8, 2.0)
+        @test intersect(Interval(1.0, 2.0),
+                        Interval(-1.0, 5.0),
+                        Interval(1.8, 3.0)) == Interval(1.8, 2.0)
+        @test intersect(a, emptyinterval(), b) == emptyinterval()
+        @test intersect(0..1, 3..4, 0..1, 0..1) == emptyinterval()
     end
 
     @testset "Hull and union tests" begin


### PR DESCRIPTION
Closes #256.

Some timings:

```julia
julia> using IntervalArithmetic
[ Info: Recompiling stale cache file /Users/forets/.julia/compiled/v1.1/IntervalArithmetic/Gjmwo.ji for IntervalArithmetic [d1acc4aa-44c8-5952-acd4-
ba5d80a2a253]

julia> Ik = [Interval(rand()-1,rand()) for _ in 1:4];

julia> using BenchmarkTools

julia> @btime intersect($Ik[1], $Ik[2], $Ik[3], $Ik[4])
  17.967 ns (0 allocations: 0 bytes)
[-0.00897583, 0.433356]

julia> @btime reduce(intersect, $Ik)
  29.546 ns (0 allocations: 0 bytes)
[-0.00897583, 0.433356]

julia> @btime intersect($Ik...)
  121.255 ns (5 allocations: 160 bytes)
[-0.00897583, 0.433356]
```