### PR TITLE
Add nthroot function and test cases

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -62,7 +62,7 @@ export
     midpoint_radius, interval_from_midpoint_radius,
     RoundTiesToEven, RoundTiesToAway,
     cancelminus, cancelplus, isunbounded,
-    .., @I_str, ±,
+    .., @I_str, ±, nthroot,
     pow, extended_div,
     setformat, @format
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -219,6 +219,29 @@ function ^(a::Interval{BigFloat}, x::Interval)
     hull(lo1, hi1)
 end
 
+function nthroot(a::Interval{T}, n::Integer) where T
+    q = 1//n
+    n == 1 && return a
+    n < 0 && a == zero(a) && return emptyinterval(a)
+    iseven(n) && return(^(a, q))
+    # n is odd
+    isentire(a) && return a
+    isempty(a) && return a
+    if n > 0
+        a.lo ≥ 0 && return ^(a, q)
+        a.hi ≤ 0 && return -(^(-a,q))
+        a.lo < 0 && a.hi > 0 && return ∪(-(^(0 .. -a.lo , q)) , ^(0 .. a.hi , q)) 
+
+    else
+        if a.lo ≥ 0
+            return ^(a,q)
+        elseif a.hi ≤ 0
+            return -(^(-a,q))
+        else
+            return entireinterval(a)
+        end
+    end
+end
 
 function sqrt(a::Interval{T}) where T
     domain = Interval{T}(0, Inf)

--- a/test/ITF1788_tests/libieeep1788_tests_elem.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_elem.jl
@@ -905,6 +905,33 @@ end
     @test decoration(DecoratedInterval(Interval(0x1.999999999999ap-4, 0x1.999999999999ap-4), com) ^(2.0)) == decoration(DecoratedInterval(Interval(0x1.47ae147ae147bp-7, 0x1.47ae147ae147cp-7), com))
 end
 
+@testset "minimal_nthroot_test" begin
+    @test nthroot(∅, 3) == ∅
+    @test nthroot(∅, 4) == ∅
+    @test nthroot(∅, -3) == ∅
+    @test nthroot(∅, -4) == ∅
+    @test nthroot(Interval(8, 27), 3) ⊇ Interval(2, 3)
+    @test nthroot(Interval(0, 27), 3) ⊇ Interval(0, 3)
+    @test nthroot(Interval(-27, 0), 3) ⊇ Interval(-3, 0)
+    @test nthroot(Interval(-27, 27), 3) ⊇ Interval(-3, 3)
+    @test nthroot(Interval(-27, -8), 3) ⊇ Interval(-3, -2)
+    @test nthroot(Interval(16, 81), 4) == Interval(2, 3)
+    @test nthroot(Interval(0, 81), 4) == Interval(0, 3)
+    @test nthroot(Interval(-81, 0), 4) == Interval(0)
+    @test nthroot(Interval(-81, 81), 4) == Interval(0, 3)
+    @test nthroot(Interval(-81, -16), 4) == ∅
+    @test nthroot(Interval(8, 27), -3) ⊇ Interval(1/3, 1/2)
+    @test nthroot(Interval(0, 27), -3) == Interval(1/3, Inf)
+    @test nthroot(Interval(-27, 0), -3) == Interval(-Inf, -1/3)
+    @test nthroot(Interval(-27, 27), -3) == Interval(-Inf, Inf)
+    @test nthroot(Interval(-27, -8), -3) ⊇ Interval(-1/2, -1/3)
+    @test nthroot(Interval(16, 81), -4) == Interval(1/3, 1/2)
+    @test nthroot(Interval(0, 81), -4) == Interval(1/3, Inf)
+    @test nthroot(Interval(-81, 0), -4) == ∅
+    @test nthroot(Interval(-81, 81), -4) == Interval(1/3, Inf)
+    @test nthroot(Interval(-81, -16), -4) == ∅
+end
+
 @testset "minimal_sqrt_test" begin
     @test sqrt(∅) == ∅
     @test (∅)^(1/2) == ∅

--- a/test/ITF1788_tests/libieeep1788_tests_elem.jl
+++ b/test/ITF1788_tests/libieeep1788_tests_elem.jl
@@ -905,33 +905,6 @@ end
     @test decoration(DecoratedInterval(Interval(0x1.999999999999ap-4, 0x1.999999999999ap-4), com) ^(2.0)) == decoration(DecoratedInterval(Interval(0x1.47ae147ae147bp-7, 0x1.47ae147ae147cp-7), com))
 end
 
-@testset "minimal_nthroot_test" begin
-    @test nthroot(∅, 3) == ∅
-    @test nthroot(∅, 4) == ∅
-    @test nthroot(∅, -3) == ∅
-    @test nthroot(∅, -4) == ∅
-    @test nthroot(Interval(8, 27), 3) ⊇ Interval(2, 3)
-    @test nthroot(Interval(0, 27), 3) ⊇ Interval(0, 3)
-    @test nthroot(Interval(-27, 0), 3) ⊇ Interval(-3, 0)
-    @test nthroot(Interval(-27, 27), 3) ⊇ Interval(-3, 3)
-    @test nthroot(Interval(-27, -8), 3) ⊇ Interval(-3, -2)
-    @test nthroot(Interval(16, 81), 4) == Interval(2, 3)
-    @test nthroot(Interval(0, 81), 4) == Interval(0, 3)
-    @test nthroot(Interval(-81, 0), 4) == Interval(0)
-    @test nthroot(Interval(-81, 81), 4) == Interval(0, 3)
-    @test nthroot(Interval(-81, -16), 4) == ∅
-    @test nthroot(Interval(8, 27), -3) ⊇ Interval(1/3, 1/2)
-    @test nthroot(Interval(0, 27), -3) == Interval(1/3, Inf)
-    @test nthroot(Interval(-27, 0), -3) == Interval(-Inf, -1/3)
-    @test nthroot(Interval(-27, 27), -3) == Interval(-Inf, Inf)
-    @test nthroot(Interval(-27, -8), -3) ⊇ Interval(-1/2, -1/3)
-    @test nthroot(Interval(16, 81), -4) == Interval(1/3, 1/2)
-    @test nthroot(Interval(0, 81), -4) == Interval(1/3, Inf)
-    @test nthroot(Interval(-81, 0), -4) == ∅
-    @test nthroot(Interval(-81, 81), -4) == Interval(1/3, Inf)
-    @test nthroot(Interval(-81, -16), -4) == ∅
-end
-
 @testset "minimal_sqrt_test" begin
     @test sqrt(∅) == ∅
     @test (∅)^(1/2) == ∅

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -190,6 +190,33 @@ end
     @test @interval(1/9) == @interval(1//9)
 end
 
+@testset "nthroot test" begin
+    @test nthroot(∅, 3) == ∅
+    @test nthroot(∅, 4) == ∅
+    @test nthroot(∅, -3) == ∅
+    @test nthroot(∅, -4) == ∅
+    @test nthroot(Interval(8, 27), 3) == Interval(2, 3)
+    @test nthroot(Interval(0, 27), 3) == Interval(0, 3)
+    @test nthroot(Interval(-27, 0), 3) == Interval(-3, 0)
+    @test nthroot(Interval(-27, 27), 3) == Interval(-3, 3)
+    @test nthroot(Interval(-27, -8), 3) == Interval(-3, -2)
+    @test nthroot(Interval(16, 81), 4) == Interval(2, 3)
+    @test nthroot(Interval(0, 81), 4) == Interval(0, 3)
+    @test nthroot(Interval(-81, 0), 4) == Interval(0)
+    @test nthroot(Interval(-81, 81), 4) == Interval(0, 3)
+    @test nthroot(Interval(-81, -16), 4) == ∅
+    @test nthroot(Interval(8, 27), -3) == Interval(1/3, 1/2)
+    @test nthroot(Interval(0, 27), -3) == Interval(1/3, Inf)
+    @test nthroot(Interval(-27, 0), -3) == Interval(-Inf, -1/3)
+    @test nthroot(Interval(-27, 27), -3) == Interval(-Inf, Inf)
+    @test nthroot(Interval(-27, -8), -3) == Interval(-1/2, -1/3)
+    @test nthroot(Interval(16, 81), -4) == Interval(1/3, 1/2)
+    @test nthroot(Interval(0, 81), -4) == Interval(1/3, Inf)
+    @test nthroot(Interval(-81, 0), -4) == ∅
+    @test nthroot(Interval(-81, 81), -4) == Interval(1/3, Inf)
+    @test nthroot(Interval(-81, -16), -4) == ∅
+end
+
 @testset "Floor etc. tests" begin
     a = @interval(0.1)
     b = Interval(0.1, 0.1)


### PR DESCRIPTION
Some test cases are failing even though function returns the correct value.
```jl
julia> @test nthroot(Interval(8, 27), -3) == Interval(1/3, 1/2)
Test Failed at REPL[17]:1
  Expression: nthroot(Interval(8, 27), -3) == Interval(1 / 3, 1 / 2)
   Evaluated: [0.333333, 0.5] == [0.333333, 0.5]
ERROR: There was an error during testing

julia> @test nthroot(Interval(0, 27), -3) == Interval(1/3, Inf)
Test Failed at REPL[18]:1
  Expression: nthroot(Interval(0, 27), -3) == Interval(1 / 3, Inf)
   Evaluated: [0.333333, ∞] == [0.333333, ∞]
ERROR: There was an error during testing

julia> @test nthroot(Interval(-27, 0), -3) == Interval(-Inf, -1/3)
Test Failed at REPL[19]:1
  Expression: nthroot(Interval(-27, 0), -3) == Interval(-Inf, -1 / 3)
   Evaluated: [-∞, -0.333333] == [-∞, -0.333333]
ERROR: There was an error during testing

julia> @test nthroot(Interval(-27, -8), -3) == Interval(-1/2, -1/3)
Test Failed at REPL[21]:1
  Expression: nthroot(Interval(-27, -8), -3) == Interval(-1 / 2, -1 / 3)
   Evaluated: [-0.5, -0.333333] == [-0.5, -0.333333]
ERROR: There was an error during testing
```
