### PR TITLE
hypot() defined for intervals (#306)

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -21,7 +21,7 @@ import Base:
     +, -, *, /, //, fma,
     <, >, ==, !=, ⊆, ^, <=,
     in, zero, one, eps, typemin, typemax, abs, abs2, real, min, max,
-    sqrt, exp, log, sin, cos, tan, inv,
+    sqrt, exp, log, sin, cos, tan, inv, hypot
     exp2, exp10, log2, log10,
     asin, acos, atan,
     sinh, cosh, tanh, asinh, acosh, atanh, sinpi, cospi,
@@ -63,7 +63,7 @@ export
     RoundTiesToEven, RoundTiesToAway,
     cancelminus, cancelplus, isunbounded,
     .., @I_str, ±,
-    pow, extended_div,
+    pow, hypot, extended_div,
     setformat, @format
 
 export

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -264,7 +264,9 @@ function pow(x::Interval, y::Real)  # fast real power, including for y an Interv
 
 end
 
-
+function hypot(x::Interval, y::Interval)
+    sqrt(x^2 + y^2)
+end
 
 
 for f in (:exp, :expm1)


### PR DESCRIPTION
Hello,

I have added the trivial implementation and the necessary import and export for hypot to be usable. I didn't add a doc comment or a test case (as I didn't know where you would want to put that).