### PR TITLE
assign ≼ to precedes()

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -54,7 +54,7 @@ export
     @interval, @biginterval, @floatinterval, @make_interval,
     diam, radius, mid, mag, mig, hull,
     emptyinterval, ∅, ∞, isempty, isinterior, isdisjoint, ⪽,
-    precedes, strictprecedes, ≺, ⊂, ⊃, ⊇, contains_zero,
+    precedes, strictprecedes, ≼, ≺, ⊂, ⊃, ⊇, contains_zero,
     entireinterval, isentire, nai, isnai, isthin, iscommon, isatomic,
     widen, inf, sup, bisect,
     parameters, eps, dist,

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -40,6 +40,7 @@ function precedes(a::Interval, b::Interval)
     (isempty(a) || isempty(b)) && return true
     a.hi ≤ b.lo
 end
+const ≼ = precedes # \preccurlyeq
 
 # strictpreceds
 function strictprecedes(a::Interval, b::Interval)
@@ -227,7 +228,7 @@ function extended_div(a::Interval{T}, b::Interval{T}) where T<:Real
     elseif 0 ∈ a && 0 ∈ b
         return (entireinterval(S), emptyinterval(S))
     end
-    
+
     return (a / b, emptyinterval(S))
 end
 


### PR DESCRIPTION
implements JuliaIntervals/IntervalArithmetic.jl/issues/314