### PR TITLE
Remove extra type constraints

### DIFF
--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -107,3 +107,5 @@ IntervalBox(x::Interval, ::Val{n}) where {n} = IntervalBox(SVector(ntuple( _ -> 
 IntervalBox(x::Interval, n::Int) = IntervalBox(x, Val(n))
 
 dot(x::IntervalBox, y::IntervalBox) = dot(x.v, y.v)
+
+Base.:(==)(x::IntervalBox, y::IntervalBox) = x.v == y.v

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -66,12 +66,12 @@ big(X::IntervalBox) = big.(X)
 
 # TODO: Update to use generator
 for (op, dotop) in ((:⊆, :.⊆), (:⊂, :.⊂), (:⊃, :.⊃))
-    @eval $(op)(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} = all($(dotop)(X, Y))
+    @eval $(op)(X::IntervalBox{N}, Y::IntervalBox{N}) where {N} = all($(dotop)(X, Y))
 end
 
-∩(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} =
+∩(X::IntervalBox{N}, Y::IntervalBox{N}) where {N} =
     IntervalBox(X.v .∩ Y.v)
-∪(X::IntervalBox{N,T}, Y::IntervalBox{N,T}) where {N,T} =
+∪(X::IntervalBox{N}, Y::IntervalBox{N}) where {N} =
     IntervalBox(X.v .∪ Y.v)
 
 ∈(X::AbstractVector, Y::IntervalBox{N,T}) where {N,T} = all(X .∈ Y)

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -35,34 +35,38 @@ let X, A  # avoid problems with global variables
     @test A .^ 2 == IntervalBox(1..4, 9..16)
     @test B .^ 0.5 == IntervalBox(@interval(0,sqrt(2)), @interval(sqrt(3),sqrt(6)))
 
-    @test A ⊆ A
-    @test A ⊆ B
-    @test A.v ⊆ B
-    @test A ⊂ B.v
-    @test !(A ⊂ A)
-    @test A ⊂ B
-    @test A.v ⊂ B
-    @test A ⊆ B.v
-    @test !(B ⊆ A)
-    @test !(B ⊂ A)
-    @test B ⊇ B
-    @test B ⊇ A
-    @test B.v ⊇ A
-    @test B ⊇ A.v
-    @test !(B ⊃ B)
-    @test B ⊃ A
-    @test B.v ⊃ A
-    @test B ⊃ A.v
-    @test !(A ⊇ B)
-    @test !(A ⊃ B)
+    for (A, B) in ( (A,B), (big(A), B), (A, big(B)), (big(A), big(B)) )
+        @test A ⊆ A
+        @test A ⊆ B
+        @test A.v ⊆ B
+        @test A ⊂ B.v
+        @test !(A ⊂ A)
+        @test A ⊂ B
+        @test A.v ⊂ B
+        @test A ⊆ B.v
+        @test !(B ⊆ A)
+        @test !(B ⊂ A)
+        @test B ⊇ B
+        @test B ⊇ A
+        @test B.v ⊇ A
+        @test B ⊇ A.v
+        @test !(B ⊃ B)
+        @test B ⊃ A
+        @test B.v ⊃ A
+        @test B ⊃ A.v
+        @test !(A ⊇ B)
+        @test !(A ⊃ B)
 
-    @test A ∩ B == A
-    @test A.v ∩ B == A
-    @test A ∩ B.v == A
+        @test A ∩ B == A
+        @test A.v ∩ B == A
+        @test A ∩ B.v == A
+    
+        @test A ∪ B == B
+        @test A.v ∪ B == B
+        @test A ∪ B.v == B
+    end
 
-    @test A ∪ B == B
-    @test A.v ∪ B == B
-    @test A ∪ B.v == B
+
 
     X = IntervalBox(1..2, 3..4)
     Y = IntervalBox(3..4, 3..4)


### PR DESCRIPTION
Ref https://github.com/JuliaIntervals/IntervalOptimisation.jl/pull/45/files#r355474198. As far as I can tell, they are unnecessary. They disallow comparing IntervalBoxes of different numeric types, but it just dispatches to the 1D versions which can handle different types, e.g.

```julia
julia> x1 = -1.0..2.0
[-1, 2]

julia> x2 = big(1.0)..big(3.0)
[1, 3]₂₅₆

julia> x1 ∩ x2
[1, 2]₂₅₆

julia> x1 ∪ x2
[-1, 3]₂₅₆

julia> x1 ⊂ x2
false

julia> x1 ⊆ x2
false

julia> x1 ⊃ x2
false

julia> x1 ⊆ x2
false
```