### PR TITLE
Return a concrete interval with negative-integer powers

### DIFF
--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -237,6 +237,9 @@ A faster implementation of `x^n`, currently using `power_by_squaring`.
 enclosure when using multiplication with correct rounding.
 """
 function pow(x::Interval, n::Integer)  # fast integer power
+    if n < 0
+        return 1/pow(x, -n)
+    end
 
     isempty(x) && return x
 
@@ -259,7 +262,7 @@ end
 function pow(x::Interval, y::Real)  # fast real power, including for y an Interval
 
     isempty(x) && return x
-
+    isinteger(y) && return pow(x, Int(y.lo))
     return exp(y * log(x))
 
 end

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -273,6 +273,9 @@ end
         @test pow(-1..2, 3) == -1..8
         @test pow(-1..2, 4) == 0..16
 
+        @test pow(-2 .. -1, 4..4) == 1..16
+        @test pow(-2 .. -1, -1 .. -1) == -1 .. -0.5
+
         @test pow(@biginterval(-1, 2), 2) == 0..4
         @test pow(@biginterval(-1, 2), 3) == -1..8
         @test pow(@biginterval(1, 2), 2) == 1..4


### PR DESCRIPTION
On v0.16.2 I get

```julia
julia> pow(-2 .. -1, -1 .. -1)
∅
```

With this I get
```julia
julia> pow(-2 .. -1, -1 .. -1)
[-1, -0.5]
```