### PR TITLE
Overload Base.show for complex type

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -11,6 +11,8 @@ function Base.show(io::IO, params::DisplayParameters)
     print(io, "- significant figures: $(params.sigfigs)")
 end
 
+Base.show(io::IO, x::Complex{<:Interval}) = print(io, x.re, " + ", x.im, "im")
+
 const display_params = DisplayParameters(:standard, false, 6)
 
 const display_options = (:standard, :full, :midpoint)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -85,6 +85,12 @@ setprecision(Interval, Float64)
         @test string(a) == "1.5f0 ± 0.5f0"
     end
 
+    @testset "Complex{Interval}" begin
+        a = Complex(Interval(0, 2), 1)
+        @test typeof(a)== Complex{Interval{Float64}}
+        setformat(:standard)
+        @test string(a) == "[0, 2] + [1, 1]im"
+    end
 
     setprecision(Interval, 256)
 

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -87,7 +87,7 @@ setprecision(Interval, Float64)
 
     @testset "Complex{Interval}" begin
         a = Complex(Interval(0, 2), 1)
-        @test typeof(a)== Complex{Interval{Float64}}
+        @test typeof(a) == Complex{Interval{Float64}}
         setformat(:standard)
         @test string(a) == "[0, 2] + [1, 1]im"
     end


### PR DESCRIPTION
Fixes: https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/402
Followed @dpsanders's comment [here](https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/402#issuecomment-665360533).

Note: It prevented the error on my machine!

I am new to Julia. Please let me know if I am wrong with the format or something or even if I am completely wrong.