### PR TITLE
Add CRlibm-1.0.0 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.17.7"
+version = "0.17.8"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"
@@ -15,7 +15,7 @@ SetRounding = "3cc68bcd-71a2-5612-b932-767ffbe40ab0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-CRlibm = "0.7, 0.8"
+CRlibm = "0.7, 0.8, 1.0.1"
 FastRounding = "0.2"
 Polynomials = "0.7"
 RecipesBase = "1.0"


### PR DESCRIPTION
This allows IntervalArithmetic to be used with the binarybuilder version of CRlibm.