### PR TITLE
Add special interval constructors

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -22,7 +22,7 @@ import Base:
     +, -, *, /, //, fma,
     <, >, ==, !=, ⊆, ^, <=,
     in, zero, one, eps, typemin, typemax, abs, abs2, real, min, max,
-    sqrt, exp, log, sin, cos, tan, cot, inv, cbrt, csc, hypot, sec, 
+    sqrt, exp, log, sin, cos, tan, cot, inv, cbrt, csc, hypot, sec,
     exp2, exp10, log2, log10,
     asin, acos, atan,
     sinh, cosh, tanh, coth, csch, sech, asinh, acosh, atanh, sinpi, cospi,
@@ -57,6 +57,7 @@ export
     emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot,
     precedes, strictprecedes, ≼, ≺, ⊂, ⊃, ⊇, contains_zero,
     entireinterval, isentire, nai, isnai, isthin, iscommon, isatomic,
+    zero_interval,
     widen, inf, sup, bisect, mince,
     parameters, eps, dist,
     midpoint_radius, interval_from_midpoint_radius,
@@ -86,7 +87,7 @@ import Base: rounding, setrounding, setprecision
 
 ## Multidimensional
 export
-    IntervalBox
+    IntervalBox, zero_box, symmetric_box
 
 ## Decorations
 export

--- a/src/intervals/special.jl
+++ b/src/intervals/special.jl
@@ -83,3 +83,11 @@ contains_zero(X::Interval{T}) where {T} = zero(T) ∈ X
 # """
 # widen(x::Interval{T}) where T<:AbstractFloat =
 #     Interval(prevfloat(x.lo), nextfloat(x.hi))
+
+"""
+    zero_interval(T)
+
+Return the zero interval `Interval(0, 0)` in the numeric type `T`.
+"""
+zero_interval(::Type{T}) where T<:Real = zero(Interval{T})
+zero_interval(x::Interval{T}) where T<:Real = zero(Interval{T})

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -140,3 +140,18 @@ end
 
 hull(a::IntervalBox{N,T}, b::IntervalBox{N,T}) where {N,T} = IntervalBox(hull.(a[:], b[:]))
 hull(a::Vector{IntervalBox{N,T}}) where {N,T} = hull(a...)
+
+"""
+    zero_box(N, T)
+
+Return the zero interval box of dimension `N` in the numeric type `T`.
+"""
+zero_box(N, ::Type{T}) where T<:Real = IntervalBox(zero_interval(T), N)
+
+"""
+    symmetric_box(N, T)
+
+Return the symmetric interval box of dimension `N` in the numeric type `T`,
+each side is `Interval(-1, 1)`.
+"""
+symmetric_box(N, ::Type{T}) where T<:Real = IntervalBox(Interval{T}(-1, 1), N)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -370,3 +370,8 @@ import IntervalArithmetic: force_interval
     @test force_interval(Inf, -Inf) == Interval(-Inf, Inf)
     @test_throws ArgumentError force_interval(NaN, 3)
 end
+
+@testset "Zero interval" begin
+    @test zero_interval(Float64) === Interval{Float64}(0, 0)
+    @test zero_interval(0 .. 1) === Interval{Float64}(0, 0)
+end

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -314,4 +314,9 @@ end
     @test hull(vb4) == ib4
 end
 
+@testset "Special box constructors" begin
+    @test zero_box(2, Float64) === IntervalBox(0 .. 0, 2)
+    @test symmetric_box(2, Float64) === IntervalBox(-1 .. 1, 2)
+end
+
 end


### PR DESCRIPTION
This PR adds special constructors for zero interval / box and symmetric box that are commonly used in other packages (such as TaylorModels.jl or ReachabilityAnalysis.jl).