### PR TITLE
fixing displaying issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.17.8"
+version = "0.18.0"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/display.jl
+++ b/src/display.jl
@@ -360,4 +360,5 @@ for T in (IntervalBox, Complex{<:Interval})
     @eval show(io::IO, a::$T) = print(io, representation(a))
     @eval show(io::IO, ::MIME"text/plain", a::$T) = print(io, representation(a))
     @eval showfull(io::IO, a::$T) = print(io, representation(a, :full))
+    @eval showfull(a::$T) = showfull(stdout, a)
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -324,18 +324,31 @@ end
 
 function representation(X::IntervalBox{N, T}, format=nothing) where {N, T}
 
-    isempty(X) && return string("∅", superscriptify(N))
-
     if format == nothing
         format = display_params.format  # default
     end
 
-    if all(==(first(X)), X)
-        return string(representation(first(X), format), superscriptify(N))
+    n = format == :full ? N : superscriptify(N)
+
+    if isempty(X)
+        format == :full && return string("IntervalBox(∅, ", n, ")")
+        return string("∅", n)
+    end
+
+    x = first(X)
+    if all(==(x), X)
+        if format == :full
+            return string("IntervalBox(", representation(x, format), ", ", n, ")")
+        elseif format == :midpoint
+            return string("(", representation(x, format), ")", n)
+        else
+            return string(representation(x, format), n)
+        end
     end
 
     if format == :full
-        return string("IntervalBox(", join(X.v, ", "), ")")
+        full_str = representation.(X.v, :full)
+        return string("IntervalBox(", join(full_str, ", "), ")")
     elseif format == :midpoint
         return string("(", join(X.v, ") × ("), ")")
     else

--- a/src/display.jl
+++ b/src/display.jl
@@ -11,8 +11,6 @@ function Base.show(io::IO, params::DisplayParameters)
     print(io, "- significant figures: $(params.sigfigs)")
 end
 
-Base.show(io::IO, x::Complex{<:Interval}) = print(io, x.re, " + ", x.im, "im")
-
 const display_params = DisplayParameters(:standard, false, 6)
 
 const display_options = (:standard, :full, :midpoint)
@@ -334,6 +332,16 @@ function representation(X::IntervalBox, format=nothing)
 
 end
 
+function representation(x::Complex{<:Interval}, format=nothing)
+
+    if format == nothing
+        format = display_params.format
+    end
+
+    format == :midpoint && return string('(', x.re, ')', " + ", '(', x.im, ')', "im")
+
+    return string(x.re, " + ", x.im, "im")
+end
 
 for T in (Interval, DecoratedInterval)
     @eval show(io::IO, a::$T{S}) where S = print(io, representation(a))
@@ -341,7 +349,8 @@ for T in (Interval, DecoratedInterval)
     @eval showfull(a::$T{S}) where S = showfull(stdout, a)
 end
 
-T = IntervalBox
-@eval show(io::IO, a::$T) = print(io, representation(a))
-@eval show(io::IO, ::MIME"text/plain", a::$T) = print(io, representation(a))
-@eval showfull(io::IO, a::$T) = print(io, representation(a, :full))
+for T in (IntervalBox, Complex{<:Interval})
+    @eval show(io::IO, a::$T) = print(io, representation(a))
+    @eval show(io::IO, ::MIME"text/plain", a::$T) = print(io, representation(a))
+    @eval showfull(io::IO, a::$T) = print(io, representation(a, :full))
+end

--- a/src/display.jl
+++ b/src/display.jl
@@ -272,6 +272,11 @@ function subscriptify(n::Integer)
     join( [Char(subscript_0 + i) for i in dig])
 end
 
+function superscriptify(n::Integer)
+    exps = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
+    dig = reverse(digits(n))
+    return join([exps[d+1] for d in dig])
+end
 
 # fall-back:
 representation(a::Interval{T}, format=nothing) where T =
@@ -317,7 +322,9 @@ function representation(a::DecoratedInterval{T}, format=nothing) where T
 end
 
 
-function representation(X::IntervalBox, format=nothing)
+function representation(X::IntervalBox{N, T}, format=nothing) where {N, T}
+
+    all(==(first(X)), X) && return string(first(X), superscriptify(N))
 
     if format == nothing
         format = display_params.format  # default

--- a/src/display.jl
+++ b/src/display.jl
@@ -336,7 +336,8 @@ function representation(X::IntervalBox{N, T}, format=nothing) where {N, T}
 
     if format == :full
         return string("IntervalBox(", join(X.v, ", "), ")")
-
+    elseif format == :midpoint
+        return string("(", join(X.v, ") × ("), ")")
     else
         return join(X.v, " × ")
     end

--- a/src/display.jl
+++ b/src/display.jl
@@ -324,13 +324,17 @@ end
 
 function representation(X::IntervalBox{N, T}, format=nothing) where {N, T}
 
-    all(==(first(X)), X) && return string(first(X), superscriptify(N))
+    isempty(X) && return string("∅", superscriptify(N))
 
     if format == nothing
         format = display_params.format  # default
     end
 
-    if display_params.format == :full
+    if all(==(first(X)), X)
+        return string(representation(first(X), format), superscriptify(N))
+    end
+
+    if format == :full
         return string("IntervalBox(", join(X.v, ", "), ")")
 
     else

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -90,6 +90,9 @@ setprecision(Interval, Float64)
         @test typeof(a) == Complex{Interval{Float64}}
         setformat(:standard)
         @test string(a) == "[0, 2] + [1, 1]im"
+
+        setformat(:midpoint)
+        @test string(a) == "(1 ± 1) + (1 ± 0)im"
     end
 
     setprecision(Interval, 256)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -177,6 +177,26 @@ setprecision(Interval, Float64)
         setformat(:full)
         @test string(X) == "IntervalBox(Interval(-Inf, Inf), 2)"
 
+
+        setformat(:standard)
+        a = IntervalBox(1..2, 2..3)
+        @test string(a) == "[1, 2] × [2, 3]"
+
+        b = IntervalBox(emptyinterval(), 2)
+        @test string(b) == "∅²"
+
+        c = IntervalBox(1..2, 1)
+        @test string(c) == "[1, 2]¹"
+
+        setformat(:full)
+        @test string(a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
+        @test string(b) == "IntervalBox(∅, 2)"
+        @test string(c) == "IntervalBox(Interval(1.0, 2.0), 1)"
+
+        setformat(:midpoint)
+        @test string(a) == "(1.5 ± 0.5) × (2.5 ± 0.5)"
+        @test string(b) == "∅²"
+        @test string(c) == "(1.5 ± 0.5)¹"
     end
 end
 
@@ -202,6 +222,14 @@ end
 
     setformat(decorations=true)
     @test string(x) == "[0, 1]₁₂₈_def"
+
+    a = IntervalBox(1..2, 2..3)
+    b = IntervalBox(emptyinterval(), 2)
+    c = IntervalBox(1..2, 1)
+
+    @test sprint(showfull, a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
+    @test sprint(showfull, b) == "IntervalBox(∅, 2)"
+    @test sprint(showfull, c) == "IntervalBox(Interval(1.0, 2.0), 1)"
 
 end
 

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -175,7 +175,7 @@ setprecision(Interval, Float64)
         @test string(X) == "[-∞, ∞]²"
 
         setformat(:full)
-        @test string(X) == "Interval(-Inf, Inf)²"
+        @test string(X) == "IntervalBox(Interval(-Inf, Inf), 2)"
 
     end
 end

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -172,10 +172,10 @@ setprecision(Interval, Float64)
         @test string(X) == "[1.09999, 1.20001] × [2.09999, 2.20001]"
 
         X = IntervalBox(-Inf..Inf, -Inf..Inf)
-        @test string(X) == "[-∞, ∞] × [-∞, ∞]"
+        @test string(X) == "[-∞, ∞]²"
 
         setformat(:full)
-        @test string(X) == "IntervalBox(Interval(-Inf, Inf), Interval(-Inf, Inf))"
+        @test string(X) == "Interval(-Inf, Inf)²"
 
     end
 end


### PR DESCRIPTION
Here is a summary of the changes

- complex intervals (fixes #287, fixes #332 ), `Base.show` was already implemented, I just modified it to be nicer with midpoint-format
```
julia> (1..2)+(3..4)im
(1.5 ± 0.5) + (3.5 ± 0.5)im
```

- cubic interval boxes (fixes #339) now cubic interval boxes are displayed in a more compact way with a superscript
```
julia> IntervalBox(1..2, 100)
[1, 2]¹⁰⁰
```

- thanks to the previous fix, now also empty interval boxes in the form `IntervalBox(emptyinterval(), N)` are displayed more compactly. (fixes #432 )
```
julia> IntervalBox(emptyinterval(), 100)
∅¹⁰⁰
```

However, Interval boxes where only some components are emptyintervals are still displayed normally, not sure whether this is a good idea
```
  julia> IntervalBox(1..2, emptyinterval(), 3..4)
[1, 2] × ∅ × [3, 4]
```

- 1-dimensional interval-boxes have a "1" as superscript, (fixes #171 )
```
julia> IntervalBox(1..2)
[1, 2]¹
```

not sure how many of these ideas are actually good, open for feedback 😃 