### PR TITLE
Draft of multi-intervals (unions of disjoint intervals)

### DIFF
--- a/src/intervals/multi_intervals.jl
+++ b/src/intervals/multi_intervals.jl
@@ -1,6 +1,6 @@
 using IntervalArithmetic
 import Base: getindex, ∪
-import Base: +, -, *, /, min, max, ^, log, <, >
+import Base: +, -, *, /, min, max, ^, log, <, >, exp, sin, cos, tan
 import IntervalArithmetic: hull
 
 """
@@ -131,6 +131,10 @@ for op in (:+, :-, :*, :/, :min, :max, :^, :log, :<, :>)
     @eval ($op)( x::IntervalM, n::Real) = intervalM(broadcast($op, x.v, n))
     @eval ($op)( n::Real, x::IntervalM) = intervalM(broadcast($op, n, x.v))
     
+end
+
+for op in (:-, :sin, :cos, :tan, :exp, :log)
+    @eval ($op)( x::IntervalM) = intervalM(broadcast($op, x.v))
 end
 
 ###

--- a/src/intervals/multi_intervals.jl
+++ b/src/intervals/multi_intervals.jl
@@ -36,9 +36,9 @@ intervalM(x :: IntervalM, y :: Interval) = intervalM([x.v; y])
 intervalM(x :: IntervalM, y :: IntervalM) = intervalM([x.v; y.v])
 ∪(x :: IntervalM, y :: IntervalM) = intervalM(x,y)
 
-# MultiInterval can act like a vector
+# Get index from multi-interval array
 getindex(x :: IntervalM, ind :: Integer) = getindex(x.v,ind)
-getindex(x :: IntervalM, ind :: Array{ <: Integer}) = getindex(x.v,ind)
+getindex(x :: IntervalM, ind :: Array{ <:Integer}) = getindex(x.v,ind)
 
 # Remove ∅ from Multi-Interval
 function removeEmpties(x :: IntervalM)
@@ -47,7 +47,7 @@ function removeEmpties(x :: IntervalM)
     return IntervalM(Vnew)
 end
 
-# Envolpe intervals which intersect. Recursive condense!
+# Recursively envolpe intervals which intersect
 function condense(x :: IntervalM)
 
     if isCondensed(x); return x; end
@@ -82,6 +82,7 @@ hull(x :: IntervalM) = IntervalM(hull(x.v))
 ###
 
 for op in (:+, :-, :*, :/, :min, :max, :^, :log, :<, :>)
+    
     @eval ($op)( x::IntervalM, y::IntervalM) = intervalM([$op(xv, yv) for xv in x.v, yv in y.v][:])
 
     @eval ($op)( x::IntervalM, y::Interval) = intervalM(broadcast($op, x.v, y))

--- a/src/intervals/multi_intervals.jl
+++ b/src/intervals/multi_intervals.jl
@@ -1,0 +1,99 @@
+using IntervalArithmetic
+import Base: getindex, ∪
+import Base: +, -, *, /, min, max, ^, log, <, >
+
+abstract type MultiInterval{T} <: AbstractInterval{T} end
+
+###
+#   Multi-Interval constructor. Consists of a vector of intervals
+###
+struct IntervalM{T<:Real} <: MultiInterval{T} 
+    v :: Array{Interval{T}}
+end
+
+
+###
+#   Outer constructors
+###
+function intervalM(x) 
+    x = IntervalM(x)
+    x = removeEmpties(x)
+    return condense(x)
+end
+
+intervalM(x :: Interval) = IntervalM([x])
+∪(x :: Interval) = intervalM(x)
+
+∪(x :: Interval, y :: Interval) = intervalM([x; y])
+∪(x :: Array{Interval{T}}) where T <:Real = intervalM(x)
+
+intervalM(x :: Interval, y :: IntervalM) = intervalM([x; y.v])
+∪(x :: Interval, y :: IntervalM) = intervalM(x,y)
+
+intervalM(x :: IntervalM, y :: Interval) = intervalM([x.v; y])
+∪(x :: IntervalM, y :: Interval) = intervalM(x,y)
+
+intervalM(x :: IntervalM, y :: IntervalM) = intervalM([x.v; y.v])
+∪(x :: IntervalM, y :: IntervalM) = intervalM(x,y)
+
+# MultiInterval can act like a vector
+getindex(x :: IntervalM, ind :: Integer) = getindex(x.v,ind)
+getindex(x :: IntervalM, ind :: Array{ <: Integer}) = getindex(x.v,ind)
+
+# Remove ∅ from Multi-Interval
+function removeEmpties(x :: IntervalM)
+    v = x.v
+    Vnew = v[v .!= ∅]
+    return IntervalM(Vnew)
+end
+
+# Envolpe intervals which intersect. Recursive condense!
+function condense(x :: IntervalM)
+
+    if isCondensed(x); return x; end
+
+    v = sort(x.v)
+    v = unique(v)
+
+    Vnew = Interval{Float64}[]
+    for i =1:length(v)
+        these = findall( intersect.(v[i],v ) .!= ∅)
+        push!(Vnew, hull(v[these]))
+    end
+    return condense( intervalM(Vnew) )
+end
+
+function isCondensed(x :: IntervalM)
+    v = sort(x.v)
+    for i=1:length(v)
+        intersects = findall( intersect.(v[i],v[1:end .!= i]) .!= ∅)
+        if !isempty(intersects); return false; end
+    end
+    return true
+end
+
+# Envolpe/hull. Keeps it as a multi interval
+env(x :: IntervalM) = IntervalM(hull(x.v))
+hull(x :: IntervalM) = IntervalM(hull(x.v))
+
+
+###
+#   Multi-Interval Arithmetic
+###
+
+for op in (:+, :-, :*, :/, :min, :max, :^, :log, :<, :>)
+    @eval ($op)( x::IntervalM, y::IntervalM) = intervalM([$op(xv, yv) for xv in x.v, yv in y.v][:])
+
+    @eval ($op)( x::IntervalM, y::Interval) = intervalM(broadcast($op, x.v, y))
+    @eval ($op)( x::Interval, y::IntervalM) = intervalM(broadcast($op, y, x.v))
+
+    @eval ($op)( x::IntervalM, n::Real) = intervalM(broadcast($op, x.v, n))
+    @eval ($op)( n::Real, x::IntervalM) = intervalM(broadcast($op, n, x.v))
+    
+end
+
+
+function Base.show(io::IO, this::IntervalM)
+    v = sort(this.v)
+    print(io, join(v, " ∪ "));
+end


### PR DESCRIPTION
Are you guys interested in an implementation of Multi-Intervals?

Multi-Intervals are sets of reals defined by unions of disjoint intervals. This PR includes:

- Constructors, which remove any empty sets and envelope intervals which intersect
- Arithmetic of Multi-Intervals, including with intervals and scalars
- Complement functions

Usage:

```Julia
    julia> a = interval(0,2) ∪ interval(3,3.6) ∪ interval(3.5,4)
    [0, 2] ∪ [3, 4]

    julia> b = interval(1,2) ∪ interval(4,5) ∪ ∅
    [1, 2] ∪ [4, 5]

    julia> c = a * b 
    [0, 10] ∪ [12, 20]
    
    julia> complement(c)
    [-∞, 0] ∪ [10, 12] ∪ [20, ∞]
```

Note that the arithmetic doesn't broadcast on the elements of the multi-interval, but does every combination. The result is then condensed if any intervals overlap.

I'm agnostic to the name "Multi-Interval", it's what we call them but maybe there's a better name.

This is a draft and just includes a stand alone file which uses IntervalArithmetic.jl, and does not yet integrate it into the module.

Extension to interval boxes should also be possible.