### PR TITLE
Improve support for `Interval{<:Integer}`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.17.8"
+version = "0.17.9"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/display.jl
+++ b/src/display.jl
@@ -170,6 +170,7 @@ function round_string(x::BigFloat, digits::Int, r::RoundingMode)
 end
 
 round_string(x::Real, digits::Int, r::RoundingMode) = round_string(big(x), digits, r)
+round_string(x::Integer, digits::Int, r::RoundingMode) = string(x)
 
 
 function basic_representation(a::Interval, format=nothing)

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -123,6 +123,10 @@ function atomic(::Type{Interval{T}}, x::Interval) where T<:AbstractFloat
     Interval{T}( T(x.lo, RoundDown), T(x.hi, RoundUp) )
 end
 
+function atomic(::Type{Interval{T}}, x::Interval) where T<:Integer
+    Interval{T}( floor(T, x.lo), ceil(T, x.hi) )
+end
+
 # Complex numbers:
 atomic(::Type{Interval{T}}, x::Complex{Bool}) where T<:AbstractFloat =
     (x == im) ? one(T)*im : throw(ArgumentError("Complex{Bool} not equal to im"))

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -232,6 +232,7 @@ function sqrt(a::Interval{T}) where T
 
     @round(sqrt(a.lo), sqrt(a.hi))  # `sqrt` is correctly-rounded
 end
+sqrt(a::Interval{<:Integer}) where T = sqrt(float(a))
 
 
 
@@ -301,6 +302,7 @@ for f in (:exp2, :exp10, :cbrt)
             @round( ($f)(a.lo), ($f)(a.hi) )
         end
 end
+cbrt(a::Interval{T}) where T<:Integer = cbrt(float(a))
 
 
 for f in (:log, :log2, :log10)
@@ -314,6 +316,7 @@ for f in (:log, :log2, :log10)
             @round( ($f)(a.lo), ($f)(a.hi) )
 
         end
+    @eval ($f)(a::Interval{<:Integer}) = ($f)(float(a))
 end
 
 function log1p(a::Interval{T}) where T
@@ -324,10 +327,12 @@ function log1p(a::Interval{T}) where T
 
     @round( log1p(a.lo), log1p(a.hi) )
 end
+log1p(a::Interval{<:Integer}) = log1p(float(a))
 
 hypot(a::Interval{BigFloat}, b::Interval{BigFloat}) = sqrt(a^2 + b^2)
 
-hypot(a::Interval{T}, b::Interval{T}) where T= atomic(Interval{T}, hypot(bigequiv(a), bigequiv(b)))
+hypot(a::Interval{T}, b::Interval{T}) where T<:AbstractFloat = atomic(Interval{T}, hypot(bigequiv(a), bigequiv(b)))
+hypot(a::Interval{T}, b::Interval{T}) where T<:Integer = hypot(float(a), float(b))
 
 """
 nthroot(a::Interval{BigFloat}, n::Integer)
@@ -359,4 +364,4 @@ end
 function nthroot(a::Interval{T}, n::Integer) where T
     b = nthroot(bigequiv(a), n)
     return convert(Interval{T}, b)
-end 
+end

--- a/src/intervals/precision.jl
+++ b/src/intervals/precision.jl
@@ -21,10 +21,12 @@ function bigequiv(a::Interval{T}) where {T <: AbstractFloat}
         return atomic(Interval{BigFloat}, a)
     end
 end
+bigequiv(a::Interval{<:Integer}) = Interval(BigFloat(a.lo), BigFloat(a.hi))
 
 bigequiv(x::AbstractFloat) = guarded_setprecision(precision(x)) do
     return BigFloat(x)
 end
+bigequiv(x::Integer) = big(x)
 
 # NOTE: prevents multiple threads from calling setprecision() concurrently
 const precision_lock = ReentrantLock()

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -171,7 +171,7 @@ for mode in (:Down, :Up)
                                 $f(a, b)
                             end
                         end
-        
+
         @eval function $f(::IntervalRounding{:tight},
                             a::T, b::T, $mode1) where T<:AbstractFloat
                       setrounding(T, $mode2) do
@@ -276,6 +276,7 @@ function _setrounding(::Type{Interval}, rounding_type::Symbol)
     # binary functions:
     for f in (:+, :-, :*, :/)
         @eval $f(a::T, b::T, r::RoundingMode) where {T<:AbstractFloat} = $f($roundtype, a, b, r)
+        @eval $f(a::T, b::T, r::RoundingMode) where {T<:Integer} = $f(float(a), float(b), r)
     end
 
     # unary functions:

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -57,6 +57,19 @@ setprecision(Interval, Float64)
         end
     end
 
+    @testset "Interval{Int}" begin
+        a = Interval{Int}(1, 5)
+        @test typeof(a)== Interval{Int}
+        setformat(:standard)
+        @test string(a) == "[1, 5]"
+
+        setformat(:full)
+        @test string(a) == "Interval(1, 5)"
+
+        setformat(:midpoint)
+        @test string(a) == "3 ± 2"
+    end
+
     @testset "Interval{Rational{T}}" begin
         a = Interval(1//3, 5//4)
         @test typeof(a)== Interval{Rational{Int}}

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -283,6 +283,9 @@ end
 
     @test Interval{BigFloat}(1) == @biginterval(1, 1)
     @test Interval{BigFloat}(big"1.1") == Interval(big"1.1", big"1.1")
+
+    @test Interval{Int}(3 .. 5) == Interval{Int}(3, 5)
+    @test Interval{Int}(3.2 .. 4.7) == Interval{Int}(3, 5)
 end
 
 # issue 192:


### PR DESCRIPTION
When intervals are components of bigger `struct`s that impose
`eltype`-consistency, it would be nice not to have to force the
`eltype` to be an `AbstractFloat`. It's been possible to construct
`Interval{<:Integer}` for some time, but many methods throw errors.
This reduces the fragility of the package, hopefully without introducing
new numeric errors.

This also takes the liberty of bumping the patch version in hopes
of getting this into a release, but I'm happy to remove that if you'd
prefer to manage that separately.