### PR TITLE
Avoid NaN caused by using rationalize within atomic

### DIFF
--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -106,6 +106,9 @@ function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:AbstractF
 
     xrat = rationalize(x)
 
+    # Prevent generating NaN if denominator is too large
+    isinf(T(xrat.den)) && return Interval{T}( T(x, RoundDown), T(x, RoundUp) )
+
     # This prevents that xrat returns a 0//1 when x is very small
     # or 1//0 when x is too large but finite
     if (x != zero(x) && xrat == 0) || isinf(xrat)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -186,6 +186,9 @@ const eeuler = Base.MathConstants.e
     setprecision(Interval, 53)
     a = big(1)//3
     @test @interval(a) == Interval(big(3.3333333333333331e-01), big(3.3333333333333337e-01))
+
+    setprecision(Interval, Float16, 53)
+    @test @interval(1.00001) == Interval{Float16}(1, 1.00098)
 end
 
 @testset "Big intervals" begin


### PR DESCRIPTION
The `@interval` macro can produce `[NaN, NaN]` in case `rationalize` chooses a denominator that does not fit into the datatype used for the boundaries. Example:

```
julia> using IntervalArithmetic

julia> setprecision(Interval, Float16, 53)
53

julia> @interval(1.00001)
[NaN, NaN]
```

This pull request works around this by adding a corresponing check to `atomic`. Above example is added as a unit test. New behavior:

```
julia> using IntervalArithmetic

julia> setprecision(Interval, Float16, 53)
53

julia> @interval(1.00001)
[1, 1.00098]
```