### PR TITLE
operations on bare and decorated intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.18.2"
+version = "0.18.3"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.18.1"
+version = "0.18.2"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -363,9 +363,29 @@ for (f, domain) in restricted_functions2
     end
 end
 
-## comparisons
+## mixed operations
 
-for op in (:(==), :<=, :>=, :<, :>)
-      @eval Base.$op(a::Interval, b::DecoratedInterval) = $op(a, b.interval)
-      @eval Base.$op(a::DecoratedInterval, b::Interval) = $op(a.interval, b)
+for op in (:(==), :!=, :<=, :<, :≼, :≺, :⊂, :⊃, :⊇, :⊆, :⪽, :isdisjoint,
+            :+, :-, :*, :/, ://, :^, :pow, :extended_div, :atan, :min, :max, :dist,
+            :cancelminus, :cancelplus, :hypot, :copysign, :flipsign,
+            :in, :intersect, :union, :setdiff, :hull)
+      @eval $op(::Interval, ::DecoratedInterval) =
+        throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+
+      @eval $op(::DecoratedInterval, ::Interval) =
+        throw(ArgumentError("operations between bare and decorated intervals not allowed"))
 end
+
+fma(::Interval, ::Interval, ::DecoratedInterval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+fma(::Interval, ::DecoratedInterval, ::Interval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+fma(::DecoratedInterval, ::Interval, ::Interval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+
+fma(::Interval, ::DecoratedInterval, ::DecoratedInterval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+fma(::DecoratedInterval, ::DecoratedInterval, ::Interval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))
+fma(::DecoratedInterval, ::Interval, ::DecoratedInterval) =
+    throw(ArgumentError("operations between bare and decorated intervals not allowed"))

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -362,3 +362,10 @@ for (f, domain) in restricted_functions2
         DecoratedInterval(r, trv)
     end
 end
+
+## comparisons
+
+for op in (:(==), :<=, :>=, :<, :>)
+      @eval Base.$op(a::Interval, b::DecoratedInterval) = $op(a, b.interval)
+      @eval Base.$op(a::DecoratedInterval, b::Interval) = $op(a.interval, b)
+end

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -41,13 +41,13 @@ let b
     @test @decorated(-3,-2) ^ -3 == DecoratedInterval(-1/8.,-1/27)
     @test @decorated(0,3) ^ 2 == DecoratedInterval(0, 9)
     @test @decorated(0,3) ^ -2 == DecoratedInterval(1/9, Inf, trv)
-    @test @decorated(2,3)^Interval(0.0, 1.0) == DecoratedInterval(1.0,3.0)
     @test @decorated(2,3)^@decorated(0.0, 1.0) == DecoratedInterval(1.0,3.0)
-    @test @decorated(0, 2)^Interval(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
+    @test @decorated(2,3)^@decorated(0.0, 1.0) == DecoratedInterval(1.0,3.0)
     @test @decorated(0, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
-    @test @decorated(-3, 2)^Interval(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
+    @test @decorated(0, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
-    @test @decorated(-3, 2)^Interval(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
+    @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
+    @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
     @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0, Inf, trv)
 end
 
@@ -63,26 +63,37 @@ end
 
 @testset "Decorated intervals comparison" begin
 
-    a = 1..3
-    b = @decorated 1 3
+    a = @decorated 1 3
 
-    c = @decorated 4 5
+    b = @decorated 4 5
 
-    @test a == b
-    @test b == a
+    @test a != b
 
-    @test a < c
-    @test c > a
-    @test a <= c
-    @test c >= a
-
-    d = @decorated 0 2
-
-    @test d < a
-    @test a > d
-    @test d <= a
-    @test a >= d
+    @test a < b
+    @test b > a
+    @test a <= b
+    @test b >= a
 
 end
 
+@testset "Mixed bare/decorated operations" begin
+
+    a = 1..2
+    b = @decorated 3 4
+    for op in (:(==), :!=, :<=, :>=, :<, :>, :≼, :≺, :⊂, :⊃, :⊇, :⊆, :⪽, :isdisjoint,
+        :+, :-, :*, :/, ://, :^, :pow, :extended_div, :atan, :min, :max, :dist,
+        :cancelminus, :cancelplus, :hypot, :copysign, :flipsign,
+        :in, :intersect, :union, :setdiff, :hull)
+
+        @eval @test_throws ArgumentError $op($a, $b)
+        @eval @test_throws ArgumentError $op($b, $a)
+    end
+
+    @test_throws ArgumentError fma(a, a, b)
+    @test_throws ArgumentError fma(a, b, a)
+    @test_throws ArgumentError fma(b, a, a)
+    @test_throws ArgumentError fma(a, b, b)
+    @test_throws ArgumentError fma(b, b, a)
+    @test_throws ArgumentError fma(b, a, b)
+end
 end

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -45,7 +45,6 @@ let b
     @test @decorated(0, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
-    @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0, Inf, trv)
 
     a = @decorated 1 2
     b = @decorated 3 4

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -42,13 +42,9 @@ let b
     @test @decorated(0,3) ^ 2 == DecoratedInterval(0, 9)
     @test @decorated(0,3) ^ -2 == DecoratedInterval(1/9, Inf, trv)
     @test @decorated(2,3)^@decorated(0.0, 1.0) == DecoratedInterval(1.0,3.0)
-    @test @decorated(2,3)^@decorated(0.0, 1.0) == DecoratedInterval(1.0,3.0)
     @test @decorated(0, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
-    @test @decorated(0, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
-    @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
-    @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0, Inf, trv)
 end
 
 @testset "Convert string to DecoratedInterval" begin

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -60,4 +60,29 @@ end
 
 end
 
+
+@testset "Decorated intervals comparison" begin
+
+    a = 1..3
+    b = @decorated 1 3
+
+    c = @decorated 4 5
+
+    @test a == b
+    @test b == a
+
+    @test a < c
+    @test c > a
+    @test a <= c
+    @test c >= a
+
+    d = @decorated 0 2
+
+    @test d < a
+    @test a > d
+    @test d <= a
+    @test a >= d
+
+end
+
 end


### PR DESCRIPTION
The standard says (section 12.12.9 boolean functions on intervals)

```
Each bare interval operation in this subclause shall have a decorated version, where each input of bare interval
type is replaced by an input having the corresponding decorated interval type. Following 11.7, if any input
is NaI, the result is false (in particular equal(NaI, NaI) is false). Otherwise the result is obtained by
discarding the decoration and applying the corresponding bare interval operation
```

so I think the comparison of bare and decorated interval should be possible and the result be based on the interval part of both?