### PR TITLE
Speed up set difference of interval boxes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.17.8"
+version = "0.18.1"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -54,7 +54,7 @@ export
     interval,
     @interval, @biginterval, @floatinterval,
     diam, radius, mid, mag, mig, hull,
-    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot, setdiff1, setdiff2,
+    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot,
     precedes, strictprecedes, ≼, ≺, ⊂, ⊃, ⊇, contains_zero,
     entireinterval, isentire, nai, isnai, isthin, iscommon, isatomic,
     widen, inf, sup, bisect, mince,

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -54,7 +54,7 @@ export
     interval,
     @interval, @biginterval, @floatinterval,
     diam, radius, mid, mag, mig, hull,
-    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot, setdiff2,
+    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot, setdiff1, setdiff2,
     precedes, strictprecedes, ≼, ≺, ⊂, ⊃, ⊇, contains_zero,
     entireinterval, isentire, nai, isnai, isthin, iscommon, isatomic,
     widen, inf, sup, bisect, mince,

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -54,7 +54,7 @@ export
     interval,
     @interval, @biginterval, @floatinterval,
     diam, radius, mid, mag, mig, hull,
-    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot,
+    emptyinterval, ∅, ∞, isempty, isinterior, ⪽, nthroot, setdiff2,
     precedes, strictprecedes, ≼, ≺, ⊂, ⊃, ⊇, contains_zero,
     entireinterval, isentire, nai, isnai, isthin, iscommon, isatomic,
     widen, inf, sup, bisect, mince,

--- a/src/multidim/setdiff.jl
+++ b/src/multidim/setdiff.jl
@@ -1,23 +1,23 @@
 """
-Returns a list of pairs (interval, label)
-label is 1 if the interval is *excluded* from the setdiff
-label is 0 if the interval is included in the setdiff
-label is -1 if the intersection of the two intervals was empty
+    _setdiff(x::Interval{T}, y::Interval{T})
+
+Computes the set difference x\\y and always returns a tuple of two intervals.
+If the set difference is only one interval or is empty, then the returned tuple contains 1
+or 2 empty intervals.
 """
-function labelled_setdiff(x::Interval{T}, y::Interval{T}) where T
+function _setdiff(x::Interval{T}, y::Interval{T}) where T
     intersection = x ∩ y
 
-    isempty(intersection) && return [(x, -1)]
-    intersection == x && return [(x, 1)]
+    isempty(intersection) && return (x, emptyinterval(T))
+    intersection == x && return (emptyinterval(T), emptyinterval(T))  # x is subset of y; setdiff is empty
 
-    x.lo == intersection.lo && return [(intersection, 1), (Interval(intersection.hi, x.hi), 0)]
-    x.hi == intersection.hi && return [(intersection, 1), (Interval(x.lo, intersection.lo), 0)]
+    x.lo == intersection.lo && return (Interval(intersection.hi, x.hi), emptyinterval(T))
+    x.hi == intersection.hi && return (Interval(x.lo, intersection.lo), emptyinterval(T))
 
-    return [(y, 1),
-            (Interval(x.lo, y.lo), 0),
-            (Interval(y.hi, x.hi), 0)]
+    return (Interval(x.lo, y.lo), Interval(y.hi, x.hi))
 
 end
+
 
 """
     setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T})
@@ -28,53 +28,6 @@ i.e. the set of `x` that are in `A` but not in `B`.
 Algorithm: Start from the total overlap (in all directions);
 expand each direction in turn.
 """
-function setdiff1(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
-    X = [labelled_setdiff(a, b) for (a, b) in zip(A.v, B.v)]
-    # ordered such that the first in each is the excluded interval
-
-    first = [ i[1] for i in X ]
-    labels = [i[2] for i in first]
-
-    any(labels .== -1) && return [A]  # no overlap
-
-    # @assert all(labels .== 1)
-
-    excluded = [i[1] for i in first]
-
-    result_list = IntervalBox{N,T}[]
-
-    for dimension in N:-1:1
-        for which in X[dimension][2:end]
-            excluded[dimension] = which[1]
-            push!(result_list,
-                IntervalBox(excluded[1:dimension]..., A[dimension+1:N]...))
-        end
-    end
-
-    result_list
-
-end
-
-function setdiff2(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
-
-    intersection = A ∩ B
-    isempty(intersection) && return [A]
-
-    result_list = fill(IntervalBox(emptyinterval(T), N), 2*N)
-    offset = 0
-    x = Array(A.v)
-    @inbounds for i = 1:N
-        tmp = setdiff(A[i], B[i])
-        @inbounds for j = 1:length(tmp)
-            x[i] = tmp[j]
-            result_list[offset+j] = IntervalBox{N, T}(x)
-        end
-        offset += length(tmp)
-        x[i] = intersection[i]
-    end
-    filter!(!isempty, result_list)
-end
-
 function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
 
     intersection = A ∩ B
@@ -93,17 +46,4 @@ function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
         x[i] = intersection[i]
     end
     filter!(!isempty, result_list)
-end
-
-function _setdiff(x::Interval{T}, y::Interval{T}) where T
-    intersection = x ∩ y
-
-    isempty(intersection) && return (x, emptyinterval(T))
-    intersection == x && return (emptyinterval(T), emptyinterval(T))  # x is subset of y; setdiff is empty
-
-    x.lo == intersection.lo && return (Interval(intersection.hi, x.hi), emptyinterval(T))
-    x.hi == intersection.hi && return (Interval(x.lo, intersection.lo), emptyinterval(T))
-
-    return (Interval(x.lo, y.lo), Interval(y.hi, x.hi))
-
 end

--- a/src/multidim/setdiff.jl
+++ b/src/multidim/setdiff.jl
@@ -35,15 +35,15 @@ function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
 
     result_list = fill(IntervalBox(emptyinterval(T), N), 2*N)
     offset = 0
-    x = Array(A.v)
+    x = A.v
     @inbounds for i = 1:N
         tmp = _setdiff(A[i], B[i])
         @inbounds for j = 1:2
-            x[i] = tmp[j]
+            x = setindex(x, tmp[j], i)
             result_list[offset+j] = IntervalBox{N, T}(x)
         end
         offset += 2
-        x[i] = intersection[i]
+        x = setindex(x, intersection[i], i)
     end
     filter!(!isempty, result_list)
 end

--- a/src/multidim/setdiff.jl
+++ b/src/multidim/setdiff.jl
@@ -28,7 +28,7 @@ i.e. the set of `x` that are in `A` but not in `B`.
 Algorithm: Start from the total overlap (in all directions);
 expand each direction in turn.
 """
-function setdiff2(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
+function setdiff1(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
     X = [labelled_setdiff(a, b) for (a, b) in zip(A.v, B.v)]
     # ordered such that the first in each is the excluded interval
 
@@ -55,7 +55,7 @@ function setdiff2(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
 
 end
 
-function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
+function setdiff2(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
 
     intersection = A ∩ B
     isempty(intersection) && return [A]
@@ -73,4 +73,37 @@ function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
         x[i] = intersection[i]
     end
     filter!(!isempty, result_list)
+end
+
+function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
+
+    intersection = A ∩ B
+    isempty(intersection) && return [A]
+
+    result_list = fill(IntervalBox(emptyinterval(T), N), 2*N)
+    offset = 0
+    x = Array(A.v)
+    @inbounds for i = 1:N
+        tmp = _setdiff(A[i], B[i])
+        @inbounds for j = 1:2
+            x[i] = tmp[j]
+            result_list[offset+j] = IntervalBox{N, T}(x)
+        end
+        offset += 2
+        x[i] = intersection[i]
+    end
+    filter!(!isempty, result_list)
+end
+
+function _setdiff(x::Interval{T}, y::Interval{T}) where T
+    intersection = x ∩ y
+
+    isempty(intersection) && return (x, emptyinterval(T))
+    intersection == x && return (emptyinterval(T), emptyinterval(T))  # x is subset of y; setdiff is empty
+
+    x.lo == intersection.lo && return (Interval(intersection.hi, x.hi), emptyinterval(T))
+    x.hi == intersection.hi && return (Interval(x.lo, intersection.lo), emptyinterval(T))
+
+    return (Interval(x.lo, y.lo), Interval(y.hi, x.hi))
+
 end

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -158,6 +158,12 @@ end
                               IntervalBox(3..4, 3..6, 7..10) ])
 
 
+    X = IntervalBox(-Inf..Inf, 1..2)
+    Y = IntervalBox(1..2, -1..1.5)
+
+    @test Set(setdiff(X, Y)) == Set([IntervalBox(-Inf..1, 1..2),
+                              IntervalBox(2..Inf, 1..2),
+                              IntervalBox(1..2, 1.5..2)])
 end
 
 @testset "mid, diam, × for IntervalBox" begin

--- a/test/multidim_tests/multidim.jl
+++ b/test/multidim_tests/multidim.jl
@@ -108,34 +108,34 @@ end
 @testset "setdiff for IntervalBox" begin
     X = IntervalBox(2..4, 3..5)
     Y = IntervalBox(3..5, 4..6)
-    @test setdiff(X, Y) == [ IntervalBox(3..4, 3..4),
-                              IntervalBox(2..3, 3..5) ]
+    @test Set(setdiff(X, Y)) == Set([ IntervalBox(3..4, 3..4),
+                              IntervalBox(2..3, 3..5) ])
 
-    @test setdiff(X.v, Y) == [ IntervalBox(3..4, 3..4),
-                              IntervalBox(2..3, 3..5) ]
+    @test Set(setdiff(X.v, Y)) == Set([ IntervalBox(3..4, 3..4),
+                              IntervalBox(2..3, 3..5) ])
 
-    @test setdiff(X, Y.v) == [ IntervalBox(3..4, 3..4),
-                              IntervalBox(2..3, 3..5) ]
+    @test Set(setdiff(X, Y.v)) == Set([ IntervalBox(3..4, 3..4),
+                              IntervalBox(2..3, 3..5) ])
 
     X = IntervalBox(2..5, 3..6)
     Y = IntervalBox(-10..10, 4..5)
-    @test setdiff(X, Y) == [ IntervalBox(2..5, 3..4),
-                              IntervalBox(2..5, 5..6) ]
+    @test Set(setdiff(X, Y)) == Set([ IntervalBox(2..5, 3..4),
+                              IntervalBox(2..5, 5..6) ])
 
 
     X = IntervalBox(2..5, 3..6)
     Y = IntervalBox(4..6, 4..5)
-    @test setdiff(X, Y) == [ IntervalBox(4..5, 3..4),
+    @test Set(setdiff(X, Y)) == Set([ IntervalBox(4..5, 3..4),
                               IntervalBox(4..5, 5..6),
-                              IntervalBox(2..4, 3..6) ]
+                              IntervalBox(2..4, 3..6) ])
 
 
     X = IntervalBox(2..5, 3..6)
     Y = IntervalBox(3..4, 4..5)
-    @test setdiff(X, Y) == [ IntervalBox(3..4, 3..4),
+    @test Set(setdiff(X, Y)) == Set([ IntervalBox(3..4, 3..4),
                               IntervalBox(3..4, 5..6),
                               IntervalBox(2..3, 3..6),
-                              IntervalBox(4..5, 3..6) ]
+                              IntervalBox(4..5, 3..6) ])
 
 
     X = IntervalBox(2..5, 3..6)
@@ -150,12 +150,12 @@ end
 
     X = IntervalBox(1..4, 3..6, 7..10)
     Y = IntervalBox(2..3, 4..5, 8..9)
-    @test setdiff(X, Y) == [ IntervalBox(2..3, 4..5, 7..8),
+    @test Set(setdiff(X, Y)) == Set([ IntervalBox(2..3, 4..5, 7..8),
                               IntervalBox(2..3, 4..5, 9..10),
                               IntervalBox(2..3, 3..4, 7..10),
                               IntervalBox(2..3, 5..6, 7..10),
                               IntervalBox(1..2, 3..6, 7..10),
-                              IntervalBox(3..4, 3..6, 7..10) ]
+                              IntervalBox(3..4, 3..6, 7..10) ])
 
 
 end


### PR DESCRIPTION
For start this new version is faster and allocates less. In the following benchmark, setdiff2 is the original one and setdiff the new one. In this commit I kept setdiff2 so that people can compare the two methods locally if they wish. I'll remove it once this is ready.

```jl
julia> X = IntervalBox(0..2, 3..4, 5..6)
[0, 2] × [3, 4] × [5, 6]

julia> Y = IntervalBox(0.5..0.6, 3.5..3.6, 5.5..5.6)
[0.5, 0.600001] × [3.5, 3.60001] × [5.5, 5.60001]

julia> @btime setdiff($X, $Y)
  234.033 ns (11 allocations: 1.00 KiB)
6-element Vector{IntervalBox{3, Float64}}:
 [0, 0.5] × [3, 4] × [5, 6]
 [0.6, 2] × [3, 4] × [5, 6]
 [0.5, 0.600001] × [3, 3.5] × [5, 6]
 [0.5, 0.600001] × [3.6, 4] × [5, 6]
 [0.5, 0.600001] × [3.5, 3.60001] × [5, 5.5]
 [0.5, 0.600001] × [3.5, 3.60001] × [5.6, 6]

julia> @btime setdiff2($X, $Y)
  4.586 μs (62 allocations: 5.02 KiB)
6-element Vector{IntervalBox{3, Float64}}:
 [0.5, 0.600001] × [3.5, 3.60001] × [5, 5.5]
 [0.5, 0.600001] × [3.5, 3.60001] × [5.6, 6]
 [0.5, 0.600001] × [3, 3.5] × [5, 6]
 [0.5, 0.600001] × [3.6, 4] × [5, 6]
 [0, 0.5] × [3, 4] × [5, 6]
 [0.6, 2] × [3, 4] × [5, 6]
 ```