### PR TITLE
fix dist for decorated intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.18.1"
+version = "0.18.2"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -47,13 +47,14 @@ in(x::T, a::DecoratedInterval) where T<:Real = in(x, interval(a))
 
 ## scalar functions: mig, mag and friends
 scalar_functions = (
-    :mig, :mag, :inf, :sup, :mid, :diam, :radius, :dist, :eps, :midpoint_radius
+    :mig, :mag, :inf, :sup, :mid, :diam, :radius, :eps, :midpoint_radius
 )
 
 for f in scalar_functions
     @eval $(f)(xx::DecoratedInterval{T}) where T = $f(interval(xx))
 end
 
+dist(xx::DecoratedInterval, yy::DecoratedInterval) = dist(interval(xx), interval(yy))
 
 ## Arithmetic function; / is treated separately
 arithm_functions = ( :+, :-, :* )

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -49,6 +49,11 @@ let b
     @test @decorated(-3, 2)^@decorated(0.0, 1.0) == DecoratedInterval(0.0,2.0, trv)
     @test @decorated(-3, 2)^Interval(-1.0, 1.0) == DecoratedInterval(0.0,Inf, trv)
     @test @decorated(-3, 2)^@decorated(-1.0, 1.0) == DecoratedInterval(0.0, Inf, trv)
+
+    a = @decorated 1 2
+    b = @decorated 3 4
+
+    @test dist(a, b) == 2.0
 end
 
 @testset "Convert string to DecoratedInterval" begin


### PR DESCRIPTION
`dist` for decorated intervals was accidentally defined as unary function [here](https://github.com/JuliaIntervals/IntervalArithmetic.jl/blob/master/src/decorations/functions.jl#L49-L55)

before:
```
julia> a = @decorated 1 2
[1, 2]_com

julia> b = @decorated 3 4
[3, 4]_com

julia> dist(a, b)
ERROR: MethodError: no method matching dist(::DecoratedInterval{Float64}, ::DecoratedInterval{Float64})
Stacktrace:
 [1] top-level scope
   @ REPL[13]:1
```

after:
```
julia> dist(a, b)
2.0
```