### PR TITLE
fix `..` for irrational inputs

### DIFF
--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -151,12 +151,12 @@ end
 
 function ..(a::Irrational{T}, b::S) where {T, S}
     R = promote_type(Irrational{T}, S)
-    return Interval(R(a, RoundDown), atomic(Interval{R}, b).hi)
+    return interval(R(a, RoundDown), atomic(Interval{R}, b).hi)
 end
 
 function ..(a::Irrational{T}, b::Irrational{S}) where {T, S}
     R = promote_type(Irrational{T}, Irrational{S})
-    return Interval(a, b)
+    return interval(a, b)
 end
 
 # ..(a::Integer, b::Integer) = interval(a, b)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -236,6 +236,10 @@ end
 
     a = big(0.1)..2
     @test typeof(a) == Interval{BigFloat}
+
+    @test_throws ArgumentError 2..1
+    @test_throws ArgumentError π..1
+    @test_throws ArgumentError π..eeuler
 end
 
 @testset "± tests" begin

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -240,6 +240,8 @@ end
     @test_throws ArgumentError 2..1
     @test_throws ArgumentError π..1
     @test_throws ArgumentError π..eeuler
+    @test_throws ArgumentError 4..π
+    @test 1..π == Interval(1, π)
 end
 
 @testset "± tests" begin


### PR DESCRIPTION
`a..b` didn't check that `a ≤ b` when `b` is irrational. This PR fixes it.

before:
```
julia> π..1
[3.14159, 1]

julia> π..ℯ
[3.14159, 2.71829]
```

after:
```
julia> π..1
ERROR: ArgumentError: `[3.141592653589793, 1.0]` is not a valid interval. Need `a ≤ b` to construct `interval(a, b)`.
Stacktrace:
 [1] interval
   @ ~\.julia\packages\IntervalArithmetic\zFxqb\src\intervals\intervals.jl:111 [inlined]
 [2] ..(a::Irrational{:π}, b::Int64)
   @ IntervalArithmetic ~\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:154
 [3] top-level scope
   @ REPL[56]:1

julia> π..ℯ
ERROR: ArgumentError: `[π, ℯ]` is not a valid interval. Need `a ≤ b` to construct `interval(a, b)`.
Stacktrace:
 [1] interval(a::Irrational{:π}, b::Irrational{:ℯ})
   @ IntervalArithmetic ~\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:111
 [2] ..(a::Irrational{:π}, b::Irrational{:ℯ})
   @ IntervalArithmetic ~\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:159
 [3] top-level scope
   @ REPL[57]:1
```