### PR TITLE
update interval-macro docstring

### DIFF
--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -105,6 +105,7 @@ end
     interval(a, b)
 
 `interval(a, b)` checks whether [a, b] is a valid `Interval`, which is the case if `-∞ <= a <= b <= ∞`, using the (non-exported) `is_valid_interval` function. If so, then an `Interval(a, b)` object is returned; if not, then an error is thrown.
+No directed rounding is performed on the extremes of the interval.
 """
 function interval(a::Real, b::Real)
     if !is_valid_interval(a, b)
@@ -140,6 +141,11 @@ include("complex.jl")
 
 # Syntax for intervals
 
+"""
+    a..b
+
+This is the main method to create an interval. If a <= b, the interval [a, b] is created using directed rounding.
+"""
 function ..(a::T, b::S) where {T, S}
     interval(atomic(Interval{T}, a).lo, atomic(Interval{S}, b).hi)
 end

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -1,19 +1,21 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
-"""The `@interval` macro converts each expression into a narrow interval that is guaranteed to contain the true value passed by the user in the one or two expressions passed to it.
+"""The `@interval` macro converts an expression into a narrow interval that is guaranteed to contain the true value of the expression.
 When passed two expressions, it takes the hull of the resulting intervals
 to give a guaranteed containing interval.
 
 Examples:
 ```
-    @interval(0.1)
-
-    @interval(0.1, 0.2)
-
-    @interval(1/3, 1/6)
-
-    @interval(1/3^2)
+    @interval sin(0.1) + cos(0.2)
 ```
+
+is equivalent to
+```
+    sin(0.1..0.1) + cos(0.2..0.2)
+```
+
+NOTE! `@interval` should be used only to create intervals from an expression, as in the example
+before. To construct an interval from single numbers, the `..` is preferred, e.g. `0.1..0.2`
 """
 macro interval(expr1)
     make_interval(:(parameters.precision_type), expr1, ())

--- a/src/intervals/macros.jl
+++ b/src/intervals/macros.jl
@@ -1,7 +1,6 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
-"""The `@interval` macro is the main method to create an interval.
-It converts each expression into a narrow interval that is guaranteed to contain the true value passed by the user in the one or two expressions passed to it.
+"""The `@interval` macro converts each expression into a narrow interval that is guaranteed to contain the true value passed by the user in the one or two expressions passed to it.
 When passed two expressions, it takes the hull of the resulting intervals
 to give a guaranteed containing interval.
 


### PR DESCRIPTION
The docstring of `@interval` is outdated as it still states that the macro is the main way to create an interval. This can sometimes be misleading as pointed out in #454 .