### PR TITLE
Lf/invalid as empty

### DIFF
--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -47,7 +47,7 @@ DecoratedInterval(I::Interval{T}, d::DECORATION) where T<:AbstractFloat =
     DecoratedInterval{T}(I, d)
 
 function DecoratedInterval(a::T, b::T, d::DECORATION) where T<:Real
-    a > b && return nai(T)
+    is_valid_interval(a, b) || return nai(T)
     DecoratedInterval(Interval(a,b), d)
 end
 
@@ -63,7 +63,7 @@ DecoratedInterval(a::T, b::S, d::DECORATION) where {T<:Real, S<:Real} =
 DecoratedInterval(I::Interval) = DecoratedInterval(I, decoration(I))
 
 function DecoratedInterval(a::T, b::T) where T<:Real
-    a > b && return nai(T)
+    is_valid_interval(a, b) || return nai(T)
     DecoratedInterval(Interval(a,b))
 end
 

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -79,11 +79,7 @@ function is_valid_interval(a::Real, b::Real)
     # println("isvalid()")
 
     if isnan(a) || isnan(b)
-        if isnan(a) && isnan(b)
-            return true
-        else
-            return false
-        end
+        return false
     end
 
     if a > b
@@ -106,9 +102,10 @@ end
 
 `interval(a, b)` checks whether [a, b] is a valid `Interval`, which is the case if `-∞ <= a <= b <= ∞`, using the (non-exported) `is_valid_interval` function. If so, then an `Interval(a, b)` object is returned; if not, then an error is thrown.
 """
-function interval(a::Real, b::Real)
+function interval(a::T, b::S) where {T<:Real, S<:Real}
     if !is_valid_interval(a, b)
-        throw(ArgumentError("`[$a, $b]` is not a valid interval. Need `a ≤ b` to construct `interval(a, b)`."))
+        @warn "Invalid input, empty interval is returned"
+        return emptyinterval(promote_type(T, S, Float64))
     end
 
     return Interval(a, b)

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -54,6 +54,15 @@ let b
     b = @decorated 3 4
 
     @test dist(a, b) == 2.0
+
+    # invalid input
+    @test isnai(@decorated(3, 1, com))
+    @test isnai(@decorated(3, 1))
+    @test isnai(@decorated(Inf, Inf))
+    @test isnai(@decorated(-Inf, -Inf))
+    @test isnai(@decorated(NaN, 3))
+    @test isnai(@decorated(3, NaN))
+    @test isnai(@decorated(NaN, NaN))
 end
 
 @testset "Convert string to DecoratedInterval" begin

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -380,10 +380,10 @@ setprecision(Interval, Float64)
         @test interval(1, 2) == Interval(1, 2)
 
         @test inf(Interval(3, 2)) == 3
-        @test_throws ArgumentError interval(3, 2)
+        @test isempty(interval(3, 2))
 
         @test sup(Interval(Inf, Inf)) == Inf
-        @test_throws ArgumentError interval(Inf, Inf)
+        @test isempty(interval(Inf, Inf))
 
     end
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -69,20 +69,20 @@ const eeuler = Base.MathConstants.e
 
     # Disallowed conversions with a > b
 
-    @test_throws ArgumentError interval(2, 1)
-    @test_throws ArgumentError interval(big(2), big(1))
-    @test_throws ArgumentError interval(BigInt(1), 1//10)
-    @test_throws ArgumentError interval(1, 0.1)
-    @test_throws ArgumentError interval(big(1), big(0.1))
+    @test isempty(interval(2, 1))
+    @test isempty(interval(big(2), big(1)))
+    @test isempty(interval(BigInt(1), 1//10))
+    @test isempty(interval(1, 0.1))
+    @test isempty(interval(big(1), big(0.1)))
 
-    @test_throws ArgumentError @interval(2, 1)
-    @test_throws ArgumentError @interval(big(2), big(1))
-    @test_throws ArgumentError @interval(big(1), 1//10)
-    @test_throws ArgumentError @interval(1, 0.1)
-    @test_throws ArgumentError @interval(big(1), big(0.1))
-    @test_throws ArgumentError interval(Inf)
-    @test_throws ArgumentError interval(-Inf, -Inf)
-    @test_throws ArgumentError interval(Inf, Inf)
+    @test isempty(@interval(2, 1))
+    @test isempty(@interval(big(2), big(1)))
+    @test isempty(@interval(big(1), 1//10))
+    @test isempty(@interval(1, 0.1))
+    @test isempty(@interval(big(1), big(0.1)))
+    @test isempty(interval(Inf))
+    @test isempty(interval(-Inf, -Inf))
+    @test isempty(interval(Inf, Inf))
 
     # Conversion to Interval without type
     @test convert(Interval, 1) == Interval(1.0)
@@ -237,10 +237,10 @@ end
     a = big(0.1)..2
     @test typeof(a) == Interval{BigFloat}
 
-    @test_throws ArgumentError 2..1
-    @test_throws ArgumentError π..1
-    @test_throws ArgumentError π..eeuler
-    @test_throws ArgumentError 4..π
+    @test isempty(2..1)
+    @test isempty(π..1)
+    @test isempty(π..eeuler)
+    @test isempty(4..π)
     @test 1..π == Interval(1, π)
 end
 
@@ -292,9 +292,10 @@ end
 end
 
 # issue 192:
-@testset "Disallow a single NaN in an interval" begin
-    @test_throws ArgumentError interval(NaN, 2)
-    @test_throws ArgumentError interval(Inf, NaN)
+@testset "Disallow NaN in an interval" begin
+    @test isempty(interval(NaN, 2))
+    @test isempty(interval(Inf, NaN))
+    @test isempty(interval(NaN, NaN))
 end
 
 # issue 206:
@@ -342,7 +343,7 @@ end
 end
 
 @testset "a..b with a > b" begin
-    @test_throws ArgumentError 3..2
+    @test isempty(3..2)
 end
 
 @testset "Hashing of Intervals" begin
@@ -374,7 +375,7 @@ import IntervalArithmetic: force_interval
     @test force_interval(4, Inf) == Interval(4, Inf)
     @test force_interval(Inf, 4) == Interval(4, Inf)
     @test force_interval(Inf, -Inf) == Interval(-Inf, Inf)
-    @test_throws ArgumentError force_interval(NaN, 3)
+    @test isempty(force_interval(NaN, 3))
 end
 
 @testset "Zero interval" begin

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -11,7 +11,7 @@ setprecision(Interval, Float64)
     y = 4..5
     a = 3
     b = 12
-    
+
     @test sqrt(sum(x.^2 .+ y.^2)) == 5..13
 
     for i in 1:20
@@ -24,7 +24,7 @@ setprecision(Interval, Float64)
     end
 
     a = 4
-    b = 5 
+    b = 5
     for i in 1:20
         @test y.+i == (a+i)..(b+i)
     end
@@ -115,7 +115,7 @@ end
     @test Interval(1,2) ^ -3 == Interval(1/8, 1.0)
     @test Interval(0,3) ^ -3 == @interval(1/27, Inf)
     @test Interval(-1,2) ^ -3 == entireinterval()
-    @test_throws ArgumentError interval(-1, -2) ^ -3  # wrong way round
+    @test isempty(interval(-1, -2) ^ -3)  # wrong way round
     @test Interval(-3,2) ^ (3//1) == Interval(-27, 8)
     @test Interval(0.0) ^ 1.1 == Interval(0, 0)
     @test Interval(0.0) ^ 0.0 == emptyinterval()
@@ -432,4 +432,4 @@ end
     @test nthroot(Interval{BigFloat}(-27, 27), -3) == Interval{BigFloat}(-Inf, Inf)
     @test nthroot(Interval{BigFloat}(-81, -16), -4) == ∅
     @test nthroot(Interval{BigFloat}(-81, -16), 1) == Interval{BigFloat}(-81, -16)
-end 
+end


### PR DESCRIPTION
It seems that the standard requires invalid inputs to return an empty interval (see discussion in #457 ), this is also the octave behavior. 

Now the package returns an empty interval but also prints a warning (like octave does), a few examples

````
julia> 3..1
┌ Warning: Invalid input, empty interval is returned
└ @ IntervalArithmetic C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:107
∅

julia> interval(Inf, Inf)
┌ Warning: Invalid input, empty interval is returned
└ @ IntervalArithmetic C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:107
∅

julia> interval(NaN, π)
┌ Warning: Invalid input, empty interval is returned
└ @ IntervalArithmetic C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\intervals\intervals.jl:107
∅

julia> @decorated 3 1
[NaN, NaN]_ill

julia> @decorated NaN 3
[NaN, NaN]_ill

julia> @decorated Inf Inf
[NaN, NaN]_ill

julia> @decorated Inf -Inf
∅_trv
```