### PR TITLE
fix decorated intervals constructors issues

### DIFF
--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -11,7 +11,7 @@ one(::Type{DecoratedInterval{T}}) where T<:Real = DecoratedInterval(one(T))
 
 # NaI: not-an-interval
 """`NaI` not-an-interval: [NaN, NaN]."""
-nai(::Type{<:Int}) = nai(Float64)
+                            nai(::Type{<:Integer}) = nai(Float64)
 nai(::Type{Rational}) = nai(Rational{Int})
 nai(::Type{Rational{T}}) where {T<:Real} = DecoratedInterval{Rational{T}}(Interval{Rational{T}}(1//0, -1//0), ill)
 nai(::Type{T}) where T<:Real = DecoratedInterval{T}(Interval{T}(convert(T, NaN), convert(T, NaN)), ill)
@@ -35,7 +35,10 @@ bool_binary_functions = (
 )
 
 for f in bool_functions
-    @eval $(f)(xx::DecoratedInterval) = $(f)(interval(xx))
+    @eval function $(f)(xx::DecoratedInterval)
+        isnai(xx) && return false
+        return $(f)(interval(xx))
+    end
 end
 
 for f in bool_binary_functions

--- a/src/display.jl
+++ b/src/display.jl
@@ -311,7 +311,7 @@ function representation(a::DecoratedInterval{T}, format=nothing) where T
         return "DecoratedInterval($(representation(interval(a), format)), $(decoration(a)))"
     end
 
-    var_interval = representation(interval(a), format)
+    var_interval = isnai(a) ? "[NaI]" : representation(interval(a), format)
 
     if display_params.decorations
         string(var_interval, "_", decoration(a))

--- a/test/ITF1788_tests/ITF1788_tests.jl
+++ b/test/ITF1788_tests/ITF1788_tests.jl
@@ -1,6 +1,8 @@
 include("ieee1788-constructors.jl")
+include("ieee1788-exceptions.jl")
 include("libieeep1788_tests_bool.jl")
 include("libieeep1788_tests_cancel.jl")
+include("libieeep1788_class.jl")
 include("libieeep1788_tests_elem.jl")
 include("libieeep1788_tests_mul_rev.jl")
 include("libieeep1788_tests_num.jl")

--- a/test/ITF1788_tests/ieee1788-exceptions.jl
+++ b/test/ITF1788_tests/ieee1788-exceptions.jl
@@ -1,0 +1,8 @@
+@testset "exceptions" begin
+
+    @test_logs (:warn, ) @test interval(+Inf,-Inf) == emptyinterval()
+
+    @test_logs (:warn, ) @test interval(nai()) == emptyinterval()
+
+end
+

--- a/test/ITF1788_tests/libieeep1788_class.jl
+++ b/test/ITF1788_tests/libieeep1788_class.jl
@@ -1,0 +1,167 @@
+@testset "minimal_nums_to_interval_test" begin
+
+    @test interval(-1.0,1.0) == Interval(-1.0,1.0)
+
+    @test interval(-Inf,1.0) == Interval(-Inf,1.0)
+
+    @test interval(-1.0,Inf) == Interval(-1.0,Inf)
+
+    @test interval(-Inf,Inf) == Interval(-Inf,Inf)
+
+    @test_logs (:warn, ) @test interval(NaN,NaN) == emptyinterval()
+
+    @test_logs (:warn, ) @test interval(1.0,-1.0) == emptyinterval()
+
+    @test_logs (:warn, ) @test interval(-Inf,-Inf) == emptyinterval()
+
+    @test_logs (:warn, ) @test interval(Inf,Inf) == emptyinterval()
+
+end
+
+@testset "minimal_nums_to_decorated_interval_test" begin
+
+    @test DecoratedInterval(-1.0,1.0) == DecoratedInterval(Interval(-1.0,1.0), com) && decoration(DecoratedInterval(-1.0,1.0)) == decoration(DecoratedInterval(Interval(-1.0,1.0), com))
+
+    @test DecoratedInterval(-Inf,1.0) == DecoratedInterval(Interval(-Inf,1.0), dac) && decoration(DecoratedInterval(-Inf,1.0)) == decoration(DecoratedInterval(Interval(-Inf,1.0), dac))
+
+    @test DecoratedInterval(-1.0,Inf) == DecoratedInterval(Interval(-1.0,Inf), dac) && decoration(DecoratedInterval(-1.0,Inf)) == decoration(DecoratedInterval(Interval(-1.0,Inf), dac))
+
+    @test DecoratedInterval(-Inf,Inf) == DecoratedInterval(Interval(-Inf,Inf), dac) && decoration(DecoratedInterval(-Inf,Inf)) == decoration(DecoratedInterval(Interval(-Inf,Inf), dac))
+
+    @test isnai(DecoratedInterval(NaN,NaN))
+    
+    @test isnai(DecoratedInterval(1.0,-1.0))
+
+    @test isnai(DecoratedInterval(-Inf,-Inf))
+
+    @test isnai(DecoratedInterval(Inf,Inf))
+
+end
+
+
+@testset "minimal_interval_part_test" begin
+
+    @test interval(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), trv)) == Interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4)
+
+    @test interval(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)) == Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4)
+
+    @test interval(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), dac)) == Interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4)
+
+    @test interval(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), def)) == Interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4)
+
+    @test interval(DecoratedInterval(interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), trv)) == Interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022)
+
+    @test interval(DecoratedInterval(interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), trv)) == Interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022)
+
+    @test interval(DecoratedInterval(interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), trv)) == Interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022)
+
+    @test interval(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), trv)) == Interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023)
+
+    @test interval(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv)) == Interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023)
+
+    @test interval(DecoratedInterval(interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv)) == Interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023)
+
+    @test interval(DecoratedInterval(interval(-Inf,Inf), trv)) == Interval(-Inf,Inf)
+
+    @test interval(DecoratedInterval(emptyinterval(), trv)) == emptyinterval()
+
+    @test interval(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)) == Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4)
+
+    @test_logs (:warn, ) @test interval(nai()) == emptyinterval()
+
+end
+
+@testset "minimal_new_dec_test" begin
+
+    @test DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4)) == DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), com) && decoration(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4))) == decoration(DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), com))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4)) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4))) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com))
+
+    @test DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4)) == DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), com) && decoration(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4))) == decoration(DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), com))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4)) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), com) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4))) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), com))
+
+    @test DecoratedInterval(interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022)) == DecoratedInterval(Interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), com) && decoration(DecoratedInterval(interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022))) == decoration(DecoratedInterval(Interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), com))
+
+    @test DecoratedInterval(interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022)) == DecoratedInterval(Interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), com) && decoration(DecoratedInterval(interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022))) == decoration(DecoratedInterval(Interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), com))
+
+    @test DecoratedInterval(interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022)) == DecoratedInterval(Interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), com) && decoration(DecoratedInterval(interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022))) == decoration(DecoratedInterval(Interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), com))
+
+    @test DecoratedInterval(interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023)) == DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com) && decoration(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023))) == decoration(DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com))
+
+    @test DecoratedInterval(interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023)) == DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), com) && decoration(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023))) == decoration(DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), com))
+
+    @test DecoratedInterval(interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023)) == DecoratedInterval(Interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), com) && decoration(DecoratedInterval(interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023))) == decoration(DecoratedInterval(Interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), com))
+
+    @test DecoratedInterval(interval(-Inf,Inf)) == DecoratedInterval(Interval(-Inf,Inf), dac) && decoration(DecoratedInterval(interval(-Inf,Inf))) == decoration(DecoratedInterval(Interval(-Inf,Inf), dac))
+
+    @test DecoratedInterval(emptyinterval()) == DecoratedInterval(emptyinterval(), trv) && decoration(DecoratedInterval(emptyinterval())) == decoration(DecoratedInterval(emptyinterval(), trv))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4)) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4))) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com))
+
+end
+
+@testset "minimal_set_dec_test" begin
+
+    @test DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), trv) == DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), trv) && decoration(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), trv)) == decoration(DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.9999999999999P-4), trv))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com))
+
+    @test DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), dac) == DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), dac) && decoration(DecoratedInterval(interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), dac)) == decoration(DecoratedInterval(Interval(-0x1.99999A842549Ap+4,0x1.99999A0000000p-4), dac))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), def) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), def) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), def)) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.99999A0000000p-4), def))
+
+    @test DecoratedInterval(interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), trv) == DecoratedInterval(Interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), trv) && decoration(DecoratedInterval(interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), trv)) == decoration(DecoratedInterval(Interval(-0x0.0000000000001p-1022,-0x0.0000000000001p-1022), trv))
+
+    @test DecoratedInterval(interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), def) == DecoratedInterval(Interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), def) && decoration(DecoratedInterval(interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), def)) == decoration(DecoratedInterval(Interval(-0x0.0000000000001p-1022,0x0.0000000000001p-1022), def))
+
+    @test DecoratedInterval(interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), dac) == DecoratedInterval(Interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), dac) && decoration(DecoratedInterval(interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), dac)) == decoration(DecoratedInterval(Interval(0x0.0000000000001p-1022,0x0.0000000000001p-1022), dac))
+
+    @test DecoratedInterval(interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com) == DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com) && decoration(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com)) == decoration(DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,-0x1.fffffffffffffp+1023), com))
+
+    @test DecoratedInterval(interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), def) == DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), def) && decoration(DecoratedInterval(interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), def)) == decoration(DecoratedInterval(Interval(-0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), def))
+
+    @test DecoratedInterval(interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv) == DecoratedInterval(Interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv) && decoration(DecoratedInterval(interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv)) == decoration(DecoratedInterval(Interval(0x1.fffffffffffffp+1023,0x1.fffffffffffffp+1023), trv))
+
+    @test DecoratedInterval(interval(-Inf,Inf), dac) == DecoratedInterval(Interval(-Inf,Inf), dac) && decoration(DecoratedInterval(interval(-Inf,Inf), dac)) == decoration(DecoratedInterval(Interval(-Inf,Inf), dac))
+
+    @test DecoratedInterval(emptyinterval(), trv) == DecoratedInterval(emptyinterval(), trv) && decoration(DecoratedInterval(emptyinterval(), trv)) == decoration(DecoratedInterval(emptyinterval(), trv))
+
+    @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) == DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) && decoration(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)) == decoration(DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com))
+
+    @test DecoratedInterval(emptyinterval(), def) == DecoratedInterval(emptyinterval(), trv) && decoration(DecoratedInterval(emptyinterval(), def)) == decoration(DecoratedInterval(emptyinterval(), trv))
+
+    @test DecoratedInterval(emptyinterval(), dac) == DecoratedInterval(emptyinterval(), trv) && decoration(DecoratedInterval(emptyinterval(), dac)) == decoration(DecoratedInterval(emptyinterval(), trv))
+
+    @test DecoratedInterval(emptyinterval(), com) == DecoratedInterval(emptyinterval(), trv) && decoration(DecoratedInterval(emptyinterval(), com)) == decoration(DecoratedInterval(emptyinterval(), trv))
+
+    @test DecoratedInterval(interval(1.0,Inf), com) == DecoratedInterval(Interval(1.0,Inf), dac) && decoration(DecoratedInterval(interval(1.0,Inf), com)) == decoration(DecoratedInterval(Interval(1.0,Inf), dac))
+
+    @test DecoratedInterval(interval(-Inf,3.0), com) == DecoratedInterval(Interval(-Inf,3.0), dac) && decoration(DecoratedInterval(interval(-Inf,3.0), com)) == decoration(DecoratedInterval(Interval(-Inf,3.0), dac))
+
+    @test DecoratedInterval(interval(-Inf,Inf), com) == DecoratedInterval(Interval(-Inf,Inf), dac) && decoration(DecoratedInterval(interval(-Inf,Inf), com)) == decoration(DecoratedInterval(Interval(-Inf,Inf), dac))
+
+    @test isnai(DecoratedInterval(emptyinterval(), ill))
+
+    @test isnai(DecoratedInterval(interval(-Inf,3.0), ill))
+
+    @test isnai(DecoratedInterval(interval(-1.0,3.0), ill))
+
+end
+
+@testset "minimal_decoration_part_test" begin
+
+    @test decoration(nai()) == ill
+
+    @test decoration(DecoratedInterval(emptyinterval(), trv)) == trv
+
+    @test decoration(DecoratedInterval(interval(-1.0,3.0), trv)) == trv
+
+    @test decoration(DecoratedInterval(interval(-1.0,3.0), def)) == def
+
+    @test decoration(DecoratedInterval(interval(-1.0,3.0), dac)) == dac
+
+    @test decoration(DecoratedInterval(interval(-1.0,3.0), com)) == com
+
+end
+

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -74,4 +74,14 @@ end
 
 end
 
+@testset "decorated rational intervals" begin
+    @test isnai(nai(Rational))
+    @test isnai(nai(Rational{BigInt}))
+    
+    @test DecoratedInterval(1//2, 3//4) == DecoratedInterval{Rational{Int}}(1//2..3//4, com)
+
+    @test DecoratedInterval(1//2, 1//0) == DecoratedInterval{Rational{Int}}(1//2..1//0, dac)
+    @test DecoratedInterval(1//2, 1//0, com) == DecoratedInterval{Rational{Int}}(1//2..1//0, dac)
+end
+
 end

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -175,7 +175,7 @@ setprecision(Interval, Float64)
 
         @test nai(a) === nai(a)
         @test nai(Float64) === DecoratedInterval(NaN)
-        @test isnan(interval(nai(BigFloat)).lo)
+        @test_logs (:warn, ) @test isempty(interval(nai(BigFloat)))
         @test isnai(nai())
         @test !(isnai(a))
 
@@ -185,7 +185,6 @@ setprecision(Interval, Float64)
         @test sup(emptyinterval(a)) == -Inf
         @test inf(entireinterval(a)) == -Inf
         @test sup(entireinterval(a)) == Inf
-        @test isnan(sup(nai(BigFloat)))
     end
 
     @testset "mid" begin
@@ -271,11 +270,6 @@ setprecision(Interval, Float64)
         @test isnan(mid(emptyinterval()))
         @test mid(entireinterval()) == 0.0
         @test isnan(mid(nai()))
-        if VERSION < v"0.7.0-DEV"
-            @test_throws ArgumentError nai(Interval(1//2))
-        else
-            @test_throws InexactError nai(Interval(1//2))
-        end
     end
 
     @testset "abs, min, max, sign" begin


### PR DESCRIPTION
## Changes

- fixed issues with decorated intervals constructors (see examples below)
- `interval(nai())` now returns an empty interval instead of `[NaN, NaN]`, it also prints a warning, this is mentioned in the standard
- changed printing of `nai()` from `[NaN, NaN]_ill` to `[NaI]_ill` (happy to switch it back if you prefer the former
- nai(Rational) wasn't supported before (see #462 ), now it returns `[1//0, -1//0]_ill`, which also motivates the change in printing above

## Examples
- before
```
julia> DecoratedInterval(Inf)
[∞, ∞]_dac

julia> DecoratedInterval(1, Inf, com)
[1, ∞]_com

julia> DecoratedInterval(1//2, 3//4)
ERROR: MethodError: no method matching atomic(::Type{Interval{Interval{Rational{Int64}}}}, ::Interval{Interval{Rational{Int64}}})
Closest candidates are:
  atomic(::Type{Interval{T}}, ::Interval) where T<:AbstractFloat at C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\intervals\conversion.jl:122
  atomic(::Type{Interval{T}}, ::S) where {T<:AbstractFloat, S<:Real} at C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\intervals\conversion.jl:79

julia> nai(Rational)
ERROR: InexactError: Int64(NaN)

julia> interval(nai())
[NaN, NaN]

julia> DecoratedInterval(1, 2, ill)
ERROR: ArgumentError: cannot parse "[NaN, NaN]_ill" as BigFloat

julia> DecoratedInterval(3, 1, ill)
ERROR: InexactError: Int64(NaN)
```

- after
```
julia> DecoratedInterval(Inf)
[NaI]_ill

julia> DecoratedInterval(1, Inf, com)
[1, ∞]_dac

julia> DecoratedInterval(1//2, 3//4)
[1//2, 3//4]_com

julia> nai(Rational)
[NaI]_ill

julia> interval(nai())
┌ Warning: trying to access interval part of NaI, empty interval is returned
└ @ IntervalArithmetic C:\Users\lucaa\.julia\dev\IntervalArithmetic\src\decorations\intervals.jl:89
∅

julia> DecoratedInterval(1, 2, ill)
[NaI]_ill

julia> DecoratedInterval(3, 1, ill)
[NaI]_ill
```

## Fixed issues
- fixes #170 
- fixes #462 

## Open problems
- [x] functions that are supposed to return `NaN` still don't work with rational intervals, because I don't think there's a rational equivalent of `NaN` (see #462 ), e.g. `inf(nai(Rational))` fails. **edit** to be addressed in a separated PR
- [ ] While the original ITF tests also test that a warning is thrown when a decorated interval is constructed from an invalid input, I removed the warnings because I think the `NaI` itself is flagging something went wrong. I understand printing the warning for bare intervals, to distinguish between empty interval itself and empty interval because of exceptional behavior, but I think for decorated intervals NaI itself conveys this information. I think also the standard says something like this, but I need to double check, what do you think?

## Question
- why is `decorations` set to `false` by default in the display parameters? I think if someone wants to work with decorated intervals, it is more likely they want to see the decoration?