### PR TITLE
overload isapprox for intervals

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -20,7 +20,7 @@ export ×, dot
 
 import Base:
     +, -, *, /, //, fma,
-    <, >, ==, !=, ⊆, ^, <=,
+    <, >, ==, !=, ⊆, ^, <=, isapprox,
     in, zero, one, eps, typemin, typemax, abs, abs2, real, min, max,
     sqrt, exp, log, sin, cos, tan, cot, inv, cbrt, csc, hypot, sec,
     exp2, exp10, log2, log10,

--- a/src/intervals/arithmetic.jl
+++ b/src/intervals/arithmetic.jl
@@ -50,6 +50,7 @@ function strictprecedes(a::Interval, b::Interval)
 end
 const ≺ = strictprecedes # \prec
 
+isapprox(a::Interval, b::Interval; kwargs...) = isapprox(a.lo, b.lo; kwargs...) && isapprox(a.hi, b.hi; kwargs...)
 
 # zero, one, typemin, typemax
 zero(a::Interval{T}) where T<:Real = Interval(zero(T))

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -200,6 +200,10 @@ end
 
     # real
     @test real(@interval(-1, 1)) == Interval(-1, 1)
+
+    a = 0.3..0.7
+    b = a + 1e-10
+    @test a ≈ b
 end
 
 @testset "Rational tests" begin


### PR DESCRIPTION
##
`isapprox` wasn't overloaded for intervals and was using the fallback `isapprox(a::Number, b::Number)`. This PR defines the method `isapprox(a::Interval, b::Interval)`

## before
```julia
julia> a = 0.3..0.7
[0.299999, 0.700001]

julia> b = a + 1e-10
[0.3, 0.700001]

julia> a ≈ b
false
```

## after
```julia
julia> a = 0.3..0.7
[0.299999, 0.700001]

julia> b = a + 1e-10
[0.3, 0.700001]

julia> a ≈ b
true
```

## Related issues:
fixes #479 

