### PR TITLE
Dispatch for exponentiation on Float32 intervals

### DIFF
--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -6,10 +6,10 @@
 # Use the BigFloat version from MPFR instead, which is correctly-rounded:
 
 # Write explicitly like this to avoid ambiguity warnings:
-for T in (:Integer, :Float64, :Float32, :BigFloat, :Interval)
+for T in (:Integer, :Float64, :BigFloat, :Interval)
     @eval ^(a::Interval{Float64}, x::$T) = atomic(Interval{Float64}, bigequiv(a)^x)
 end
-
+@eval ^(a::Interval{Float32}, x::$T) = atomic(Interval{Float32}, bigequiv(a)^x)
 
 # Integer power:
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -6,7 +6,7 @@
 # Use the BigFloat version from MPFR instead, which is correctly-rounded:
 
 # Write explicitly like this to avoid ambiguity warnings:
-for T in (:Integer, :Float64, :BigFloat, :Interval)
+for T in (:Integer, :Float64, :Float32, :BigFloat, :Interval)
     @eval ^(a::Interval{Float64}, x::$T) = atomic(Interval{Float64}, bigequiv(a)^x)
 end
 

--- a/src/intervals/functions.jl
+++ b/src/intervals/functions.jl
@@ -9,7 +9,7 @@
 for T in (:Integer, :Float64, :BigFloat, :Interval)
     @eval ^(a::Interval{Float64}, x::$T) = atomic(Interval{Float64}, bigequiv(a)^x)
 end
-@eval ^(a::Interval{Float32}, x::$T) = atomic(Interval{Float32}, bigequiv(a)^x)
+^(a::Interval{Float32}, x::Interval) = atomic(Interval{Float32}, bigequiv(a)^x)
 
 # Integer power:
 

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -377,6 +377,7 @@ end
         a = Interval{Float32}(1e38)
         b = Interval{Float32}(1e2)
         @test a * b == Interval{Float32}(floatmax(Float32), Inf)
+        @test Interval(1.0f0) ^ Interval(1.0f0) == Interval(1.0f0) # test for PR #482
     end
 
 


### PR DESCRIPTION
Currently this fails:

```julia
Interval(1.0f0) ^ Interval(1.0f0)
```
while this works
```julia
Interval(1.0) ^ Interval(1.0)
```

With this change both things will work, but I'm not too sure if it's the right thing to do. 

Happy to add tests etc.