### PR TITLE
Lf complex interior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.19.1"
+version = "0.19.2"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/intervals/complex.jl
+++ b/src/intervals/complex.jl
@@ -1,5 +1,5 @@
 
-for op in (:⊆, :⊂)
+for op in (:⊆, :⊂, :⪽)
     @eval function $(op)(x::Complex{Interval{T}}, y::Complex{Interval{S}}) where {T, S}
         return $(op)(real(x), real(y)) && $(op)(imag(x), imag(y))
     end

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -10,6 +10,7 @@ using LinearAlgebra
 
     @test a ⊂ c
     @test a ⊆ c
+    @test a ⪽ c
     @test (b ⊂ c) == false
     @test (b ⊆ c) == false
 


### PR DESCRIPTION
added isinterior for complex intervals

### before

```julia
julia> a = (1..2) + (3..4)*im
[1, 2] + [3, 4]im

julia> isinterior(a, a)
ERROR: MethodError: no method matching isinterior(::Complex{Interval{Float64}}, ::Complex{Interval{Float64}})
Stacktrace:
 [1] top-level scope
   @ REPL[32]:1
```

### After

```julia
julia> a = (1..2) + (3..4)*im
[1, 2] + [3, 4]im

julia> isinterior(a, a)
false
```