### PR TITLE
Use `@ccall` instead of `ccall`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.19.2"
+version = "0.20.0"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"
@@ -22,7 +22,7 @@ RecipesBase = "1.0"
 RoundingEmulator = "0.2"
 SetRounding = "0.2"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"
-julia = "1.3, 1.4, 1.5"
+julia = "1.5"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/display.jl
+++ b/src/display.jl
@@ -156,9 +156,11 @@ function round_string(x::BigFloat, digits::Int, r::RoundingMode)
     lng = digits + Int32(8)
     buf = Array{UInt8}(undef, lng + 1)
 
-    lng = ccall((:mpfr_snprintf, :libmpfr), Int32,
-    (Ptr{UInt8}, Culong,  Ptr{UInt8}, Int32, Ref{BigFloat}...),
-    buf, lng + 1, "%.$(digits)R*g", to_mpfr(r), x)
+    lng = @ccall "libmpfr".mpfr_snprintf(buf::Ptr{UInt8},
+                                         (lng + 1)::Csize_t,
+                                         "%.$(digits)R*g"::Ptr{UInt8};
+                                         to_mpfr(r)::Cint,
+                                         x::Ref{BigFloat})::Cint
 
     repr = unsafe_string(pointer(buf))
 


### PR DESCRIPTION
How'd you feel about requiring Julia v1.5?  This change makes the package work on `aarch64-apple-darwin` (aka Apple Silicon, for example the M1 processor).  For the background issue see https://github.com/JuliaLang/julia/issues/42614.

Fix #494.