### PR TITLE
Bump CRlibm to 1 while keeping the existing compats

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.20.2"
+version = "0.20.3"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"
@@ -15,7 +15,7 @@ SetRounding = "3cc68bcd-71a2-5612-b932-767ffbe40ab0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-CRlibm = "0.7, 0.8"
+CRlibm = "0.7, 0.8, 1"
 FastRounding = "0.2"
 Polynomials = "0.7"
 RecipesBase = "1.0"


### PR DESCRIPTION
- The older versions of CRlibm untars the deps which can't be supported on machines where you don't have root access
- CRlibm fails to build with
```
tar: crlibm-1.0beta4/trigo_fast.c: Cannot change ownership to uid 1000, gid 1000: Invalid argument
tar: crlibm-1.0beta4/trigpi.h: Cannot change ownership to uid 1000, gid 1000: Invalid argument
tar: crlibm-1.0beta4/ChangeLog: Cannot change ownership to uid 1000, gid 1000: Invalid argument
tar: crlibm-1.0beta4/triple-double.h: Cannot change ownership to uid 1000, gid 1000: Invalid argument
tar: crlibm-1.0beta4/log2-td.c: Cannot change ownership to uid 1000, gid 1000: Invalid argument
tar: crlibm-1.0beta4/exp-td-standalone.c: Cannot change ownership to uid 1000, gid 1000: Invalid argument
:
:
```