### PR TITLE
update decorated intervals constructors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches: "main"
+    tags: ["*"]
+  pull_request:
+  release:
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/src/decorations/decorations.jl
+++ b/src/decorations/decorations.jl
@@ -1,14 +1,14 @@
 include("intervals.jl")
 include("functions.jl")
 
-isnan(x::Interval) = false  # NaI is always decorated
+# isnan(x::Interval) = false  # NaI is always decorated
 
 """`NaI` not-an-interval: [NaN, NaN]."""
-nai(::Type{T}) where T = DecoratedInterval(convert(T, NaN), convert(T, NaN), ill)
+nai(::Type{T}) where T = DecoratedInterval(Interval(convert(T, NaN), convert(T, NaN)), ill)
 nai(::Type{F}) where {T, F<:Interval{T}} = nai(T)
 nai(::Interval{T}) where T<:Real = nai(T)
 nai(::DecoratedInterval{T}) where T<:Real = nai(T)
-nai() = nai(Interval{default_bound()})
+nai() = nai(default_bound())
 
-isnai(x::Interval) = isnan(x.lo) || isnan(x.hi) #|| x.lo > x.hi || (isinf(x.lo) && x.lo == x.hi)
-isnai(x::DecoratedInterval) = isnai(interval(x)) || x.decoration == ill
+isnai(x::Interval) = false  # NaI is always decorated
+isnai(x::DecoratedInterval) = x.decoration == ill

--- a/src/decorations/functions.jl
+++ b/src/decorations/functions.jl
@@ -23,7 +23,7 @@ const bool_binary_functions = (
 )
 
 for f in bool_functions
-    @eval $(f)(xx::DecoratedInterval) = $(f)(interval(xx))
+    @eval $(f)(xx::DecoratedInterval) = $(f)(xx.interval)
 end
 
 for f in bool_binary_functions
@@ -42,7 +42,7 @@ scalar_functions = (
 )
 
 for f in scalar_functions
-    @eval $(f)(xx::DecoratedInterval{T}) where T = $f(interval(xx))
+    @eval $(f)(xx::DecoratedInterval{T}) where T = $f(xx.interval)
 end
 
 dist(xx::DecoratedInterval, yy::DecoratedInterval) = dist(interval(xx), interval(yy))

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -33,7 +33,7 @@ struct DecoratedInterval{T}
     function DecoratedInterval{T}(I::Interval, d::DECORATION) where T
         dd = min(d, decoration(I))
         dd == ill && return new{T}(Interval(T(NaN), T(NaN)), ill)
-        return new{T}(I, min(d, dd))
+        return new{T}(I, dd)
     end
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -297,6 +297,7 @@ end
 
 
 function representation(a::DecoratedInterval{T}, format=nothing) where T
+    isnai(a) && return "[NaI]"
     if isnothing(format)
         format = display_params.format  # default
     end

--- a/test/decoration_tests/decoration_tests.jl
+++ b/test/decoration_tests/decoration_tests.jl
@@ -4,6 +4,9 @@ using Test
 let b
 
 @testset "DecoratedInterval tests" begin
+
+    @test DecoratedInterval(Interval(big(1), big(2))) isa DecoratedInterval{BigFloat}
+
     a = DecoratedInterval(@interval(1, 2), com)
     @test decoration(a) == com
 
@@ -30,6 +33,7 @@ let b
     @test isnai((DecoratedInterval(big(2), big(1))))
     @test isnai(@decorated(big(2), big(1)))
 
+    @test decoration(DecoratedInterval(DecoratedInterval(0, Inf), com)) == dac
     # Disabling the following tests, because Julia 0.5 has some strange behaviour here
     # @test_throws ArgumentError DecoratedInterval(BigInt(1), 1//10)
     # @test_throws ArgumentError @decorated(BigInt(1), 1//10)
@@ -63,6 +67,12 @@ let b
     @test isnai(@decorated(NaN, 3))
     @test isnai(@decorated(3, NaN))
     @test isnai(@decorated(NaN, NaN))
+
+    @test !isnai(Interval(1, 2))
+
+    @test decoration(Interval(3, 1)) == ill
+
+    @test decoration(DecoratedInterval(3, Inf, com)) == dac
 end
 
 end

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -165,7 +165,7 @@ using Test
         @test !(nai(a) ≛ nai(a))
         @test nai(a) === nai(a)
         @test nai(Float64) === DecoratedInterval(NaN)
-        @test isnan(interval(nai(BigFloat)).lo)
+        @test isnan(inf(nai(BigFloat)))
         @test isnai(nai())
         @test !(isnai(a))
 

--- a/test/test_ITF1788/ieee1788-exceptions.jl
+++ b/test/test_ITF1788/ieee1788-exceptions.jl
@@ -4,9 +4,8 @@
 
     @test interval(+Inf,-Inf) === emptyinterval()
 
-    @test_broken interval(nai()) === emptyinterval()
+    @test interval(nai()) === emptyinterval()
 
     @test @interval("[1.0000000000000001, 1.0000000000000002]") === Interval(1.0, 0x1.0000000000001p+0)
 
 end
-

--- a/test/test_ITF1788/libieeep1788_class.jl
+++ b/test/test_ITF1788/libieeep1788_class.jl
@@ -352,7 +352,7 @@ end
 
     @test interval(DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)) === Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4)
 
-    @test_broken interval(nai()) === emptyinterval()
+    @test interval(nai()) === emptyinterval()
 
 end
 
@@ -414,17 +414,17 @@ end
 
     @test DecoratedInterval(interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com) === DecoratedInterval(Interval(-0x1.99999C0000000p+4,0x1.9999999999999P-4), com)
 
-    @test_broken DecoratedInterval(emptyinterval(), def) === DecoratedInterval(emptyinterval(), trv)
+    @test DecoratedInterval(emptyinterval(), def) === DecoratedInterval(emptyinterval(), trv)
 
-    @test_broken DecoratedInterval(emptyinterval(), dac) === DecoratedInterval(emptyinterval(), trv)
+    @test DecoratedInterval(emptyinterval(), dac) === DecoratedInterval(emptyinterval(), trv)
 
-    @test_broken DecoratedInterval(emptyinterval(), com) === DecoratedInterval(emptyinterval(), trv)
+    @test DecoratedInterval(emptyinterval(), com) === DecoratedInterval(emptyinterval(), trv)
 
-    @test_broken DecoratedInterval(interval(1.0,Inf), com) === DecoratedInterval(Interval(1.0,Inf), dac)
+    @test DecoratedInterval(interval(1.0,Inf), com) === DecoratedInterval(Interval(1.0,Inf), dac)
 
-    @test_broken DecoratedInterval(interval(-Inf,3.0), com) === DecoratedInterval(Interval(-Inf,3.0), dac)
+    @test DecoratedInterval(interval(-Inf,3.0), com) === DecoratedInterval(Interval(-Inf,3.0), dac)
 
-    @test_broken DecoratedInterval(interval(-Inf,Inf), com) === DecoratedInterval(Interval(-Inf,Inf), dac)
+    @test DecoratedInterval(interval(-Inf,Inf), com) === DecoratedInterval(Interval(-Inf,Inf), dac)
 
     @test isnai(DecoratedInterval(emptyinterval(), ill))
 


### PR DESCRIPTION
## What

This PR fixes issues in 1.0-dev with decorated interval constructors. After this all related ITF tests pass.

## Changes

### Check for validity of interval

Added inner constructor that checks if the given decoration is appropriate and behaves accordingly. Also for `ill` the interval part is normalized to `[NaN, NaN]`, which simplifies computations since `NaN` poisons everything

- before
```julia
julia> DecoratedInterval(Interval(0, Inf), com)
[0, ∞]_com

julia> DecoratedInterval(Interval(2, 1), com)
[2, 1]_com

julia> DecoratedInterval(Interval(0, Inf), com)
[0, ∞]_com

julia> DecoratedInterval(Interval(2, 1), com)
[2, 1]_com

julia> a = DecoratedInterval(2, 1)
[2, 1]_ill

julia> inf(a)
2.0
```

- after
```julia
julia> DecoratedInterval(Interval(0, Inf), com)
[0, ∞]_dac

julia> DecoratedInterval(Interval(2, 1), com)
[NaI]

julia> ans.interval
[NaN, NaN]

julia> DecoratedInterval(2, 1)
[NaI]

julia> ans.interval
[NaN, NaN]

julia> inf(a)
NaN
```

there was (and still is) some asymmetry between constructors of decorated intervals and bare intervals. For bare intervals, we have the unsafe constructor `Interval` which does nothing, the safe constructor `interval` and the safe macro with correct rounding `@interval`. For decorated intervals we have the safe macro with correct rounding interval `@decorated`, but only one constructor `DecoratedInterval`, which before this PR was unsafe and after this PR is safe (at the price of extra overhead). Are we happy with this? Or should we have a safe `decorated` constructor and unsafe `DecoratedInterval` constructor? I don't have strong opinions about this.

### Interval part of nai()

according to the standard, the interval part of the `[NaI]` should be the empty interval and a warning should be thrown. This mainly had a few consequences
  1. for a few functions (e.g. inf, sup) `interval` could not be used directly, since `inf(nai())` should still be `NaN`
  2. Now all tests pass, so I guess it's fine but as a drawback, warnings are emitted in the middle
  ```julia
julia> nai() + DecoratedInterval(1, 2)
┌ Warning: trying to access interval part of [NaI], returning empty interval
└ @ IntervalArithmetic ~/.julia/dev/IntervalArithmetic/src/decorations/intervals.jl:63
[NaI]
```
is this fine? The alternatives are
1. use `x.interval` internally. This would probably work but might be a little contradictory with the latest decision to use `inf, sup` internally instead of `.lo, .hi`. On the other side, This matters only when implementing operations for decorated intervals but the end user who writes some generic algorithm with intervals would not note the difference, as would write generic code for `AbstractInterval` and hence would not need to access the interval part.
2. have an interval function `_interval(x::DecoratedInterval) = x.interval` and external `interval` that does the "standard" behavior. Alternatively the internal could be called `interval` and external `intervalPart` or viceversa. 

Personally, I think option 1 would be better in this case.

### printing

- changed printing on `[NaI]` now it's displayed as `[NaI]`