### PR TITLE
Quick and dirty fix for hull(1, 2..3)

### DIFF
--- a/src/intervals/set_operations.jl
+++ b/src/intervals/set_operations.jl
@@ -120,6 +120,10 @@ Returns the "interval hull" of the intervals `a` and `b`, considered as
 all of `a` and `b`.
 """
 hull(a::Interval, b::Interval) = Interval(min(a.lo, b.lo), max(a.hi, b.hi))
+
+# Prevent using fallback from Base
+hull(a::Real, b::Interval) = hull(Interval(a), b)
+hull(a::Interval, b::Real) = hull(a, Interval(b))
 #
 # hull{T,S}(a::Interval{T}, b::Interval{S}) = hull(promote(a, b)...)
 hull(a::Complex{<:Interval},b::Complex{<:Interval}) =

--- a/src/intervals/set_operations.jl
+++ b/src/intervals/set_operations.jl
@@ -128,7 +128,11 @@ hull(a::Interval, b::Real) = hull(a, Interval(b))
 # hull{T,S}(a::Interval{T}, b::Interval{S}) = hull(promote(a, b)...)
 hull(a::Complex{<:Interval},b::Complex{<:Interval}) =
     complex(hull(real(a),real(b)),hull(imag(a),imag(b)))
-hull(a...) = reduce(hull, a)
+
+tointerval(x) = Interval(x)
+tointerval(x::Interval) = x
+
+hull(a...) = reduce(hull, tointerval.(a))
 hull(a::Vector{Interval{T}}) where {T} = reduce(hull, a)
 
 """

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -45,7 +45,7 @@ numtype(x::IntervalBox{N, T}) where {N, T<:Real} = T
 
 length(X::IntervalBox{N,T}) where {N,T} = N
 
-
+tointerval(x::IntervalBox) = x
 
 # IntervalBox(xx) = IntervalBox(Interval.(xx))
 # IntervalBox(xx::SVector) where {N,T} = IntervalBox(Interval.(xx))

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -163,6 +163,14 @@ setprecision(Interval, Float64)
 
         @test union(1..2, 3..4) == Interval(1, 4)
         @test union(Interval(1//3, 3//4), Interval(3, 4)) == @interval(1/3, 4)
+
+        @test hull(1, 2..3) == Interval(1, 3)
+        @test hull(1..2, 3) == Interval(1, 3)
+
+        @test hull(1..2, 3, 4..5) == Interval(1, 5)
+        @test hull(1, 2..3, 4, 5) == Interval(1, 5)
+        @test hull(1..2, 3, 4..5, 6) == Interval(1, 6)
+        @test hull(1, 2..3, 4, 5..6) == Interval(1, 6)
     end
 
     @testset "Special interval tests" begin

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -171,6 +171,9 @@ setprecision(Interval, Float64)
         @test hull(1, 2..3, 4, 5) == Interval(1, 5)
         @test hull(1..2, 3, 4..5, 6) == Interval(1, 6)
         @test hull(1, 2..3, 4, 5..6) == Interval(1, 6)
+
+        @test hull(1, 2, 3, 4..5) == 1..5
+        @test hull(1, 1) == 1..1
     end
 
     @testset "Special interval tests" begin


### PR DESCRIPTION
As proposed in #528 by @lucaferranti .

Unfortunately, it does not cover all the cases yet, like 
``` julia
julia> hull(1, 2, 3, 1..2)
ERROR: StackOverflowError:
...
julia> hull(1, 1)
ERROR: StackOverflowError:
...
```
So, it's only a draft now.