### PR TITLE
Fix type parameter warning, mild cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.20.7"
+version = "0.20.8"
 
 [deps]
 CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -1,7 +1,5 @@
 # This file is part of the IntervalArithmetic.jl package; MIT licensed
 
-__precompile__(true)
-
 module IntervalArithmetic
 
 import CRlibm
@@ -66,12 +64,7 @@ export
     pow, extended_div,
     setformat, @format
 
-if VERSION >= v"1.5.0-DEV.124"
-    import Base: isdisjoint
-else
-    export isdisjoint
-end
-
+import Base: isdisjoint
 
 export
     setindex   # re-export from StaticArrays for IntervalBox

--- a/src/multidim/intervalbox.jl
+++ b/src/multidim/intervalbox.jl
@@ -18,7 +18,7 @@ IntervalBox(x) = IntervalBox(x...)
 IntervalBox(X::IntervalBox, n) = foldl(×, Iterators.repeated(X, n))
 
 # construct from two vectors giving bottom and top corners:
-IntervalBox(lo::AbstractVector, hi::AbstractVector) where {N,T} = IntervalBox(force_interval.(lo, hi))
+IntervalBox(lo::AbstractVector, hi::AbstractVector) = IntervalBox(force_interval.(lo, hi))
 
 IntervalBox(lo::SVector{N,T}, hi::SVector{N,T}) where {N,T} = IntervalBox(force_interval.(lo, hi))
 


### PR DESCRIPTION
This fixes an "unused type parameter" warning, removes a branch that cannot be reached because the Project.toml requires v1.5+ anyway, and removes the precompile line at the very beginning.