### PR TITLE
1.0-dev: remove superfluous `Real`-like methods for `Interval`

### DIFF
--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -1,13 +1,16 @@
-#= This file contains the function that must be defined on Intervals
-    so that they behave like Real in julia.
+# This file is part of the IntervalArithmetic.jl package; MIT licensed
+
+#=
+Description:
+
+This file contains the functions that must be defined on `Interval`s so that
+they behave like `Real` in julia.
 =#
 
-real(a::Interval) = a
-
-zero(a::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
+zero(::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
 zero(::Type{F}) where {T<:Real, F<:Interval{T}} = F(zero(T))
 
-one(a::F) where {T<:Real, F<:Interval{T}} = F(one(T))
+one(::F) where {T<:Real, F<:Interval{T}} = F(one(T))
 one(::Type{F}) where {T<:Real, F<:Interval{T}} = F(one(T))
 
 typemin(::Type{F}) where {T<:Real, F<:Interval{T}} = F(typemin(T), nextfloat(typemin(T)))
@@ -19,11 +22,11 @@ size(::Interval) = (1,)
 eltype(::F) where {F<:Interval} = F
 
 """
-    numtype(x::Interval)
+    numtype(::Interval{T}) where {T}
 
-Returns the type of the bounds of the interval.
+Return the type `T` of the bounds of the interval.
 
-### Example
+# Example
 
 ```julia
 julia> numtype(1..2)
@@ -38,8 +41,8 @@ eps(::Type{F}) where {T, F<:Interval{T}} = F(eps(T))
 """
     hash(x::Interval, h)
 
-Computes the integer hash code for an interval using the method for composite
-types used in `AutoHashEquals.jl`
+Compute the integer hash code for an interval using the method for composite
+types used in `AutoHashEquals.jl`.
 
 Note that in `IntervalArithmetic.jl`, equality of intervals is given by
 `≛` rather than the `==` operator.

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -18,9 +18,6 @@ typemax(::Type{F}) where {T<:Real, F<:Interval{T}} = F(prevfloat(typemax(T)), ty
 typemin(::Type{F}) where {T<:Integer, F<:Interval{T}} = F(typemin(T))
 typemax(::Type{F}) where {T<:Integer, F<:Interval{T}} = F(typemax(T))
 
-size(::Interval) = (1,)
-eltype(::F) where {F<:Interval} = F
-
 """
     numtype(::Interval{T}) where {T}
 
@@ -53,4 +50,3 @@ hash(x::Interval, h::UInt) = hash(sup(x), hash(inf(x), hash(Interval, h)))
 
 # TODO No idea where this comes from and if it is the correct place to put it.
 dist(a::Interval, b::Interval) = max(abs(inf(a)-inf(b)), abs(sup(a)-sup(b)))
-

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -6,7 +6,7 @@ using Test
 @testset "Constructing intervals" begin
     # Naive constructors, with no conversion involved
     @test Interval(1) ≛ Interval(1.0, 1.0)
-    @test size(Interval(1)) == (1,)
+    @test size(Interval(1)) == ()  # Match the `size` behaviour of `Number`
     @test Interval(big(1)) ≛ Interval(1.0, 1.0)
     @test_broken Interval(1//10) ≛ Interval{Rational{Int}}(1//10, 1//10)
     @test_broken Interval(BigInt(1)//10) ≛ Interval{Rational{BigInt}}(1//10, 1//10)


### PR DESCRIPTION
Julia already defines the fallback method `real(x::Real) = x` so there is no need to add a new method.

Also, minor format changes in the docstrings and the header of the file.