### PR TITLE
1.0-dev: fix `Interval(::Interval)` ambiguity error

### DIFF
--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -34,7 +34,7 @@ Interval{Float64}
 """
 default_bound() = Float64
 
-@inline _normalisezero(a::Real) = ifelse(iszero(a) && signbit(a), copysign(a, 1), a)
+@inline _normalisezero(a::Real) = ifelse(iszero(a), zero(a), a)
 
 """
     Interval
@@ -64,18 +64,11 @@ struct Interval{T} <: Real
     lo::T
     hi::T
 
-    function Interval{T}(a, b) where T
-        new{T}(_normalisezero(T(a, RoundDown)), _normalisezero(T(b, RoundUp)))
-    end
-
-    function Interval{T}(a::T, b::T) where T
-        a = _normalisezero(a)
-        b = _normalisezero(b)
-        new{T}(a, b)
-    end
+    Interval{T}(a::T, b::T) where T = new{T}(_normalisezero(a), _normalisezero(b))
 end
 
 #= Outer constructors =#
+Interval{T}(a, b) where T = Interval{T}(T(a, RoundDown), T(b, RoundUp))
 Interval{T}(a) where T = Interval{T}(a, a)
 Interval(a) = Interval(a, a)
 Interval(a::Tuple) = Interval(a...)
@@ -100,6 +93,7 @@ function Interval(a::Irrational, b::Irrational)
 end
 
 #= Interval =#
+Interval(x::Interval) = x
 Interval{T}(x::Interval{T}) where T = x
 Interval{T}(x::Interval) where T = Interval{T}(inf(x), sup(x))
 

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -1,16 +1,13 @@
-# This file is part of the IntervalArithmetic.jl package; MIT licensed
-
-#=
-Description:
-
-This file contains the functions that must be defined on `Interval`s so that
-they behave like `Real` in julia.
+#= This file contains the function that must be defined on Intervals
+    so that they behave like Real in julia.
 =#
 
-zero(::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
+real(a::Interval) = a
+
+zero(a::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
 zero(::Type{F}) where {T<:Real, F<:Interval{T}} = F(zero(T))
 
-one(::F) where {T<:Real, F<:Interval{T}} = F(one(T))
+one(a::F) where {T<:Real, F<:Interval{T}} = F(one(T))
 one(::Type{F}) where {T<:Real, F<:Interval{T}} = F(one(T))
 
 typemin(::Type{F}) where {T<:Real, F<:Interval{T}} = F(typemin(T), nextfloat(typemin(T)))
@@ -22,11 +19,11 @@ size(::Interval) = (1,)
 eltype(::F) where {F<:Interval} = F
 
 """
-    numtype(::Interval{T}) where {T}
+    numtype(x::Interval)
 
-Return the type `T` of the bounds of the interval.
+Returns the type of the bounds of the interval.
 
-# Example
+### Example
 
 ```julia
 julia> numtype(1..2)
@@ -41,8 +38,8 @@ eps(::Type{F}) where {T, F<:Interval{T}} = F(eps(T))
 """
     hash(x::Interval, h)
 
-Compute the integer hash code for an interval using the method for composite
-types used in `AutoHashEquals.jl`.
+Computes the integer hash code for an interval using the method for composite
+types used in `AutoHashEquals.jl`
 
 Note that in `IntervalArithmetic.jl`, equality of intervals is given by
 `≛` rather than the `==` operator.
@@ -53,4 +50,3 @@ hash(x::Interval, h::UInt) = hash(sup(x), hash(inf(x), hash(Interval, h)))
 
 # TODO No idea where this comes from and if it is the correct place to put it.
 dist(a::Interval, b::Interval) = max(abs(inf(a)-inf(b)), abs(sup(a)-sup(b)))
-

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -1,13 +1,16 @@
-#= This file contains the function that must be defined on Intervals
-    so that they behave like Real in julia.
+# This file is part of the IntervalArithmetic.jl package; MIT licensed
+
+#=
+Description:
+
+This file contains the functions that must be defined on `Interval`s so that
+they behave like `Real` in julia.
 =#
 
-real(a::Interval) = a
-
-zero(a::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
+zero(::F) where {T<:Real, F<:Interval{T}} = F(zero(T))
 zero(::Type{F}) where {T<:Real, F<:Interval{T}} = F(zero(T))
 
-one(a::F) where {T<:Real, F<:Interval{T}} = F(one(T))
+one(::F) where {T<:Real, F<:Interval{T}} = F(one(T))
 one(::Type{F}) where {T<:Real, F<:Interval{T}} = F(one(T))
 
 typemin(::Type{F}) where {T<:Real, F<:Interval{T}} = F(typemin(T), nextfloat(typemin(T)))
@@ -19,11 +22,11 @@ size(::Interval) = (1,)
 eltype(::F) where {F<:Interval} = F
 
 """
-    numtype(x::Interval)
+    numtype(::Interval{T}) where {T}
 
-Returns the type of the bounds of the interval.
+Return the type `T` of the bounds of the interval.
 
-### Example
+# Example
 
 ```julia
 julia> numtype(1..2)
@@ -38,8 +41,8 @@ eps(::Type{F}) where {T, F<:Interval{T}} = F(eps(T))
 """
     hash(x::Interval, h)
 
-Computes the integer hash code for an interval using the method for composite
-types used in `AutoHashEquals.jl`
+Compute the integer hash code for an interval using the method for composite
+types used in `AutoHashEquals.jl`.
 
 Note that in `IntervalArithmetic.jl`, equality of intervals is given by
 `≛` rather than the `==` operator.

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -5,6 +5,7 @@ using Test
 
 @testset "Constructing intervals" begin
     # Naive constructors, with no conversion involved
+    @test Interval(1.0) ≛ Interval(Interval(1.0)) ≛ Interval{Float64}(Interval(1.0))
     @test Interval(1) ≛ Interval(1.0, 1.0)
     @test size(Interval(1)) == (1,)
     @test Interval(big(1)) ≛ Interval(1.0, 1.0)


### PR DESCRIPTION
Before this PR
```Julia
julia> Interval(Interval(1))
ERROR: MethodError: Interval(::Interval{Float64}) is ambiguous.

Candidates:
  (::Type{T})(x::T) where T<:Number
    @ Core boot.jl:792
  Interval(a)
    @ IntervalArithmetic ~/.julia/dev/dev_IA/IntervalArithmetic/src/intervals/construction.jl:73

Possible fix, define
  Interval(::Interval)

Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```
With this PR:
```Julia
julia> Interval(Interval(1))
[1, 1]
```

The PR also contains some minor changes:
- simplified the logic in `_normalisezero` as I did not observe any impact on performance. But perhaps I am missing something?
- only keep the required inner constructor (the other one is now a regular outer constructor)