### PR TITLE
1.0-dev: fix `interval(::Interval)` and some ambiguities

### DIFF
--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -116,13 +116,9 @@ Interval(x::Irrational) = Interval{default_bound()}(x)
 end
 
 # promotion
+
 Base.promote_rule(::Type{Interval{T}}, ::Type{Interval{S}}) where {T,S} =
     Interval{promote_type(T, S)}
-Base.promote_rule(::Type{Interval{T}}, ::Type{<:Real}) where {T} = Interval{T}
-#=
-Do not define `Base.promote_rule(::Type{<:Real}, ::Type{Interval{T}}) where {T} = Interval{T}`
-It is superfluous and leads to ambiguities, e.g. `promote_type(Bool, Interval{Float64})`
-=#
 
 """
     interval(a, b)

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -115,6 +115,12 @@ Interval(x::Irrational) = Interval{default_bound()}(x)
     return :(return $res)  # Set body of the function to return the precomputed result
 end
 
+# promotion
+Base.promote_rule(::Type{Interval{T}}, ::Type{Interval{S}}) where {T,S} =
+    Interval{promote_type(T, S)}
+Base.promote_rule(::Type{Interval{T}}, ::Type{<:Real}) where {T} = Interval{T}
+Base.promote_rule(::Type{<:Real}, ::Type{Interval{T}}) where {T} = Interval{T}
+
 """
     interval(a, b)
 
@@ -123,15 +129,13 @@ If so, then an `Interval(a, b)` object is returned;
 if not, a warning is printed and the empty interval is returned.
 """
 function interval(a::T, b::S) where {T<:Real, S<:Real}
-    if !is_valid_interval(a, b)
-        @warn "Invalid input, empty interval is returned"
-        return emptyinterval(promote_type(T, S))
-    end
-
-    return Interval(a, b)
+    is_valid_interval(a, b) && return Interval(a, b)
+    @warn "Invalid input, empty interval is returned"
+    return emptyinterval(promote_type(T, S))
 end
 
 interval(a::Real) = interval(a, a)
+interval(a::Interval) = interval(inf(a), sup(a))  # Check the validity of the interval
 
 const checked_interval = interval
 

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -119,7 +119,10 @@ end
 Base.promote_rule(::Type{Interval{T}}, ::Type{Interval{S}}) where {T,S} =
     Interval{promote_type(T, S)}
 Base.promote_rule(::Type{Interval{T}}, ::Type{<:Real}) where {T} = Interval{T}
-Base.promote_rule(::Type{<:Real}, ::Type{Interval{T}}) where {T} = Interval{T}
+#=
+Do not define `Base.promote_rule(::Type{<:Real}, ::Type{Interval{T}}) where {T} = Interval{T}`
+It is superfluous and leads to ambiguities, e.g. `promote_type(Bool, Interval{Float64})`
+=#
 
 """
     interval(a, b)

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -39,6 +39,9 @@ using Test
     @test big(ℯ) in Interval{Float32}(0, ℯ)
     @test big(π) in Interval{Float32}(π, 4)
 
+    @test interval(Interval(pi)) ≛ Interval(pi)
+    @test interval(Interval(NaN, -Inf)) ≛ emptyinterval()
+
     # a < Inf and b > -Inf
     @test @interval("1e300") ≛ Interval(9.999999999999999e299, 1.0e300)
     @test @interval("-1e307") ≛ Interval(-1.0000000000000001e307, -1.0e307)
@@ -185,6 +188,11 @@ end
 
     a = convert(Interval{Float64}, @biginterval(3, 4))
     @test typeof(a) == Interval{Float64}
+
+    pi64, pi32 = Interval{Float64}(pi), Interval{Float32}(pi)
+    x, y = promote(pi64, pi32)
+    @test x ≛ pi64
+    @test y ≛ Interval{Float64}(pi32)
 end
 
 @testset "Interval{T} constructor" begin

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -167,6 +167,16 @@ end
     @test convert(Interval{BigFloat}, x) === x
 end
 
+@testset "Promotion between intervals" begin
+    x = Interval{Float64}(π)
+    y = Interval{BigFloat}(π)
+    x_, y_ = promote(x, y)
+
+    @test promote_type(typeof(x), typeof(y)) == Interval{BigFloat}
+    @test bounds(x_) == (BigFloat(inf(x), RoundDown), BigFloat(sup(x), RoundUp))
+    @test y_ ≛ y
+end
+
 @testset "Typed intervals" begin
     @test typeof(@interval Float64 1 2) == Interval{Float64}
     @test typeof(@interval         1 2) == Interval{Float64}

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -40,6 +40,12 @@ end
     @test a + b ≛ Interval(+(a.lo, b.lo, RoundDown), +(a.hi, b.hi, RoundUp))
     @test -a ≛ Interval(-a.hi, -a.lo)
     @test a - b ≛ Interval(-(a.lo, b.hi, RoundDown), -(a.hi, b.lo, RoundUp))
+    for f in (:+, :-, :*, :/)
+        @eval begin
+            @test $f(Interval{Float64}(pi), Interval{Float32}(pi)) ≛
+                $f(Interval{Float64}(pi), Interval{Float64}(Interval{Float32}(pi)))
+        end
+    end
     @test Interval(1//4,1//2) + Interval(2//3) ≛ Interval(11//12, 7//6)
     @test_broken Interval(1//4,1//2) - Interval(2//3) ≛ Interval(-5//12, -1//6)
 


### PR DESCRIPTION

- Fix ambiguities with `+`, `-`, `*` and `/` when the operands are `Interval`s with different `numtype`. The mechanism relies on `promote`, so `promote_rule` is defined, as a side-effect `[Interval{Float32}(pi), Interval{Float64}(pi)]::Vector{Interval{Float64}}` with guaranteed error bounds.
- Fix typos in dosctrings

### Showcase:

Before this PR:

```julia
julia> Interval{Float64}(1) + Interval{Float32}(1)
ERROR: MethodError: +(::Interval{Float64}, ::Interval{Float32}) is ambiguous.

Candidates:
  +(b::Real, a::Interval)
    @ IntervalArithmetic ~/.julia/dev/dev_IA/IntervalArithmetic/src/intervals/arithmetic/basic.jl:31
  +(a::Interval{T}, b::S) where {T, S<:Real}
    @ IntervalArithmetic ~/.julia/dev/dev_IA/IntervalArithmetic/src/intervals/arithmetic/basic.jl:30

Possible fix, define
  +(::Interval{T}, ::S) where {T, S<:Interval}

Stacktrace:
 [1] top-level scope
   @ REPL[6]:1

julia> promote_type(Interval{Float32}, Interval{Float64})
Interval

Julia> showfull( interval(Interval(pi)) )
Interval([3.14159, 3.1416], [3.14159, 3.1416])
```

After this PR

```julia
julia> Interval{Float64}(1) + Interval{Float32}(1)
   [2, 2]

julia> promote_type(Interval{Float32}, Interval{Float64})
Interval{Float64}

julia> showfull( interval(Interval(pi)) )
Interval(3.141592653589793, 3.1415926535897936)
```