### PR TITLE
1.0-dev: improve printing and fix alignment issue

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -79,7 +79,6 @@ end
 export
     setindex   # re-export from StaticArrays for IntervalBox
 
-export showfull
 
 
 ## Multidimensional

--- a/src/display.jl
+++ b/src/display.jl
@@ -11,7 +11,7 @@ function Base.show(io::IO, ::MIME"text/plain", params::DisplayParameters)
     print(io, "  - significant digits: ", params.sigdigits)
 end
 
-const display_params = DisplayParameters(:standard, false, 6)  # Default
+const display_params = DisplayParameters(:standard, true, 6)  # Default
 
 """
     setformat(format::Symbol; decorations::Bool, sigdigits::Int)
@@ -38,7 +38,7 @@ Possible options:
 
 See also: `@format`.
 
-# Example:
+# Example
 ```
 julia> x = interval(0.1, 0.3)  # Default display options
 [0.0999999, 0.300001]
@@ -46,7 +46,7 @@ julia> x = interval(0.1, 0.3)  # Default display options
 julia> setformat(:full)  # Equivalent to `@format full`
 Display parameters:
   - format: full
-  - decorations: false
+  - decorations: true
   - significant digits: 6
 
 julia> x
@@ -55,7 +55,7 @@ Interval(0.09999999999999999, 0.30000000000000004)
 julia> setformat(:standard; sigdigits = 3)  # Equivalent to `@format standard 3`
 Display parameters:
   - format: standard
-  - decorations: false
+  - decorations: true
   - significant digits: 3
 
 julia> x
@@ -100,7 +100,7 @@ julia> x = interval(0.1, 0.3)  # Default display options
 julia> @format full  # Equivalent to `setformat(:full)``
 Display parameters:
   - format: full
-  - decorations: false
+  - decorations: true
   - significant digits: 6
 
 julia> x

--- a/src/display.jl
+++ b/src/display.jl
@@ -19,7 +19,7 @@ const display_params = DisplayParameters(:standard, false, 6)  # Default
 
 Change the format used by `show` to display intervals.
 
-Initially, the display options are `format = : standard`, `decorations = false`
+Initially, the display options are `format = :standard`, `decorations = false`
 and `sigdigits = 6`.
 
 If any of the three argument `format`, `decorations` and `sigdigits` is omitted,

--- a/src/display.jl
+++ b/src/display.jl
@@ -385,7 +385,8 @@ function supscript_digit(i::Integer)
     i == 6 && return "⁶"
     i == 7 && return "⁷"
     i == 8 && return "⁸"
-    return "⁹"
+    i == 9 && return "⁹"
+    return throw(DomainError(i, "supscript_digit only accept integers between 0 and 9 (included)"))
 end
 
 function subscript_digit(i::Integer)
@@ -398,5 +399,6 @@ function subscript_digit(i::Integer)
     i == 6 && return "₆"
     i == 7 && return "₇"
     i == 8 && return "₈"
-    return "₉"
+    i == 9 && return "₉"
+    return throw(DomainError(i, "subscript_digit only accept integers between 0 and 9 (included)"))
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -144,12 +144,6 @@ function show(io::IO, a::Union{Interval,Complex{<:Interval},DecoratedInterval,In
     return print(io, representation(a, :full))
 end
 
-showfull(io::IO, a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox}) =
-    print(io, representation(a, :full))
-
-showfull(a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox}) =
-    showfull(stdout, a)
-
 # `String` representation of various types of intervals
 
 representation(a::Interval, format::Symbol) = basic_representation(a, format)

--- a/src/display.jl
+++ b/src/display.jl
@@ -136,8 +136,13 @@ end
 
 # Printing mechanism for various types of intervals
 
-show(io::IO, a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox}) =
+show(io::IO, ::MIME"text/plain", a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox}) =
     print(io, representation(a, display_params.format))
+
+function show(io::IO, a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox})
+    get(io, :compact, false) && return print(io, representation(a, display_params.format))
+    return print(io, representation(a, :full))
+end
 
 showfull(io::IO, a::Union{Interval,Complex{<:Interval},DecoratedInterval,IntervalBox}) =
     print(io, representation(a, :full))
@@ -175,18 +180,20 @@ function representation(X::IntervalBox{N}, format::Symbol) where {N}
         isempty(X) && return string("IntervalBox(∅, ", N, ")")
         x = first(X)
         all(y -> x ≛ y, X) && return string("IntervalBox(", representation(x, format), ", ", N, ")")
-        full_str = representation.(X.v, :full)
-        return string("IntervalBox(", join(full_str, ", "), ")")
+        str = representation.(X.v, format)
+        return string("IntervalBox(", join(str, ", "), ")")
     elseif format === :midpoint
         isempty(X) && return string("∅", supscriptify(N))
         x = first(X)
         all(y -> x ≛ y, X) && return string("(", representation(x, format), ")", supscriptify(N))
-        return string("(", join(X.v, ") × ("), ")")
+        str = representation.(X.v, format)
+        return string("(", join(str, ") × ("), ")")
     else  # format === :standard
         isempty(X) && return string("∅", supscriptify(N))
         x = first(X)
         all(y -> x ≛ y, X) && return string(representation(x, format), supscriptify(N))
-        return join(X.v, " × ")
+        str = representation.(X.v, format)
+        return join(str, " × ")
     end
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,7 +1,7 @@
 mutable struct DisplayParameters
-    format :: Symbol
-    decorations :: Bool
-    sigdigits :: Int
+    format::Symbol
+    decorations::Bool
+    sigdigits::Int
 end
 
 function Base.show(io::IO, ::MIME"text/plain", params::DisplayParameters)

--- a/src/display.jl
+++ b/src/display.jl
@@ -106,17 +106,14 @@ Display parameters:
 julia> x
 Interval(0.09999999999999999, 0.30000000000000004)
 
-julia> y = DecoratedInterval(x)
-[0.0999, 0.301]
-
 julia> @format standard true 3  # Equivalent to `setformat(:standard; decorations = true, sigdigits = 3)`
 Display parameters:
   - format: standard
   - decorations: true
   - significant digits: 3
 
-julia> y
-[0.0999, 0.301]_com
+julia> x
+[0.0999, 0.301]
 ```
 """
 macro format(expr...)

--- a/src/display.jl
+++ b/src/display.jl
@@ -151,16 +151,35 @@ representation(a::Interval, format::Symbol) = basic_representation(a, format)
 function representation(a::Interval{T}, format::Symbol) where {T<:BigFloat}
     # `format` is either :standard, :midpoint or :full
     format === :standard && return string(basic_representation(a, format), subscriptify(precision(T)))
+    format === :midpoint && return string("(", basic_representation(a, format), ")", subscriptify(precision(T)))
     return basic_representation(a, format)
 end
 
 function representation(x::Complex{<:Interval}, format::Symbol)
     # `format` is either :standard, :midpoint or :full
-    format === :midpoint && return string("(", basic_representation(real(x), format), ") + (", basic_representation(imag(x), format), ")im")
-    return string(basic_representation(real(x), format), " + ", basic_representation(imag(x), format), "im")
+    format === :midpoint && return string("(", representation(real(x), format), ") + (", representation(imag(x), format), ")im")
+    return string(representation(real(x), format), " + ", representation(imag(x), format), "im")
+end
+
+# No extra brackets for `:midpoint` and `BigFloat`: the display of the precision add some
+function representation(x::Complex{Interval{BigFloat}}, format::Symbol)
+    # `format` is either :standard, :midpoint or :full
+    return string(representation(real(x), format), " + ", representation(imag(x), format), "im")
 end
 
 function representation(a::DecoratedInterval, format::Symbol)
+    # `format` is either :standard, :midpoint or :full
+    var_interval = representation(interval(a), format)
+    format === :full && return string("DecoratedInterval(", var_interval, ", ", decoration(a), ")")
+    if format === :midpoint  # Add extra brackets
+        var_interval = string("(", var_interval, ")")
+    end
+    display_params.decorations && return string(var_interval, "_", decoration(a))
+    return var_interval
+end
+
+# No extra brackets for `:midpoint` and `BigFloat`: the display of the precision add some
+function representation(a::DecoratedInterval{BigFloat}, format::Symbol)
     # `format` is either :standard, :midpoint or :full
     var_interval = representation(interval(a), format)
     format === :full && return string("DecoratedInterval(", var_interval, ", ", decoration(a), ")")

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -194,25 +194,25 @@ let x, b
     end
 end
 
-@testset "showfull" begin
+@testset "show" begin
     setformat(:standard; decorations = false, sigdigits = 6)
     setprecision(BigFloat, 128)
 
     x = 0..1
     @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]"
-    @test sprint(showfull, x) == "Interval(0.0, 1.0)"
+    @test sprint(show, x) == "Interval(0.0, 1.0)"
 
     x = @biginterval(0, 1)
     @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈"
-    @test sprint(showfull, x) == "Interval(0.0, 1.0)"
+    @test sprint(show, x) == "Interval(0.0, 1.0)"
 
     x = DecoratedInterval(0, 1, dac)
     @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]"
-    @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
+    @test sprint(show, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
 
     x = DecoratedInterval(big(0), big(1), def)
     @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈"
-    @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), def)"
+    @test sprint(show, x) == "DecoratedInterval(Interval(0.0, 1.0), def)"
 
     setformat(; decorations = true)
     @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈_def"
@@ -221,9 +221,9 @@ end
     b = IntervalBox(emptyinterval(), 2)
     c = IntervalBox(1..2, 1)
 
-    @test sprint(showfull, a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
-    @test sprint(showfull, b) == "IntervalBox(∅, 2)"
-    @test sprint(showfull, c) == "IntervalBox(Interval(1.0, 2.0), 1)"
+    @test sprint(show, a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
+    @test sprint(show, b) == "IntervalBox(∅, 2)"
+    @test sprint(show, c) == "IntervalBox(Interval(1.0, 2.0), 1)"
 
 end
 

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -13,188 +13,184 @@ let x, b
         @testset "6 significant digits" begin
             setformat(:standard; sigdigits = 6)
 
-            @test string(a) == "[1.0, 2.0]"
-            @test string(b) == "[-1.10001, 1.30001]"
-            @test string(c) == "[3.14159, 3.1416]"
-            @test string(large_expo) == "[-∞, -5.87565e+1388255822130839282]₂₅₆"
+            @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]"
+            @test sprint(show, MIME("text/plain"), b) == "[-1.10001, 1.30001]"
+            @test sprint(show, MIME("text/plain"), c) == "[3.14159, 3.1416]"
+            @test sprint(show, MIME("text/plain"), large_expo) ==
+                "[-∞, -5.87565e+1388255822130839282]₂₅₆"
         end
 
         @testset "10 significant digits" begin
             setformat(; sigdigits = 10)
 
-            @test string(a) == "[1.0, 2.0]"
-            @test string(b) == "[-1.100000001, 1.300000001]"
-            @test string(c) == "[3.141592653, 3.141592654]"
-            @test string(large_expo) == "[-∞, -5.875653789e+1388255822130839282]₂₅₆"
+            @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]"
+            @test sprint(show, MIME("text/plain"), b) == "[-1.100000001, 1.300000001]"
+            @test sprint(show, MIME("text/plain"), c) == "[3.141592653, 3.141592654]"
+            @test sprint(show, MIME("text/plain"), large_expo) ==
+                "[-∞, -5.875653789e+1388255822130839282]₂₅₆"
         end
 
         @testset "20 significant digits" begin
             setformat(; sigdigits = 20)
 
-            @test string(a) == "[1.0, 2.0]"
-            @test string(b) == "[-1.1000000000000000889, 1.3000000000000000445]"
-            @test string(c) == "[3.1415926535897931159, 3.1415926535897935601]"
-            @test string(large_expo) == "[-∞, -5.8756537891115875909e+1388255822130839282]₂₅₆"
+            @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]"
+            @test sprint(show, MIME("text/plain"), b) == "[-1.1000000000000000889, 1.3000000000000000445]"
+            @test sprint(show, MIME("text/plain"), c) == "[3.1415926535897931159, 3.1415926535897935601]"
+            @test sprint(show, MIME("text/plain"), large_expo) ==
+                "[-∞, -5.8756537891115875909e+1388255822130839282]₂₅₆"
         end
 
         @testset "Full" begin
             setformat(:full)
 
-            @test string(a) == "Interval(1.0, 2.0)"
-            @test string(b) == "Interval(-1.1, 1.3)"
-            @test string(c) == "Interval(3.141592653589793, 3.1415926535897936)"
-            @test string(large_expo) ==
+            @test sprint(show, MIME("text/plain"), a) == "Interval(1.0, 2.0)"
+            @test sprint(show, MIME("text/plain"), b) == "Interval(-1.1, 1.3)"
+            @test sprint(show, MIME("text/plain"), c) == "Interval(3.141592653589793, 3.1415926535897936)"
+            @test sprint(show, MIME("text/plain"), large_expo) ==
                 "Interval(-Inf, -5.875653789111587590936911998878442589938516392745498308333779606469323584389875e+1388255822130839282)"
         end
 
         @testset "Midpoint" begin
             setformat(:midpoint; sigdigits = 6)
 
-            @test string(a) == "1.5 ± 0.5"
-            @test string(b) == "0.1 ± 1.20001"
-            @test string(c) == "3.14159 ± 4.4409e-16"
-            @test string(large_expo) == "-5.87565e+1388255822130839282 ± ∞"
+            @test sprint(show, MIME("text/plain"), a) == "1.5 ± 0.5"
+            @test sprint(show, MIME("text/plain"), b) == "0.1 ± 1.20001"
+            @test sprint(show, MIME("text/plain"), c) == "3.14159 ± 4.4409e-16"
+            @test sprint(show, MIME("text/plain"), large_expo) == "-5.87565e+1388255822130839282 ± ∞"
 
             # issue 175:
-            @test string(@biginterval(1, 2)) == "1.5 ± 0.5"
+            @test sprint(show, MIME("text/plain"), @biginterval(1, 2)) == "1.5 ± 0.5"
         end
     end
 
     @testset "Interval{Rational{T}}" begin
         a = Interval(1//3, 5//4)
-        @test_broken typeof(a)== Interval{Rational{Int}}
+        @test_broken typeof(a) == Interval{Rational{Int}}
+
         setformat(:standard)
-        @test_broken string(a) == "[1//3, 5//4]"
+        @test_broken sprint(show, MIME("text/plain"), a) == "[1//3, 5//4]"
 
         setformat(:full)
-        @test_broken string(a) == "Interval(1//3, 5//4)"
+        @test_broken sprint(show, MIME("text/plain"), a) == "Interval(1//3, 5//4)"
 
         setformat(:midpoint)
-        @test_broken string(a) == "19//24 ± 11//24"
+        @test_broken sprint(show, MIME("text/plain"), a) == "19//24 ± 11//24"
     end
 
     @testset "Interval{Float32}" begin
         a = Interval{Float32}(1, 2)
         b = Interval{Float32}(-1, Inf)
+
         setformat(:standard)
-        @test string(a) == "[1.0f0, 2.0f0]"
-        @test string(b) == "[-1.0f0, ∞]"
+        @test sprint(show, MIME("text/plain"), a) == "[1.0f0, 2.0f0]"
+        @test sprint(show, MIME("text/plain"), b) == "[-1.0f0, ∞]"
 
         setformat(:full)
-        @test string(a) == "Interval(1.0f0, 2.0f0)"
-        @test string(b) == "Interval(-1.0f0, ∞)"
+        @test sprint(show, MIME("text/plain"), a) == "Interval(1.0f0, 2.0f0)"
+        @test sprint(show, MIME("text/plain"), b) == "Interval(-1.0f0, ∞)"
 
         setformat(:midpoint)
-        @test string(a) == "1.5f0 ± 0.5f0"
+        @test sprint(show, MIME("text/plain"), a) == "1.5f0 ± 0.5f0"
     end
 
     @testset "Complex{Interval}" begin
         a = Complex(Interval(0, 2), Interval(1))
         @test typeof(a) == Complex{Interval{Float64}}
+
         setformat(:standard)
-        @test string(a) == "[0.0, 2.0] + [1.0, 1.0]im"
+        @test sprint(show, MIME("text/plain"), a) == "[0.0, 2.0] + [1.0, 1.0]im"
 
         setformat(:midpoint)
-        @test string(a) == "(1.0 ± 1.0) + (1.0 ± 0.0)im"
+        @test sprint(show, MIME("text/plain"), a) == "(1.0 ± 1.0) + (1.0 ± 0.0)im"
     end
 
     setprecision(BigFloat, 256)
 
     @testset "DecoratedInterval" begin
         a = @decorated(1, 2)
-        @test typeof(a)== DecoratedInterval{Float64}
+        @test typeof(a) == DecoratedInterval{Float64}
 
         setformat(:standard; decorations = false)
-        @test string(a) == "[1.0, 2.0]"
+        @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]"
 
         setformat(; decorations = true)
-        @test string(a) == "[1.0, 2.0]_com"
+        @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]_com"
 
         # issue 131:
         a = DecoratedInterval(big(2), big(3), com)
 
         setformat(; decorations = false)
-        @test string(a) == "[2.0, 3.0]₂₅₆"
+        @test sprint(show, MIME("text/plain"), a) == "[2.0, 3.0]₂₅₆"
 
         setformat(; decorations = true)
-        @test string(a) == "[2.0, 3.0]₂₅₆_com"
+        @test sprint(show, MIME("text/plain"), a) == "[2.0, 3.0]₂₅₆_com"
 
         setformat(:full)
-        @test string(a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
+        @test sprint(show, MIME("text/plain"), a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
 
         setformat(:midpoint)
-        @test string(a) == "2.5 ± 0.5_com"
+        @test sprint(show, MIME("text/plain"), a) == "2.5 ± 0.5_com"
 
         setformat(; decorations = false)
-        @test string(a) == "2.5 ± 0.5"
-
+        @test sprint(show, MIME("text/plain"), a) == "2.5 ± 0.5"
     end
 
     setprecision(BigFloat, 128)
 
     @testset "BigFloat intervals" begin
-        setformat(:standard; decorations = false)
-
         a = Interval(big(1))
         @test typeof(a) == Interval{BigFloat}
-        @test string(a) == "[1.0, 1.0]₁₂₈"
-
-        setformat(:full)
-        @test string(a) == "Interval(1.0, 1.0)"
-
-
-        a = DecoratedInterval(big(2), big(3), com)
-        @test typeof(a)== DecoratedInterval{BigFloat}
 
         setformat(:standard; decorations = false)
-        @test string(a) == "[2.0, 3.0]₁₂₈"
-
-        setformat(:standard; decorations = true)
-        @test string(a) == "[2.0, 3.0]₁₂₈_com"
+        @test sprint(show, MIME("text/plain"), a) == "[1.0, 1.0]₁₂₈"
 
         setformat(:full)
-        @test string(a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
+        @test sprint(show, MIME("text/plain"), a) == "Interval(1.0, 1.0)"
+
+        a = DecoratedInterval(big(2), big(3), com)
+        @test typeof(a) == DecoratedInterval{BigFloat}
+
+        setformat(:standard; decorations = false)
+        @test sprint(show, MIME("text/plain"), a) == "[2.0, 3.0]₁₂₈"
+
+        setformat(:standard; decorations = true)
+        @test sprint(show, MIME("text/plain"), a) == "[2.0, 3.0]₁₂₈_com"
+
+        setformat(:full)
+        @test sprint(show, MIME("text/plain"), a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
     end
 
     @testset "IntervalBox" begin
-        setformat(:standard; sigdigits = 6)
-
         X = IntervalBox(1..2, 3..4)
         @test typeof(X) == IntervalBox{2,Float64}
-        @test string(X) == "[1.0, 2.0] × [3.0, 4.0]"
 
-        s = sprint(show, MIME("text/plain"), X)
-        @test s == "[1.0, 2.0] × [3.0, 4.0]"
-
+        setformat(:standard; sigdigits = 6)
+        @test sprint(show, MIME("text/plain"), X) == "[1.0, 2.0] × [3.0, 4.0]"
         X = IntervalBox(1.1..1.2, 2.1..2.2)
-        @test string(X) == "[1.09999, 1.20001] × [2.09999, 2.20001]"
-
+        @test sprint(show, MIME("text/plain"), X) == "[1.09999, 1.20001] × [2.09999, 2.20001]"
         X = IntervalBox(-Inf..Inf, -Inf..Inf)
-        @test string(X) == "[-∞, ∞]²"
+        @test sprint(show, MIME("text/plain"), X) == "[-∞, ∞]²"
 
         setformat(:full)
-        @test string(X) == "IntervalBox(Interval(-Inf, Inf), 2)"
-
+        @test sprint(show, MIME("text/plain"), X) == "IntervalBox(Interval(-Inf, Inf), 2)"
 
         setformat(:standard)
         a = IntervalBox(1..2, 2..3)
-        @test string(a) == "[1.0, 2.0] × [2.0, 3.0]"
-
+        @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0] × [2.0, 3.0]"
         b = IntervalBox(emptyinterval(), 2)
-        @test string(b) == "∅²"
-
+        @test sprint(show, MIME("text/plain"), b) == "∅²"
         c = IntervalBox(1..2, 1)
-        @test string(c) == "[1.0, 2.0]¹"
+        @test sprint(show, MIME("text/plain"), c) == "[1.0, 2.0]¹"
 
         setformat(:full)
-        @test string(a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
-        @test string(b) == "IntervalBox(∅, 2)"
-        @test string(c) == "IntervalBox(Interval(1.0, 2.0), 1)"
+        @test sprint(show, MIME("text/plain"), a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
+        @test sprint(show, MIME("text/plain"), b) == "IntervalBox(∅, 2)"
+        @test sprint(show, MIME("text/plain"), c) == "IntervalBox(Interval(1.0, 2.0), 1)"
 
         setformat(:midpoint)
-        @test string(a) == "(1.5 ± 0.5) × (2.5 ± 0.5)"
-        @test string(b) == "∅²"
-        @test string(c) == "(1.5 ± 0.5)¹"
+        @test sprint(show, MIME("text/plain"), a) == "(1.5 ± 0.5) × (2.5 ± 0.5)"
+        @test sprint(show, MIME("text/plain"), b) == "∅²"
+        @test sprint(show, MIME("text/plain"), c) == "(1.5 ± 0.5)¹"
     end
 end
 
@@ -203,23 +199,23 @@ end
     setprecision(BigFloat, 128)
 
     x = 0..1
-    @test string(x) == "[0.0, 1.0]"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]"
     @test sprint(showfull, x) == "Interval(0.0, 1.0)"
 
     x = @biginterval(0, 1)
-    @test string(x) == "[0.0, 1.0]₁₂₈"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈"
     @test sprint(showfull, x) == "Interval(0.0, 1.0)"
 
     x = DecoratedInterval(0, 1, dac)
-    @test string(x) == "[0.0, 1.0]"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]"
     @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
 
     x = DecoratedInterval(big(0), big(1), def)
-    @test string(x) == "[0.0, 1.0]₁₂₈"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈"
     @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), def)"
 
     setformat(; decorations = true)
-    @test string(x) == "[0.0, 1.0]₁₂₈_def"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0, 1.0]₁₂₈_def"
 
     a = IntervalBox(1..2, 2..3)
     b = IntervalBox(emptyinterval(), 2)
@@ -235,13 +231,13 @@ end
     x = prevfloat(0.1)..nextfloat(0.3)
 
     @format full
-    @test string(x) == "Interval(0.09999999999999999, 0.30000000000000004)"
+    @test sprint(show, MIME("text/plain"), x) == "Interval(0.09999999999999999, 0.30000000000000004)"
 
     @format standard 3
-    @test string(x) == "[0.0999, 0.301]"
+    @test sprint(show, MIME("text/plain"), x) == "[0.0999, 0.301]"
 
     @format standard 10
-    @test string(x) == "[0.09999999999, 0.3000000001]"
+    @test sprint(show, MIME("text/plain"), x) == "[0.09999999999, 0.3000000001]"
 end
 
 setprecision(BigFloat, 256)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -8,6 +8,7 @@ let x, b
         a = 1..2
         b = -1.1..1.3
         c = Interval(pi)
+        large_expo = IntervalArithmetic.atomic(Interval{BigFloat}, -Inf)
 
         @testset "6 significant digits" begin
             setformat(:standard; sigdigits = 6)
@@ -15,6 +16,7 @@ let x, b
             @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.10001, 1.30001]"
             @test string(c) == "[3.14159, 3.1416]"
+            @test string(large_expo) == "[-∞, -5.87565e+1388255822130839282]₂₅₆"
         end
 
         @testset "10 significant digits" begin
@@ -23,6 +25,7 @@ let x, b
             @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.100000001, 1.300000001]"
             @test string(c) == "[3.141592653, 3.141592654]"
+            @test string(large_expo) == "[-∞, -5.875653789e+1388255822130839282]₂₅₆"
         end
 
         @testset "20 significant digits" begin
@@ -31,6 +34,7 @@ let x, b
             @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.1000000000000000889, 1.3000000000000000445]"
             @test string(c) == "[3.1415926535897931159, 3.1415926535897935601]"
+            @test string(large_expo) == "[-∞, -5.8756537891115875909e+1388255822130839282]₂₅₆"
         end
 
         @testset "Full" begin
@@ -39,6 +43,8 @@ let x, b
             @test string(a) == "Interval(1.0, 2.0)"
             @test string(b) == "Interval(-1.1, 1.3)"
             @test string(c) == "Interval(3.141592653589793, 3.1415926535897936)"
+            @test string(large_expo) ==
+                "Interval(-Inf, -5.875653789111587590936911998878442589938516392745498308333779606469323584389875e+1388255822130839282)"
         end
 
         @testset "Midpoint" begin
@@ -47,6 +53,7 @@ let x, b
             @test string(a) == "1.5 ± 0.5"
             @test string(b) == "0.1 ± 1.20001"
             @test string(c) == "3.14159 ± 4.4409e-16"
+            @test string(large_expo) == "-5.87565e+1388255822130839282 ± ∞"
 
             # issue 175:
             @test string(@biginterval(1, 2)) == "1.5 ± 0.5"

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -58,10 +58,10 @@ let x, b
             @test sprint(show, MIME("text/plain"), a) == "1.5 ± 0.5"
             @test sprint(show, MIME("text/plain"), b) == "0.1 ± 1.20001"
             @test sprint(show, MIME("text/plain"), c) == "3.14159 ± 4.4409e-16"
-            @test sprint(show, MIME("text/plain"), large_expo) == "5.0e+123456788 ± 5.00001e+123456788"
+            @test sprint(show, MIME("text/plain"), large_expo) == "(5.0e+123456788 ± 5.00001e+123456788)₂₅₆"
 
             # issue 175:
-            @test sprint(show, MIME("text/plain"), @biginterval(1, 2)) == "1.5 ± 0.5"
+            @test sprint(show, MIME("text/plain"), @biginterval(1, 2)) == "(1.5 ± 0.5)₂₅₆"
         end
     end
 
@@ -118,10 +118,13 @@ let x, b
         setformat(; decorations = true)
         @test sprint(show, MIME("text/plain"), a) == "[1.0, 2.0]_com"
 
+        setformat(:midpoint; decorations = true)
+        @test sprint(show, MIME("text/plain"), a) == "(1.5 ± 0.5)_com"
+
         # issue 131:
         a = DecoratedInterval(big(2), big(3), com)
 
-        setformat(; decorations = false)
+        setformat(:standard; decorations = false)
         @test sprint(show, MIME("text/plain"), a) == "[2.0, 3.0]₂₅₆"
 
         setformat(; decorations = true)
@@ -131,10 +134,10 @@ let x, b
         @test sprint(show, MIME("text/plain"), a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
 
         setformat(:midpoint)
-        @test sprint(show, MIME("text/plain"), a) == "2.5 ± 0.5_com"
+        @test sprint(show, MIME("text/plain"), a) == "(2.5 ± 0.5)₂₅₆_com"
 
         setformat(; decorations = false)
-        @test sprint(show, MIME("text/plain"), a) == "2.5 ± 0.5"
+        @test sprint(show, MIME("text/plain"), a) == "(2.5 ± 0.5)₂₅₆"
     end
 
     setprecision(BigFloat, 128)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -9,26 +9,26 @@ let x, b
         b = -1.1..1.3
         c = Interval(pi)
 
-        @testset "6 sig figs" begin
-            setformat(:standard, sigfigs=6)
+        @testset "6 significant digits" begin
+            setformat(:standard; sigdigits = 6)
 
-            @test string(a) == "[1, 2]"
+            @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.10001, 1.30001]"
             @test string(c) == "[3.14159, 3.1416]"
         end
 
-        @testset "10 sig figs" begin
-            setformat(sigfigs=10)
+        @testset "10 significant digits" begin
+            setformat(; sigdigits = 10)
 
-            @test string(a) == "[1, 2]"
+            @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.100000001, 1.300000001]"
             @test string(c) == "[3.141592653, 3.141592654]"
         end
 
-        @testset "20 sig figs" begin
-            setformat(sigfigs=20)
+        @testset "20 significant digits" begin
+            setformat(; sigdigits = 20)
 
-            @test string(a) == "[1, 2]"
+            @test string(a) == "[1.0, 2.0]"
             @test string(b) == "[-1.1000000000000000889, 1.3000000000000000445]"
             @test string(c) == "[3.1415926535897931159, 3.1415926535897935601]"
         end
@@ -42,7 +42,7 @@ let x, b
         end
 
         @testset "Midpoint" begin
-            setformat(:midpoint, sigfigs=6)
+            setformat(:midpoint; sigdigits = 6)
 
             @test string(a) == "1.5 ± 0.5"
             @test string(b) == "0.1 ± 1.20001"
@@ -70,8 +70,8 @@ let x, b
         a = Interval{Float32}(1, 2)
         b = Interval{Float32}(-1, Inf)
         setformat(:standard)
-        @test string(a) == "[1f0, 2f0]"
-        @test string(b) == "[-1f0, ∞]"
+        @test string(a) == "[1.0f0, 2.0f0]"
+        @test string(b) == "[-1.0f0, ∞]"
 
         setformat(:full)
         @test string(a) == "Interval(1.0f0, 2.0f0)"
@@ -81,17 +81,15 @@ let x, b
         @test string(a) == "1.5f0 ± 0.5f0"
     end
 
-    #= # TODO uncomment when Complex support is restored
     @testset "Complex{Interval}" begin
-        a = Complex(Interval(0, 2), 1)
+        a = Complex(Interval(0, 2), Interval(1))
         @test typeof(a) == Complex{Interval{Float64}}
         setformat(:standard)
-        @test string(a) == "[0, 2] + [1, 1]im"
+        @test string(a) == "[0.0, 2.0] + [1.0, 1.0]im"
 
         setformat(:midpoint)
-        @test string(a) == "(1 ± 1) + (1 ± 0)im"
+        @test string(a) == "(1.0 ± 1.0) + (1.0 ± 0.0)im"
     end
-    =#
 
     setprecision(BigFloat, 256)
 
@@ -99,20 +97,20 @@ let x, b
         a = @decorated(1, 2)
         @test typeof(a)== DecoratedInterval{Float64}
 
-        setformat(:standard, decorations=false)
-        @test string(a) == "[1, 2]"
+        setformat(:standard; decorations = false)
+        @test string(a) == "[1.0, 2.0]"
 
-        setformat(:standard, decorations=true)
-        @test string(a) == "[1, 2]_com"
+        setformat(; decorations = true)
+        @test string(a) == "[1.0, 2.0]_com"
 
         # issue 131:
         a = DecoratedInterval(big(2), big(3), com)
 
-        setformat(:standard, decorations=false)
-        @test string(a) == "[2, 3]₂₅₆"
+        setformat(; decorations = false)
+        @test string(a) == "[2.0, 3.0]₂₅₆"
 
-        setformat(decorations=true)
-        @test string(a) == "[2, 3]₂₅₆_com"
+        setformat(; decorations = true)
+        @test string(a) == "[2.0, 3.0]₂₅₆_com"
 
         setformat(:full)
         @test string(a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
@@ -120,7 +118,7 @@ let x, b
         setformat(:midpoint)
         @test string(a) == "2.5 ± 0.5_com"
 
-        setformat(decorations=false)
+        setformat(; decorations = false)
         @test string(a) == "2.5 ± 0.5"
 
     end
@@ -128,11 +126,11 @@ let x, b
     setprecision(BigFloat, 128)
 
     @testset "BigFloat intervals" begin
-        setformat(:standard, decorations=false)
+        setformat(:standard; decorations = false)
 
         a = Interval(big(1))
         @test typeof(a) == Interval{BigFloat}
-        @test string(a) == "[1, 1]₁₂₈"
+        @test string(a) == "[1.0, 1.0]₁₂₈"
 
         setformat(:full)
         @test string(a) == "Interval(1.0, 1.0)"
@@ -141,28 +139,28 @@ let x, b
         a = DecoratedInterval(big(2), big(3), com)
         @test typeof(a)== DecoratedInterval{BigFloat}
 
-        setformat(:standard, decorations=false)
-        @test string(a) == "[2, 3]₁₂₈"
+        setformat(:standard; decorations = false)
+        @test string(a) == "[2.0, 3.0]₁₂₈"
 
-        setformat(:standard, decorations=true)
-        @test string(a) == "[2, 3]₁₂₈_com"
+        setformat(:standard; decorations = true)
+        @test string(a) == "[2.0, 3.0]₁₂₈_com"
 
         setformat(:full)
         @test string(a) == "DecoratedInterval(Interval(2.0, 3.0), com)"
     end
 
     @testset "IntervalBox" begin
-        setformat(:standard, sigfigs=6)
+        setformat(:standard; sigdigits = 6)
 
         X = IntervalBox(1..2, 3..4)
         @test typeof(X) == IntervalBox{2,Float64}
-        @test string(X) == "[1, 2] × [3, 4]"
+        @test string(X) == "[1.0, 2.0] × [3.0, 4.0]"
 
         s = sprint(show, MIME("text/plain"), X)
-        @test s == "[1, 2] × [3, 4]"
+        @test s == "[1.0, 2.0] × [3.0, 4.0]"
 
         X = IntervalBox(1.1..1.2, 2.1..2.2)
-        @test string(X) == "[1.1, 1.2] × [2.1, 2.20001]"
+        @test string(X) == "[1.09999, 1.20001] × [2.09999, 2.20001]"
 
         X = IntervalBox(-Inf..Inf, -Inf..Inf)
         @test string(X) == "[-∞, ∞]²"
@@ -173,13 +171,13 @@ let x, b
 
         setformat(:standard)
         a = IntervalBox(1..2, 2..3)
-        @test string(a) == "[1, 2] × [2, 3]"
+        @test string(a) == "[1.0, 2.0] × [2.0, 3.0]"
 
         b = IntervalBox(emptyinterval(), 2)
         @test string(b) == "∅²"
 
         c = IntervalBox(1..2, 1)
-        @test string(c) == "[1, 2]¹"
+        @test string(c) == "[1.0, 2.0]¹"
 
         setformat(:full)
         @test string(a) == "IntervalBox(Interval(1.0, 2.0), Interval(2.0, 3.0))"
@@ -194,27 +192,27 @@ let x, b
 end
 
 @testset "showfull" begin
-    setformat(:standard, decorations=false, sigfigs=6)
+    setformat(:standard; decorations = false, sigdigits = 6)
     setprecision(BigFloat, 128)
 
     x = 0..1
-    @test string(x) == "[0, 1]"
+    @test string(x) == "[0.0, 1.0]"
     @test sprint(showfull, x) == "Interval(0.0, 1.0)"
 
     x = @biginterval(0, 1)
-    @test string(x) == "[0, 1]₁₂₈"
+    @test string(x) == "[0.0, 1.0]₁₂₈"
     @test sprint(showfull, x) == "Interval(0.0, 1.0)"
 
     x = DecoratedInterval(0, 1, dac)
-    @test string(x) == "[0, 1]"
+    @test string(x) == "[0.0, 1.0]"
     @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), dac)"
 
     x = DecoratedInterval(big(0), big(1), def)
-    @test string(x) == "[0, 1]₁₂₈"
+    @test string(x) == "[0.0, 1.0]₁₂₈"
     @test sprint(showfull, x) == "DecoratedInterval(Interval(0.0, 1.0), def)"
 
-    setformat(decorations=true)
-    @test string(x) == "[0, 1]₁₂₈_def"
+    setformat(; decorations = true)
+    @test string(x) == "[0.0, 1.0]₁₂₈_def"
 
     a = IntervalBox(1..2, 2..3)
     b = IntervalBox(emptyinterval(), 2)

--- a/test/display_tests/display.jl
+++ b/test/display_tests/display.jl
@@ -8,7 +8,9 @@ let x, b
         a = 1..2
         b = -1.1..1.3
         c = Interval(pi)
-        large_expo = IntervalArithmetic.atomic(Interval{BigFloat}, -Inf)
+        # large_expo = IntervalArithmetic.atomic(Interval{BigFloat}, -Inf)
+        # Use smaller exponent, cf. JuliaLang/julia#48678
+        large_expo = Interval(0, big"1e123456789")
 
         @testset "6 significant digits" begin
             setformat(:standard; sigdigits = 6)
@@ -17,7 +19,7 @@ let x, b
             @test sprint(show, MIME("text/plain"), b) == "[-1.10001, 1.30001]"
             @test sprint(show, MIME("text/plain"), c) == "[3.14159, 3.1416]"
             @test sprint(show, MIME("text/plain"), large_expo) ==
-                "[-∞, -5.87565e+1388255822130839282]₂₅₆"
+                "[0.0, 1.00001e+123456789]₂₅₆"
         end
 
         @testset "10 significant digits" begin
@@ -27,7 +29,7 @@ let x, b
             @test sprint(show, MIME("text/plain"), b) == "[-1.100000001, 1.300000001]"
             @test sprint(show, MIME("text/plain"), c) == "[3.141592653, 3.141592654]"
             @test sprint(show, MIME("text/plain"), large_expo) ==
-                "[-∞, -5.875653789e+1388255822130839282]₂₅₆"
+                "[0.0, 1.000000001e+123456789]₂₅₆"
         end
 
         @testset "20 significant digits" begin
@@ -37,7 +39,7 @@ let x, b
             @test sprint(show, MIME("text/plain"), b) == "[-1.1000000000000000889, 1.3000000000000000445]"
             @test sprint(show, MIME("text/plain"), c) == "[3.1415926535897931159, 3.1415926535897935601]"
             @test sprint(show, MIME("text/plain"), large_expo) ==
-                "[-∞, -5.8756537891115875909e+1388255822130839282]₂₅₆"
+                "[0.0, 1.0000000000000000001e+123456789]₂₅₆"
         end
 
         @testset "Full" begin
@@ -47,7 +49,7 @@ let x, b
             @test sprint(show, MIME("text/plain"), b) == "Interval(-1.1, 1.3)"
             @test sprint(show, MIME("text/plain"), c) == "Interval(3.141592653589793, 3.1415926535897936)"
             @test sprint(show, MIME("text/plain"), large_expo) ==
-                "Interval(-Inf, -5.875653789111587590936911998878442589938516392745498308333779606469323584389875e+1388255822130839282)"
+                "Interval(0.0, 1.000000000000000000000000000000000000000000000000000000000000000000000000000004e+123456789)"
         end
 
         @testset "Midpoint" begin
@@ -56,7 +58,7 @@ let x, b
             @test sprint(show, MIME("text/plain"), a) == "1.5 ± 0.5"
             @test sprint(show, MIME("text/plain"), b) == "0.1 ± 1.20001"
             @test sprint(show, MIME("text/plain"), c) == "3.14159 ± 4.4409e-16"
-            @test sprint(show, MIME("text/plain"), large_expo) == "-5.87565e+1388255822130839282 ± ∞"
+            @test sprint(show, MIME("text/plain"), large_expo) == "5.0e+123456788 ± 5.00001e+123456788"
 
             # issue 175:
             @test sprint(show, MIME("text/plain"), @biginterval(1, 2)) == "1.5 ± 0.5"


### PR DESCRIPTION
Over the week-end I experimented with the printing mechanism of the 1.0-dev branch. This is the resulting PR 🙂.

Fix #316, #434.

It seems that the alignment issue when printing arrays is linked to the fact that `Interval <: Real` and sometimes the bounds of the intervals are printed with no decimal points. The current behaviour (before this PR) relies on the format `"%.g"` which gives the shortest form for a given number (e.g. `1.0` would be returned as `1`).

So this would explain also why `IntervalBox` had no printing issues: it is not a subtype of `Real`.

In this PR I tried to stay as close as possible to the current behaviour, so the only **visual change** is that exact integers are displayed with a trailing decimal point and 0, for instance `1` is printed as `1.0`.
I have modified the tests to comply with this change.

Before this PR:

```julia
julia> M = [1.2..1.6 1.2..1.6; -1..1 -1..1]  # format === :standard
2×2 Matrix{Interval{Float64}}:
      [1.19999, 1.60001]       [1.19999, 1.60001]
 [-1, 1]                  [-1, 1]

julia> M = [1.2..1.6 1.2..1.6; -1..1 -1..1]  # format === :midpoint
2×2 Matrix{Interval{Float64}}:
     1.4 ± 0.200001      1.4 ± 0.200001
 0 ± 1               0 ± 1
```

After this PR:

```julia
julia> M = [1.2..1.6 1.2..1.6; -1..1 -1..1]  # format === :standard
2×2 Matrix{Interval{Float64}}:
  [1.19999, 1.60001]   [1.19999, 1.60001] # expected shift to the right to account for potential minus signs `-`
 [-1.0, 1.0]          [-1.0, 1.0]

julia> M = [1.2..1.6 1.2..1.6; -1..1 -1..1]  # format === :midpoint
2×2 Matrix{Interval{Float64}}:
 1.4 ± 0.200001  1.4 ± 0.200001
 0.0 ± 1.0       0.0 ± 1.0
```

### Other changes

- There was only one test which did not pass but I think it is wrong.
Before this PR:
```julia
string(2.1..2.2) == [2.1, 2.20001]   # seems wrong, no?
```
After this PR:
```julia
string(2.1..2.2) == [2.09999, 2.20001]
```

- I uncommented some tests for `Complex{<:Interval}`, they pass successfully. In the file changelog.md, it is mentioned that support for `Complex{<:Interval}` is dropped 🙁. However, there are still existing functionalities for `Complex{<:Interval}` on this branch and the display tests pass without extra work.

- Rename the keyword argument `sigfigs`  of `setformat` to `sigdigits` to match the naming convention of Julia (e.g. see the keywords of `round`).

- Fix all the inconsistencies where `==` was used instead of `===` (or `!=` instead of `!==`). In particular, use `===` to compare symbols.

- Improve performance of printing. For instance, faster `supscriptify` and `subscriptify` and `representation` is now type-stable.

For instance, before this PR:

```julia
julia> @btime IntervalArithmetic.subscriptify($8);
  135.643 ns (6 allocations: 352 bytes)

julia> @btime IntervalArithmetic.subscriptify($111);
  202.847 ns (7 allocations: 464 bytes)

julia> @btime IntervalArithmetic.supscriptify($8);
  148.988 ns (7 allocations: 448 bytes)

julia> @btime IntervalArithmetic.supscriptify($111);
  178.257 ns (7 allocations: 496 bytes)
```

After this PR:

```julia
julia> @btime IntervalArithmetic.supscriptify($8);  # Same timing for subscriptify
  3.666 ns (0 allocations: 0 bytes)

julia> @btime IntervalArithmetic.supscriptify($111);  # Same timing for subscriptify
  107.967 ns (4 allocations: 240 bytes)
```