### PR TITLE
Use `AbstractIrrational` instead of `Irrational`

### DIFF
--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -125,12 +125,12 @@ const Region{T} = Union{Interval{T}, IntervalBox{T}}
 
 # These definitions has been put there because generated functions must be
 # defined after all methods they use.
-@generated function Interval{T}(x::Irrational) where T
+@generated function Interval{T}(x::AbstractIrrational) where T
     res = atomic(Interval{T}, x())  # Precompute the interval
     return :(return $res)  # Set body of the function to return the precomputed result
 end
 
-Interval{BigFloat}(x::Irrational) = atomic(Interval{BigFloat}, x)
-Interval(x::Irrational) = Interval{Float64}(x)
+Interval{BigFloat}(x::AbstractIrrational) = atomic(Interval{BigFloat}, x)
+Interval(x::AbstractIrrational) = Interval{Float64}(x)
 
 end # module IntervalArithmetic

--- a/src/intervals/conversion.jl
+++ b/src/intervals/conversion.jl
@@ -83,7 +83,7 @@ atomic(::Type{Interval{T}}, x::AbstractString) where T<:AbstractFloat =
                      parse(T, string(x), RoundUp) )
     end
 
-    function atomic(::Type{Interval{T}}, x::Union{Irrational,Rational}) where {T<:AbstractFloat}
+    function atomic(::Type{Interval{T}}, x::Union{AbstractIrrational,Rational}) where {T<:AbstractFloat}
         isinf(x) && return wideinterval(T(x))
 
         Interval{T}( T(x, RoundDown), T(x, RoundUp) )
@@ -116,7 +116,7 @@ function atomic(::Type{Interval{T}}, x::S) where {T<:AbstractFloat, S<:AbstractF
     return atomic(Interval{T}, xrat)
 end
 
-atomic(::Type{Interval{Irrational{T}}}, x::Irrational{S}) where {T, S} =
+atomic(::Type{Interval{T}}, x::S) where {T<:AbstractIrrational, S<:AbstractIrrational} =
     float(atomic(Interval{Float64}, x))
 
 function atomic(::Type{Interval{T}}, x::Interval) where T<:AbstractFloat
@@ -129,12 +129,12 @@ atomic(::Type{Interval{T}}, x::Complex{Bool}) where T<:AbstractFloat =
 
 
 # Rational intervals
-function atomic(::Type{Interval{Rational{Int}}}, x::Irrational)
+function atomic(::Type{Interval{Rational{Int}}}, x::AbstractIrrational)
     a = float(atomic(Interval{BigFloat}, x))
     atomic(Interval{Rational{Int}}, a)
 end
 
-function atomic(::Type{Interval{Rational{BigInt}}}, x::Irrational)
+function atomic(::Type{Interval{Rational{BigInt}}}, x::AbstractIrrational)
     a = atomic(Interval{BigFloat}, x)
     atomic(Interval{Rational{BigInt}}, a)
 end

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -53,16 +53,16 @@ Interval(a::T, b::S) where {T<:Real, S<:Real} = Interval(promote(a,b)...)
 # BigFloat or Rational{Integer} intervals.
 Interval(a::T, b::T) where T<:Integer = Interval(float(a), float(b))
 
-# Constructors for Irrational
-# Single argument Irrational constructor are in IntervalArithmetic.jl
+# Constructors for AbstractIrrational
+# Single argument AbstractIrrational constructor are in IntervalArithmetic.jl
 # as generated functions need to be define last.
-Interval{T}(a::Irrational, b::Irrational) where {T<:Real} = Interval{T}(T(a, RoundDown), T(b, RoundUp))
-Interval{T}(a::Irrational, b::Real) where {T<:Real} = Interval{T}(T(a, RoundDown), b)
-Interval{T}(a::Real, b::Irrational) where {T<:Real} = Interval{T}(a, T(b, RoundUp))
+Interval{T}(a::AbstractIrrational, b::AbstractIrrational) where {T<:Real} = Interval{T}(T(a, RoundDown), T(b, RoundUp))
+Interval{T}(a::AbstractIrrational, b::Real) where {T<:Real} = Interval{T}(T(a, RoundDown), b)
+Interval{T}(a::Real, b::AbstractIrrational) where {T<:Real} = Interval{T}(a, T(b, RoundUp))
 
-Interval(a::Irrational, b::Irrational) = Interval{Float64}(a, b)
-Interval(a::Irrational, b::Real) = Interval{Float64}(a, b)
-Interval(a::Real, b::Irrational) = Interval{Float64}(a, b)
+Interval(a::AbstractIrrational, b::AbstractIrrational) = Interval{Float64}(a, b)
+Interval(a::AbstractIrrational, b::Real) = Interval{Float64}(a, b)
+Interval(a::Real, b::AbstractIrrational) = Interval{Float64}(a, b)
 
 Interval(x::Interval) = x
 Interval(x::Complex) = Interval(real(x)) + im*Interval(imag(x))
@@ -144,25 +144,25 @@ function ..(a::T, b::S) where {T, S}
     Interval(atomic(Interval{T}, a).lo, atomic(Interval{S}, b).hi)
 end
 
-function ..(a::T, b::Irrational{S}) where {T, S}
+function ..(a::T, b::S) where {T, S<:AbstractIrrational}
     if !is_valid_interval(a, b)
         @warn "Invalid input, empty interval is returned"
-        return emptyinterval(promote_type(T, Irrational{S}))
+        return emptyinterval(promote_type(T, S))
     end
-    R = promote_type(T, Irrational{S})
+    R = promote_type(T, S)
     Interval(atomic(Interval{R}, a).lo, R(b, RoundUp))
 end
 
-function ..(a::Irrational{T}, b::S) where {T, S}
+function ..(a::T, b::S) where {T<:AbstractIrrational, S}
     if !is_valid_interval(a, b)
         @warn "Invalid input, empty interval is returned"
-        return emptyinterval(promote_type(Irrational{T}, S))
+        return emptyinterval(promote_type(T, S))
     end
-    R = promote_type(Irrational{T}, S)
+    R = promote_type(T, S)
     return Interval(R(a, RoundDown), atomic(Interval{R}, b).hi)
 end
 
-function ..(a::Irrational{T}, b::Irrational{S}) where {T, S}
+function ..(a::T, b::S) where {T<:AbstractIrrational, S<:AbstractIrrational}
     return interval(a, b)
 end
 


### PR DESCRIPTION
I was looking at usage of Irrational in packages (https://juliahub.com/ui/Search?q=Irrational&type=symbols&u=use&t=type), to estimate how breaking https://github.com/JuliaMath/IrrationalConstants.jl/pull/19 (motivated by https://github.com/JuliaLang/julia/issues/46531) will be. IntervalArithmetic showed up in the list of packages that define methods for `Irrational` but it seems the definitions could be generalized to support `AbstractIrrational`.