### PR TITLE
1.0-dev: Enforce the bounds of `Interval` to be a `Rational` or  an `AbstractFloat`

### DIFF
--- a/src/bisect.jl
+++ b/src/bisect.jl
@@ -1,4 +1,3 @@
-
 const where_bisect = 0.49609375
 
 """
@@ -59,7 +58,7 @@ Splits `x` in `n` intervals in each dimension of the same diameter. These
 intervals are combined in all possible `IntervalBox`-es, which are returned
 as a vector.
 """
-@generated function mince(x::IntervalBox{N,T}, n) where {N,T}
+@generated function mince(x::IntervalBox{N,T}, n) where {N,T<:NumTypes}
     quote
         nodes_matrix = Array{Interval{T},2}(undef, n, N)
         for i in 1:N

--- a/src/decorations/intervals.jl
+++ b/src/decorations/intervals.jl
@@ -26,7 +26,7 @@ a flag that records the status of the interval when thought of as the result
 of a previously executed sequence of functions acting on an initial interval.
 """
 
-struct DecoratedInterval{T}
+struct DecoratedInterval{T<:NumTypes}
     interval::Interval{T}
     decoration::DECORATION
 end
@@ -34,9 +34,9 @@ end
 DecoratedInterval(I::DecoratedInterval, dec::DECORATION) = DecoratedInterval(I.interval, dec)
 
 function DecoratedInterval(a::T, b::S, d::DECORATION) where {T<:Real, S<:Real}
-    BoundsType = promote_numtype(T, S)
-    is_valid_interval(a, b) || return DecoratedInterval(Interval{BoundsType}(a, b), ill)
-    return DecoratedInterval(Interval{BoundsType}(a, b), d)
+    NumType = promote_numtype(T, S)
+    is_valid_interval(a, b) || return DecoratedInterval(Interval{NumType}(a, b), ill)
+    return DecoratedInterval(Interval{NumType}(a, b), d)
 end
 
 DecoratedInterval(a::Real, d::DECORATION) = DecoratedInterval(a, a, d)
@@ -49,12 +49,12 @@ function DecoratedInterval{T}(I::Interval) where {T}
     return DecoratedInterval{T}(I, d)
 end
 
-DecoratedInterval(I::Interval) = DecoratedInterval{default_bound()}(I)
+DecoratedInterval(I::Interval{T}) where {T<:NumTypes} = DecoratedInterval{T}(I)
 
 function DecoratedInterval(a::T, b::S) where {T<:Real, S<:Real}
-    BoundsType = promote_numtype(T, S)
-    is_valid_interval(a, b) || return DecoratedInterval(Interval{BoundsType}(a, b), ill)
-    return DecoratedInterval(Interval{BoundsType}(a, b))
+    NumType = promote_numtype(T, S)
+    is_valid_interval(a, b) || return DecoratedInterval(Interval{NumType}(a, b), ill)
+    return DecoratedInterval(Interval{NumType}(a, b))
 end
 
 DecoratedInterval(a::Real) = DecoratedInterval(a, a)

--- a/src/display.jl
+++ b/src/display.jl
@@ -212,7 +212,7 @@ end
 
 # `String` representation of an `Interval`
 
-function basic_representation(a::Interval{T}, format::Symbol) where {T}
+function basic_representation(a::Interval{T}, format::Symbol) where {T<:AbstractFloat}
     isempty(a) && return "∅"
     sigdigits = display_params.sigdigits
     if format === :full

--- a/src/intervals/arithmetic/basic.jl
+++ b/src/intervals/arithmetic/basic.jl
@@ -15,12 +15,12 @@
 
 Implement the `add` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function +(a::F, b::T) where {T, F<:Interval{T}}
+function +(a::F, b::T) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(F)
     return @round(F, inf(a) + b, sup(a) + b)
 end
-+(a::Interval{T}, b::Real) where {T} = a + interval(T, b)
-+(a::Real, b::Interval{T}) where {T} = b + a
++(a::Interval{T}, b::Real) where {T<:NumTypes} = a + interval(T, b)
++(a::Real, b::Interval{T}) where {T<:NumTypes} = b + a
 
 function +(a::F, b::F) where {F<:Interval}
     (isempty(a) || isempty(b)) && return emptyinterval(F)
@@ -42,16 +42,16 @@ Implement the `neg` function of the IEEE Std 1788-2015 (Table 9.1).
 
 Implement the `sub` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function -(a::F, b::T) where {T<:Real, F<:Interval{T}}
+function -(a::F, b::T) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(F)
     return @round(F, inf(a) - b, sup(a) - b)
 end
-function -(b::T, a::F) where {T, F<:Interval{T}}
+function -(b::T, a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(F)
     return @round(F, b - sup(a), b - inf(a))
 end
--(a::Interval{T}, b::Real) where {T} = a - interval(T, b)
--(a::Real, b::Interval{T}) where {T} = interval(T, a) - b
+-(a::Interval{T}, b::Real) where {T<:NumTypes} = a - interval(T, b)
+-(a::Real, b::Interval{T}) where {T<:NumTypes} = interval(T, a) - b
 
 function -(a::F, b::F) where {F<:Interval}
     (isempty(a) || isempty(b)) && return emptyinterval(F)
@@ -77,7 +77,7 @@ Implement the `mul` function of the IEEE Std 1788-2015 (Table 9.1).
 
 Note: the behavior of the multiplication is flavor dependent for some edge cases.
 """
-function *(a::F, b::T) where {T<:Real, F<:Interval{T}}
+function *(a::F, b::T) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(F)
     (isthinzero(a) || iszero(b)) && return zero(F)
 
@@ -87,8 +87,8 @@ function *(a::F, b::T) where {T<:Real, F<:Interval{T}}
         return @round(F, sup(a)*b, inf(a)*b)
     end
 end
-*(a::Interval{T}, b::Real) where {T} = a * interval(T, b)
-*(a::Real, b::Interval{T}) where {T} = b * a
+*(a::Interval{T}, b::Real) where {T<:NumTypes} = a * interval(T, b)
+*(a::Real, b::Interval{T}) where {T<:NumTypes} = b * a
 
 function *(a::F, b::F) where {F<:Interval}
     (isempty(a) || isempty(b)) && return emptyinterval(F)
@@ -99,13 +99,13 @@ end
 *(a::Interval, b::Interval) = *(promote(a, b)...)
 
 # Helper functions for multiplication
-function unbounded_mult(::Type{F}, x::T, y::T, r::RoundingMode) where {T, F<:Interval{T}}
+function unbounded_mult(::Type{F}, x::T, y::T, r::RoundingMode) where {T<:NumTypes,F<:Interval{T}}
     iszero(x) && return sign(y) * zero_times_infinity(T)
     iszero(y) && return sign(x) * zero_times_infinity(T)
     return *(x, y, r)
 end
 
-function mult(op, a::F, b::F) where {T, F<:Interval{T}}
+function mult(op, a::F, b::F) where {T<:NumTypes,F<:Interval{T}}
     if inf(b) >= zero(T)
         inf(a) >= zero(T) && return @round(F, op(inf(a), inf(b)), op(sup(a), sup(b)))
         sup(a) <= zero(T) && return @round(F, op(inf(a), sup(b)), op(sup(a), inf(b)))
@@ -131,7 +131,7 @@ Implement the `div` function of the IEEE Std 1788-2015 (Table 9.1).
 
 Note: the behavior of the division is flavor dependent for some edge cases.
 """
-function /(a::F, b::Real) where {F<:Interval}
+function /(a::F, b::T) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(T)
     iszero(b) && return div_by_thin_zero(a)
 
@@ -142,9 +142,11 @@ function /(a::F, b::Real) where {F<:Interval}
     end
 end
 
+/(a::Interval{T}, b::Real) where {T<:NumTypes} = a / interval(T, b)
+
 /(a::Real, b::Interval) = a * inv(b)
 
-function /(a::F, b::F) where {T, F<:Interval{T}}
+function /(a::F, b::F) where {T<:NumTypes,F<:Interval{T}}
     (isempty(a) || isempty(b)) && return emptyinterval(F)
     isthinzero(b) && return div_by_thin_zero(a)
 
@@ -186,7 +188,7 @@ Implement the `recip` function of the IEEE Std 1788-2015 (Table 9.1).
 
 Note: the behavior of this function is flavor dependent for some edge cases.
 """
-function inv(a::F) where {T, F<:Interval{T}}
+function inv(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return emptyinterval(F)
 
     if zero(T) ∈ a
@@ -217,7 +219,7 @@ Fused multiply-add.
 
 Implement the `fma` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function fma(a::F, b::F, c::F) where {T, F<:Interval{T}}
+function fma(a::F, b::F, c::F) where {T<:NumTypes,F<:Interval{T}}
     (isempty(a) || isempty(b) || isempty(c)) && return emptyinterval(F)
 
     if isentire(a)

--- a/src/intervals/arithmetic/power.jl
+++ b/src/intervals/arithmetic/power.jl
@@ -120,11 +120,11 @@ end
 
 function ^(a::Interval{Rational{T}}, x::AbstractFloat) where {T<:Integer}
     a = Interval{Float64}(inf(a).num/inf(a).den, sup(a).num/sup(a).den)
-    return F(a^x)
+    return a^x
 end
 
 # Rational power
-function ^(a::F, x::Rational{R}) where {F<:Interval, R<:Integer}
+function ^(a::F, x::Rational{R}) where {F<:Interval,R<:Integer}
     p = x.num
     q = x.den
 
@@ -244,7 +244,7 @@ for f in (:exp2, :exp10, :cbrt)
 end
 
 for f in (:log, :log2, :log10)
-    @eval function ($f)(a::F) where {T, F<:Interval{T}}
+    @eval function ($f)(a::F) where {T<:NumTypes,F<:Interval{T}}
             domain = F(0, Inf)
             a = a ∩ domain
 
@@ -254,7 +254,7 @@ for f in (:log, :log2, :log10)
         end
 end
 
-function log1p(a::F) where {T, F<:Interval{T}}
+function log1p(a::F) where {T<:NumTypes,F<:Interval{T}}
     domain = F(-1, Inf)
     a = a ∩ domain
 
@@ -290,7 +290,7 @@ function nthroot(a::F, n::Integer) where {F<:Interval{BigFloat}}
     return interval(low , high)
 end
 
-function nthroot(a::F, n::Integer) where {T, F<:Interval{T}}
+function nthroot(a::F, n::Integer) where {T<:NumTypes,F<:Interval{T}}
     n == 1 && return a
     n == 2 && return sqrt(a)
 

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -7,10 +7,10 @@
 
 const halfpi = pi / 2.0
 
-half_pi(::Type{Interval{T}}) where {T} = scale(0.5, interval(T, π))
-two_pi(::Type{Interval{T}}) where {T} = scale(2, interval(T, π))
+half_pi(::Type{Interval{T}}) where {T<:NumTypes} = scale(0.5, interval(T, π))
+two_pi(::Type{Interval{T}}) where {T<:NumTypes} = scale(2, interval(T, π))
 
-function range_atan(::Type{F}) where {T, F<:Interval{T}}
+function range_atan(::Type{F}) where {T,F<:Interval{T}}
     temp = sup(interval(T, π))  # Using F(-π, π) converts -π to Float64 before Interval construction
     return F(-temp, temp)
 end
@@ -50,7 +50,7 @@ end
 
 Implement the `sin` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function sin(a::F) where {T, F<:Interval{T}}
+function sin(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     whole_range = F(-1, 1)
@@ -135,7 +135,7 @@ function sin(a::F) where {F<:Interval{Float64}}
     end
 end
 
-function sinpi(a::Interval{T}) where {T}
+function sinpi(a::Interval{T}) where {T<:NumTypes}
     isempty(a) && return a
     w = a * interval(T, π)
     return sin(w)
@@ -146,7 +146,7 @@ end
 
 Implement the `cos` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function cos(a::F) where {T, F<:Interval{T}}
+function cos(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     whole_range = F(-1, 1)
@@ -229,7 +229,7 @@ function cos(a::F) where {F<:Interval{Float64}}
     end
 end
 
-function cospi(a::Interval{T}) where T
+function cospi(a::Interval{T}) where {T<:NumTypes}
     isempty(a) && return a
     w = a * interval(T, π)
     return cos(w)
@@ -240,7 +240,7 @@ end
 
 Implement the `tan` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function tan(a::F) where {T, F<:Interval{T}}
+function tan(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     diam(a) > inf(interval(T, π)) && return entireinterval(a)
@@ -295,7 +295,7 @@ end
 
 Implement the `cot` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function cot(a::F) where {T, F<:Interval{T}}
+function cot(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     diam(a) > inf(interval(T, π)) && return entireinterval(a)
@@ -340,7 +340,7 @@ cot(a::F) where {F<:Interval{Float64}} = atomic(F, cot(big(a)))
 
 Implement the `sec` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function sec(a::F) where {T, F<:Interval{T}}
+function sec(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     diam(a) > inf(interval(T, π)) && return entireinterval(a)
@@ -379,7 +379,7 @@ sec(a::F) where {F<:Interval{Float64}} = atomic(F, sec(big(a)))
 
 Implement the `csc` function of the IEEE Std 1788-2015 (Table 9.1).
 """
-function csc(a::F) where {T, F<:Interval{T}}
+function csc(a::F) where {T<:NumTypes,F<:Interval{T}}
     isempty(a) && return a
 
     diam(a) > inf(interval(T, π)) && return entireinterval(a)
@@ -466,7 +466,7 @@ function atan(a::F) where {F<:Interval}
     return @round(F, atan(alo), atan(ahi))
 end
 
-function atan(y::Interval{T}, x::Interval{S}) where {T, S}
+function atan(y::Interval{T}, x::Interval{S}) where {T<:NumTypes,S<:NumTypes}
     F = Interval{promote_type(T, S)}
     (isempty(y) || isempty(x)) && return emptyinterval(F)
     return F(atan(big(y), big(x)))

--- a/src/intervals/complex.jl
+++ b/src/intervals/complex.jl
@@ -1,11 +1,10 @@
-
 for op in (:⊆, :⊂, :⪽)
-    @eval function $(op)(x::Complex{Interval{T}}, y::Complex{Interval{S}}) where {T, S}
+    @eval function $(op)(x::Complex{<:Interval}, y::Complex{<:Interval})
         return $(op)(real(x), real(y)) && $(op)(imag(x), imag(y))
     end
 end
 
-function ^(x::Complex{Interval{T}}, n::Integer) where {T}
+function ^(x::Complex{<:Interval}, n::Integer)
     if n < 0
         return inv(x)^n
     end
@@ -13,11 +12,11 @@ function ^(x::Complex{Interval{T}}, n::Integer) where {T}
     return Base.power_by_squaring(x, n)
 end
 
-function ^(x::Complex{Interval{T}}, y::Real) where {T}
+function ^(x::Complex{<:Interval}, y::Real)
     return exp(y*log(x))
 end
 
-function ^(x::Complex{Interval{T}}, y::Complex) where {T}
+function ^(x::Complex{<:Interval}, y::Complex)
     return exp(y*log(x))
 end
 
@@ -57,7 +56,7 @@ function sqrt_realpart(x::T, y::T,RND::RoundingMode) where T<:AbstractFloat
     ρ = ldexp(sqrt(ρ,RND),k) #sqrt((abs(z)+abs(x))/2) without over/underflow
 end
 
-function sqrt(z::Complex{Interval{T}}) where T<:AbstractFloat
+function sqrt(z::Complex{Interval{T}}) where {T<:AbstractFloat}
     x, y = reim(z)
 
     (inf(x) < 0 && inf(y) < 0 && sup(y) >= 0) && error("Interval lies across branch cut")
@@ -101,7 +100,7 @@ function sqrt(z::Complex{Interval{T}}) where T<:AbstractFloat
 end
 
 
-function log(z::Complex{T}) where T<:Interval
+function log(z::Complex{<:Interval})
     ρ = abs(z)
     θ = angle(z)
 
@@ -109,13 +108,10 @@ function log(z::Complex{T}) where T<:Interval
 end
 
 
-function abs2(z::Complex{T}) where T<:Interval
-    return real(z)^2 + imag(z)^2
-end
+abs2(z::Complex{<:Interval}) = real(z)^2 + imag(z)^2
 
-function abs(z::Complex{T}) where T<:Interval
-    return sqrt(abs2(z))
-end
+abs(z::Complex{<:Interval}) = sqrt(abs2(z))
+
 #
 # # \left( |x|^p \right)^{1/p}.
 # function norm(z::Complex{T}, p=2) where T<:Interval
@@ -123,6 +119,6 @@ end
 # end
 
 # real functions
-mid(z::Complex{T}) where {T <: Interval} = mid(real(z)) + mid(imag(z)) * im
-mag(z::Complex{T}) where {T <: Interval} = sup(abs(z))
-mig(z::Complex{T}) where {T <: Interval} = inf(abs(z))
+mid(z::Complex{<:Interval}) = complex(mid(real(z)), mid(imag(z)))
+mag(z::Complex{<:Interval}) = sup(abs(z))
+mig(z::Complex{<:Interval}) = inf(abs(z))

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -34,11 +34,13 @@ Interval{Float64}
 """
 default_bound() = Float64
 
+const NumTypes = Union{Rational,AbstractFloat} # allowed types for the bounds of an interval
+
 # Produce the type of the bounds of an interval when not explicitly imposed
-promote_numtype(::Type{T}, ::Type{S}) where {T<:AbstractFloat, S<:AbstractFloat} = promote_type(T, S)
-promote_numtype(::Type{T}, ::Type{S}) where {T<:AbstractFloat, S} = promote_type(T, S)
-promote_numtype(::Type{T}, ::Type{S}) where {T, S<:AbstractFloat} = promote_type(T, S)
-promote_numtype(::Type{T}, ::Type{S}) where {T, S} = promote_type(default_bound(), T, S)
+promote_numtype(::Type{T}, ::Type{S}) where {T<:NumTypes,S<:NumTypes} = promote_type(T, S)
+promote_numtype(::Type{T}, ::Type{S}) where {T<:NumTypes,S} = promote_type(T, S)
+promote_numtype(::Type{T}, ::Type{S}) where {T,S<:NumTypes} = promote_type(T, S)
+promote_numtype(::Type{T}, ::Type{S}) where {T,S} = promote_type(default_bound(), T, S)
 
 @inline _normalisezero(a::Real) = ifelse(iszero(a), zero(a), a)
 
@@ -66,20 +68,26 @@ constructors:
     are included in the interval even if they can not be represented as
     floating point numbers.
 """
-struct Interval{T} <: Real
+struct Interval{T<:NumTypes} <: Real
     lo::T
     hi::T
 
-    Interval{T}(a::T, b::T) where {T} = new{T}(_normalisezero(a), _normalisezero(b))
+    Interval{T}(a::T, b::T) where {S<:Integer,T<:Rational{S}} = new{T}(_normalisezero(a), _normalisezero(b))
+    Interval{T}(a::T, b::T) where {T<:AbstractFloat} = new{T}(_normalisezero(a), _normalisezero(b))
 end
 
-Interval{T}(a, b) where {T} = Interval{T}(T(a, RoundDown), T(b, RoundUp))
+function Interval{T}(a, b) where {S<:Integer,T<:Rational{S}}
+    R = float(S)
+    return Interval{T}(rationalize(S, prevfloat(R(a, RoundDown))), rationalize(S, nextfloat(R(b, RoundUp))))
+end
 
-Interval{T}(x::Interval) where {T} = Interval{T}(inf(x), sup(x))
+Interval{T}(a, b) where {T<:AbstractFloat} = Interval{T}(T(a, RoundDown), T(b, RoundUp))
+
+Interval{T}(x::Interval) where {T<:NumTypes} = Interval{T}(inf(x), sup(x))
 
 # promotion
 
-Base.promote_rule(::Type{Interval{T}}, ::Type{Interval{S}}) where {T, S} =
+Base.promote_rule(::Type{Interval{T}}, ::Type{Interval{S}}) where {T<:NumTypes,S<:NumTypes} =
     Interval{promote_type(T, S)}
 
 """
@@ -89,7 +97,7 @@ Create an interval, checking whether [a, b] is a valid `Interval`
 If so, then an `Interval{T}(a, b)` object is returned;
 if not, a warning is printed and the empty interval is returned.
 """
-function interval(::Type{T}, a, b) where {T}
+function interval(::Type{T}, a, b) where {T<:NumTypes}
     is_valid_interval(a, b) && return Interval{T}(a, b)
     @warn "Invalid input, empty interval is returned"
     return emptyinterval(T)
@@ -97,25 +105,25 @@ end
 interval(a::T, b::S) where {T, S} = interval(promote_numtype(T, S), a, b)
 
 # Real: `is_valid_interval(a, a) != true`
-interval(::Type{T}, a::Real) where {T} = interval(T, a, a)
+interval(::Type{T}, a::Real) where {T<:NumTypes} = interval(T, a, a)
 interval(a) = interval(a, a)
 # Prevent ambiguity error between `interval(a::T, b::S) where {T, S<:AbstractFloat}`
 # and `interval(::Type{T}, a::Real) where {T}`
-interval(::Type{T}, a::AbstractFloat) where {T} = interval(T, a, a)
+interval(::Type{T}, a::AbstractFloat) where {T<:NumTypes} = interval(T, a, a)
 
 # Interval: check the validity of the interval
-interval(::Type{T}, a::Interval) where {T} = interval(T, inf(a), sup(a))
+interval(::Type{T}, a::Interval) where {T<:NumTypes} = interval(T, inf(a), sup(a))
 interval(a::Interval) = interval(inf(a), sup(a))
 
 # Complex
-interval(::Type{T}, a::Complex) where {T} = complex(interval(T, real(a)), interval(T, imag(a)))
+interval(::Type{T}, a::Complex) where {T<:NumTypes} = complex(interval(T, real(a)), interval(T, imag(a)))
 interval(a::Complex) = complex(interval(real(a)), interval(imag(a)))
-interval(::Type{T}, a::Complex, b::Complex) where {T} = complex(interval(T, real(a), real(b)), interval(T, imag(a), imag(b)))
+interval(::Type{T}, a::Complex, b::Complex) where {T<:NumTypes} = complex(interval(T, real(a), real(b)), interval(T, imag(a), imag(b)))
 interval(a::Complex, b::Complex) = complex(interval(real(a), real(b)), interval(imag(a), imag(b)))
-interval(::Type{T}, a::Complex, b::Real) where {T} = complex(interval(T, real(a), b), interval(T, imag(a), b))
-interval(a::Complex, b::Real) = complex(interval(real(a), b), interval(imag(a), b))
-interval(::Type{T}, a::Real, b::Complex) where {T} = complex(interval(T, a, real(b)), interval(T, a, imag(b)))
-interval(a::Real, b::Complex) = complex(interval(a, real(b)), interval(a, imag(b)))
+interval(::Type{T}, a::Complex, b::Real) where {T<:NumTypes} = complex(interval(T, real(a), b), interval(T, imag(a)))
+interval(a::Complex, b::Real) = complex(interval(real(a), b), interval(imag(a)))
+interval(::Type{T}, a::Real, b::Complex) where {T<:NumTypes} = complex(interval(T, a, real(b)), interval(T, imag(b)))
+interval(a::Real, b::Complex) = complex(interval(a, real(b)), interval(imag(b)))
 
 # Irrational
 # By-pass the absence of `BigFloat(..., ROUNDING_MODE)` (cf. base/irrationals.jl)
@@ -130,7 +138,7 @@ for sym ∈ (:ℯ, :φ)
 end
 # The following function is put here because generated functions must be defined
 # after all the methods they use
-@generated function interval(::Type{T}, a::Irrational) where {T}
+@generated function interval(::Type{T}, a::Irrational) where {T<:NumTypes}
     res = Interval{T}(a(), a())  # Precompute the interval
     return :($res)  # Set body of the function to return the precomputed result
 end
@@ -200,10 +208,11 @@ to contain the number that was typed in.
 
 Otherwise it is the same as using the `Interval` constructor directly.
 """
-atomic(::Type{Interval{T}}, x) where {T} = interval(T, x)
-atomic(::Type{Interval{T}}, x::AbstractString) where {T} = parse(Interval{T}, x)
+atomic(::Type{Interval{T}}, x) where {T<:NumTypes} = interval(T, x)
+atomic(::Type{Interval{T}}, x::AbstractString) where {T<:NumTypes} = parse(Interval{T}, x)
 
-function atomic(::Type{Interval{T}}, x::AbstractFloat) where {T}
+atomic(::Type{Interval{T}}, x::AbstractFloat) where {T<:Rational} = Interval{T}(lo, hi)
+function atomic(::Type{Interval{T}}, x::AbstractFloat) where {T<:AbstractFloat}
     lo = T(x, RoundDown)
     hi = T(x, RoundUp)
     if x == lo
@@ -245,5 +254,5 @@ function bigequiv(x::AbstractFloat)
     end
 end
 
-float(x::Interval{T}) where {T} = atomic(Interval{float(T)}, x)
+float(x::Interval{T}) where {T<:NumTypes} = atomic(Interval{float(T)}, x)
 big(x::Interval) = atomic(Interval{BigFloat}, x)

--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -173,10 +173,10 @@ function in(x::Real, a::Interval)
 end
 
 in(x::Interval, y::Interval) = throw(ArgumentError("$x ∈ $y is not defined, maybe you meant `⊂`"))
-in(x::Real, a::Complex{F}) where {F<:Interval} = x ∈ real(a) && 0 ∈ imag(a)
-in(x::Complex{T}, a::Complex{F}) where {T<:Real, F<:Interval} = real(x) ∈ real(a) && imag(x) ∈ imag(a)
+in(x::Real, a::Complex{<:Interval}) = x ∈ real(a) && 0 ∈ imag(a)
+in(x::Complex, a::Complex{<:Interval}) = real(x) ∈ real(a) && imag(x) ∈ imag(a)
 
-contains_zero(x::Interval{T}) where T = zero(T) ∈ x
+contains_zero(x::Interval{T}) where {T<:NumTypes} = zero(T) ∈ x
 
 isempty(x::Interval) = (inf(x) == Inf && sup(x) == -Inf)
 isentire(x::Interval) = (inf(x) == -Inf && sup(x) == Inf)

--- a/src/intervals/interval_operations/constants.jl
+++ b/src/intervals/interval_operations/constants.jl
@@ -16,15 +16,12 @@ argument given, the default interval bound type is used.
 
 Implement the `empty` function of the IEEE Std 1788-2015 (section 10.5.2).
 """
-emptyinterval(::Type{F}) where {F<:Interval} = F(Inf, -Inf)
-emptyinterval(::F) where {F<:Interval} = emptyinterval(F)
-emptyinterval(::Type{Complex{F}}) where {F<:Interval} = complex(emptyinterval(F), emptyinterval(F))
-
-# NOTE Here the restriction should be any allowed bound type. Using
-# AbstractFloat for simplicity for now
-emptyinterval(::Type{T}) where {T<:AbstractFloat} = emptyinterval(Interval{T})
+emptyinterval(::Type{F}) where {T<:NumTypes,F<:Interval{T}} = F(typemax(T), typemin(T))
+emptyinterval(::Type{T}) where {T<:NumTypes} = emptyinterval(Interval{T})
 emptyinterval(::Type{<:Real}) = emptyinterval(default_bound())
 emptyinterval() = emptyinterval(default_bound())
+emptyinterval(::Type{Complex{T}}) where {T<:Real} = complex(emptyinterval(T), emptyinterval(T))
+emptyinterval(::T) where {T} = emptyinterval(T)
 
 
 """
@@ -41,7 +38,9 @@ of `Interval` for more information about the default interval falvor.
 
 Implement the `entire` function of the IEEE Std 1788-2015 (section 10.5.2).
 """
-entireinterval(::Type{F}) where {T, F<:Interval{T}} = F(-Inf, Inf)
-entireinterval(::F) where {F<:Interval} = entireinterval(F)
-entireinterval(::Type{T}) where T = Interval{T}(-Inf, Inf)
+entireinterval(::Type{F}) where {T<:NumTypes,F<:Interval{T}} = F(typemin(T), typemax(T))
+entireinterval(::Type{T}) where {T<:NumTypes} = entireinterval(Interval{T})
+entireinterval(::Type{<:Real}) = entireinterval(default_bound())
 entireinterval() = entireinterval(default_bound())
+entireinterval(::Type{Complex{T}}) where {T<:Real} = complex(entireinterval(T), entireinterval(T))
+entireinterval(::T) where {T} = entireinterval(T)

--- a/src/intervals/interval_operations/extended_div.jl
+++ b/src/intervals/interval_operations/extended_div.jl
@@ -11,7 +11,7 @@ Two-output division.
 
 Implement the `mulRevToPair` function of the IEEE Std 1788-2015 (section 10.5.5).
 """
-function extended_div(a::F, b::F) where {T, F<:Interval{T}}
+function extended_div(a::F, b::F) where {T<:NumTypes,F<:Interval{T}}
     alo, ahi = bounds(a)
     blo, bhi = bounds(b)
     z = zero(T)

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -17,7 +17,7 @@ Infimum of an interval.
 
 Implement the `inf` function of the IEEE Std 1788-2015 (Table 9.2, and Section 12.12.8).
 """
-inf(a::Interval{T}) where T = ifelse(iszero(a.lo), copysign(a.lo, -1), a.lo)
+inf(a::Interval{T}) where {T<:NumTypes} = ifelse(iszero(a.lo), copysign(a.lo, -1), a.lo)
 
 inf(a::Real) = a
 
@@ -46,7 +46,7 @@ Find the midpoint of interval `a`.
 
 Implement the `mid` function of the IEEE Std 1788-2015 (Table 9.2).
 """
-function mid(a::F) where {T, F<:Interval{T}}
+function mid(a::F) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN)
     isentire(a) && return zero(T)
 
@@ -62,7 +62,7 @@ function mid(a::F) where {T, F<:Interval{T}}
     return _normalisezero(inf(a) / 2 + sup(a) / 2)
 end
 
-mid(a::F) where {T, R<:Rational{T}, F<:Interval{R}} = (1//2) * (inf(a) + sup(a))
+mid(a::Interval{<:Rational}) = (1//2) * (inf(a) + sup(a))
 
 mid(a::Real) = a
 
@@ -77,7 +77,7 @@ Assume 0 ≤ α ≤ 1.
 Note that `scaled_mid(a, 0.5)` does not equal `mid(a)` for unbounded set-based
 intervals.
 """
-function scaled_mid(a::F, α) where {T, F<:Interval{T}}
+function scaled_mid(a::F, α) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN)
 
     lo = (inf(a) == -∞ ? nextfloat(inf(a)) : inf(a))
@@ -101,7 +101,7 @@ Return the diameter (length) of the interval `a`.
 
 Implement the `wid` function of the IEEE Std 1788-2015 (Table 9.2).
 """
-function diam(a::F) where {T, F<:Interval{T}}
+function diam(a::F) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN)
     return -(sup(a), inf(a), RoundUp)  # IEEE1788 section 12.12.8
 end
@@ -131,7 +131,7 @@ Return the midpoint of an interval `a` together with its radius.
 Function required by the  IEEE Std 1788-2015 in section 10.5.9 for the set-based
 flavor.
 """
-function midpoint_radius(a::F) where {T, F<:Interval{T}}
+function midpoint_radius(a::F) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN), convert(T, NaN)
     m = mid(a)
     return m, max(m - inf(a), sup(a) - m)
@@ -145,7 +145,7 @@ Magnitude of an interval. Return `NaN` for empty intervals.
 
 Implement the `mag` function of the IEEE Std 1788-2015 (Table 9.2).
 """
-function mag(a::F) where {T, F<:Interval{T}}
+function mag(a::F) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN)
     return max( abs(inf(a)), abs(sup(a)) )
 end
@@ -157,7 +157,7 @@ Mignitude of an interval. Return `NaN` for empty intervals.
 
 Implement the `mig` function of the IEEE Std 1788-2015 (Table 9.2).
 """
-function mig(a::F) where {T, F<:Interval{T}}
+function mig(a::F) where {T<:NumTypes, F<:Interval{T}}
     isempty(a) && return convert(T, NaN)
     contains_zero(a) && return zero(T)
     return min( abs(inf(a)), abs(sup(a)) )

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -15,13 +15,13 @@ the points common in `a` and `b`.
 
 Implement the `intersection` function of the IEEE Std 1788-2015 (section 9.3).
 """
-function intersect(a::Interval{T}, b::Interval{S}) where {T, S}
-    isdisjoint(a, b) && return emptyinterval(promote_type(T, S))
-    return Interval{promote_type(T, S)}(max(inf(a), inf(b)), min(sup(a), sup(b)))
+function intersect(a::F, b::G) where {F<:Interval,G<:Interval}
+    isdisjoint(a, b) && return emptyinterval(promote_type(F, G))
+    return promote_type(F, G)(max(inf(a), inf(b)), min(sup(a), sup(b)))
 end
 
-function intersect(a::Complex{F}, b::Complex{F}) where {F<:Interval}
-    isdisjoint(a, b) && return emptyinterval(Complex{F})
+function intersect(a::Complex{F}, b::Complex{G}) where {F<:Interval,G<:Interval}
+    isdisjoint(a, b) && return emptyinterval(Complex{promote_type(F, G)})
     return complex(intersect(real(a), real(b)), intersect(imag(a), imag(b)))
 end
 
@@ -47,9 +47,9 @@ all of `a` and `b`.
 Implement the `converxHull` function of the IEEE Std 1788-2015 (section 9.3).
 """
 hull(a::F, b::F) where {F<:Interval} = F(min(inf(a), inf(b)), max(sup(a), sup(b)))
-hull(a::F, b::G) where {F<:Interval, G<:Interval} =
+hull(a::F, b::G) where {F<:Interval,G<:Interval} =
     promote_type(F, G)(min(inf(a), inf(b)), max(sup(a), sup(b)))
-hull(a::Complex{F},b::Complex{F}) where {F<:Interval} =
+hull(a::Complex{F}, b::Complex{F}) where {F<:Interval} =
     complex(hull(real(a), real(b)), hull(imag(a), imag(b)))
 hull(a...) = reduce(hull, a)
 hull(a::Vector{F}) where {F<:Interval} = reduce(hull, a)
@@ -64,7 +64,7 @@ to `hull(a,b)`.
 Implement the `converxHull` function of the IEEE Std 1788-2015 (section 9.3).
 """
 union(a::Interval, b::Interval) = hull(a, b)
-union(a::Complex{<:Interval},b::Complex{<:Interval}) = hull(a, b)
+union(a::Complex{<:Interval}, b::Complex{<:Interval}) = hull(a, b)
 
 """
     setdiff(x::Interval, y::Interval)

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -8,22 +8,19 @@ they behave like `Real` in julia.
 =#
 
 zero(::F) where {F<:Interval} = zero(F)
-function zero(::Type{F}) where {T<:Real, F<:Interval{T}}
+function zero(::Type{F}) where {T<:NumTypes, F<:Interval{T}}
     x = zero(T)
     return F(x, x)
 end
 
 one(::F) where {F<:Interval} = one(F)
-function one(::Type{F}) where {T<:Real, F<:Interval{T}}
+function one(::Type{F}) where {T<:NumTypes, F<:Interval{T}}
     x = one(T)
     return F(x, x)
 end
 
-typemin(::Type{F}) where {T<:Real, F<:Interval{T}} = F(typemin(T), nextfloat(typemin(T)))
-typemax(::Type{F}) where {T<:Real, F<:Interval{T}} = F(prevfloat(typemax(T)), typemax(T))
-# No support for bounds of type integers
-# typemin(::Type{F}) where {T<:Integer, F<:Interval{T}} = interval(T, typemin(T))
-# typemax(::Type{F}) where {T<:Integer, F<:Interval{T}} = interval(T, typemax(T))
+typemin(::Type{F}) where {T<:NumTypes, F<:Interval{T}} = F(typemin(T), nextfloat(typemin(T)))
+typemax(::Type{F}) where {T<:NumTypes, F<:Interval{T}} = F(prevfloat(typemax(T)), typemax(T))
 
 """
     numtype(::Interval{T}) where {T}
@@ -37,13 +34,13 @@ julia> numtype(1..2)
 Float64
 ```
 """
-numtype(::Interval{T}) where {T} = T
+numtype(::Interval{T}) where {T<:NumTypes} = T
 
 function eps(a::F) where {F<:Interval}
     x = max(eps(inf(a)), eps(sup(a)))
     return F(x, x)
 end
-function eps(::Type{F}) where {T, F<:Interval{T}}
+function eps(::Type{F}) where {T<:NumTypes,F<:Interval{T}}
     x = eps(T)
     return F(x, x)
 end

--- a/src/multidim/setdiff.jl
+++ b/src/multidim/setdiff.jl
@@ -5,7 +5,7 @@ Computes the set difference x\\y and always returns a tuple of two intervals.
 If the set difference is only one interval or is empty, then the returned tuple contains 1
 or 2 empty intervals.
 """
-function _setdiff(x::F, y::F) where {T, F<:Interval{T}}
+function _setdiff(x::F, y::F) where {T<:NumTypes,F<:Interval{T}}
     intersection = x ∩ y
 
     isempty(intersection) && return (x, emptyinterval(T))
@@ -30,7 +30,7 @@ i.e. the set of `x` that are in `A` but not in `B`.
 Algorithm: Start from the total overlap (in all directions);
 expand each direction in turn.
 """
-function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T}
+function setdiff(A::IntervalBox{N,T}, B::IntervalBox{N,T}) where {N,T<:NumTypes}
 
     intersection = A ∩ B
     isempty(intersection) && return [A]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -27,7 +27,7 @@ julia> parse(DecoratedInterval{Float64}, "foobar")
 [NaN, NaN]_ill
 ```
 """
-function parse(::Type{DecoratedInterval{T}}, s::AbstractString) where T
+function parse(::Type{DecoratedInterval{T}}, s::AbstractString) where {T<:NumTypes}
     s = lowercase(strip(s))
     s == "[nai]" && return nai(T)
     try
@@ -123,7 +123,7 @@ julia> parse(Interval{Float64}, "foobar")
 ∅
 ```
 """
-function parse(::Type{Interval{T}}, s::AbstractString) where T
+function parse(::Type{Interval{T}}, s::AbstractString) where {T<:NumTypes}
     s = lowercase(strip(s))
     try
         ival, _ = _parse(Interval{T}, s)
@@ -152,7 +152,7 @@ error if an invalid string is given.
   unbounded (e.g. input `"[3, infinity]"`) or becomes unbounded because of overflow
   (e.g. the input `"[3, 1e400]", which is parse to `[3, ∞]` when using `Float64`).
 """
-function _parse(::Type{Interval{T}}, s::AbstractString) where T
+function _parse(::Type{Interval{T}}, s::AbstractString) where {T<:NumTypes}
     isnotcom = occursin("inf", s)
     if startswith(s, '[') && endswith(s, ']') # parse as interval
         s = strip(s[2:end-1])

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -1,12 +1,12 @@
 using Random
 
-Base.rand(X::Interval{T}) where {T} = inf(X) + rand(T) * (sup(X) - inf(X))
+Base.rand(X::Interval{T}) where {T<:NumTypes} = inf(X) + rand(T) * (sup(X) - inf(X))
 
 Base.rand(X::IntervalBox) = rand.(X)
 
 
-Random.gentype(::Type{Interval{T}}) where {T} = T
-Random.rand(rng::AbstractRNG, X::Random.SamplerTrivial{Interval{T}}) where {T} = rand(X[])
+Random.gentype(::Type{Interval{T}}) where {T<:NumTypes} = T
+Random.rand(::AbstractRNG, X::Random.SamplerTrivial{Interval{T}}) where {T<:NumTypes} = rand(X[])
 
 
 # Base.eltype(::Type{IntervalBox{2,Float64}}) = SArray{Tuple{2},Float64,1,2}

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -97,7 +97,7 @@ using Test
         c = @interval("0.1", "0.2")
         @test c ⊆ a   # c is narrower than a
         @test interval(1//2) ≛ interval(0.5)
-        @test_broken interval(1//10).lo == rationalize(0.1)
+        @test interval(1//10).lo == rationalize(0.1)
     end
 
     @test string(emptyinterval()) == "∅"

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -150,13 +150,13 @@ end
 
 @testset "Exp and log tests" begin
     @test exp(@biginterval(1//2)) ⊆ exp(interval(1//2))
-    @test exp(interval(1//2)) ≛ interval(1.648721270700128, 1.6487212707001282)
+    @test exp(big(1//2)) ∈ exp(interval(1//2))
     @test exp(@biginterval(0.1)) ⊆ exp(interval(0.1))
     @test exp(interval(0.1)) ≛ interval(1.1051709180756475e+00, 1.1051709180756477e+00)
     @test diam(exp(interval(0.1))) == eps(exp(0.1))
 
     @test log(@biginterval(1//2)) ⊆ log(interval(1//2))
-    @test log(interval(1//2)) ≛ interval(-6.931471805599454e-01, -6.9314718055994529e-01)
+    @test log(big(1//2)) ∈ log(interval(1//2))
     @test log(@biginterval(0.1)) ⊆ log(interval(0.1))
     @test log(interval(0.1)) ≛ interval(-2.3025850929940459e+00, -2.3025850929940455e+00)
     @test diam(log(interval(0.1))) == eps(log(0.1))
@@ -168,7 +168,7 @@ end
 
     @test log2(@biginterval(1//2)) ⊆ log2(interval(1//2))
     @test log2(interval(0.25, 0.5)) ≛ interval(-2.0, -1.0)
-    @test log10(@biginterval(1//10)) ⊆ log10(interval(1//10))
+    @test log10(big(1//10)) ∈ log10(interval(1//10))
     @test log10(interval(0.01, 0.1)) ≛ interval(log10(0.01, RoundDown), log10(0.1, RoundUp))
 
     @test log1p(interval(-0.5, 0.1)) ≛ interval(log1p(-0.5, RoundDown), log1p(0.1, RoundUp))
@@ -195,11 +195,9 @@ end
 @testset "Rational tests" begin
     f = 1 // 3
     g = 1 // 3
-    @test_broken interval(f*g) ≛ interval(1.1111111111111109e-01, 1.1111111111111115e-01)
+    @test interval(f*g) ≛ interval(1//9) ≛ interval(1//9, 1//9)
     @test interval(f, g) - 1 ≛ interval(-2 // 3, -2 // 3)
-    @test big(1.)/9 ∈ interval(f*g)
-    @test interval(1)/9 ⊆ interval(f*g)
-    @test_broken interval(1/9) ≛ interval(1//9)
+    @test interval(f*g) ⊆ interval(1)/9
 end
 
 @testset "Floor etc. tests" begin


### PR DESCRIPTION
In this PR, the type of the bounds for an `Interval` are restricted to `Rational` or `AbstractFloat`.

@lbenet I believe this PR fixes the few remaining items that were discussed in PR #558, i.e.

```Julia
Interval{Irrational{:π}}(π, π) # throws an error
interval(1//1, 2//1) # has type Interval{Rational{Int}} instead of Interval{Float}
```

Or did I miss some?

One note: perhaps it is possible to do better in the construction of an `Interval{<:Rational}` when the inputs have a different type? See lines https://github.com/OlivierHnt/IntervalArithmetic.jl/blob/e381c3fa23895a5d77fe963810837ecc422c1b10/src/intervals/construction.jl#L79-L82

