### PR TITLE
Add an extension to support ForwardDiff

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1.9'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,17 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RoundingEmulator = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
 SetRounding = "3cc68bcd-71a2-5612-b932-767ffbe40ab0"
 
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[extensions]
+IntervalArithmeticForwardDiffExt = "ForwardDiff"
+
 [compat]
 CRlibm = "0.7, 0.8, 1"
 EnumX = "1"
 FastRounding = "0.2, 0.3"
+ForwardDiff = "0.11"
 RoundingEmulator = "0.2"
 SetRounding = "0.2"
-julia = "1.8"
+julia = "1.9"

--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -1,0 +1,21 @@
+module IntervalArithmeticForwardDiffExt
+
+using IntervalArithmetic, ForwardDiff
+using ForwardDiff: Dual
+
+function Base.:(*)(x::Dual{Tx,Vx,N}, y::Interval{Vy}) where {Tx,Vx<:Real,Vy<:Union{AbstractFloat, Rational},N}
+    v = x.value * y
+    V = typeof(v)
+    Dual{Tx,V,N}(v, ForwardDiff.Partials{N,V}(x.partials.values .* y))
+end
+
+@generated function _iszero_tuple(::Type{<:Interval}, tup::NTuple{N,V}) where {N,V}
+    ex = Expr(:&&, [:(z ≛ tup[$i]) for i=1:N]...)
+    return quote
+        z = zero(V)
+        $(Expr(:meta, :inline))
+        @inbounds return $ex
+    end
+end
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/autodiff_tests/forwarddiff.jl
+++ b/test/autodiff_tests/forwarddiff.jl
@@ -1,0 +1,17 @@
+using Test
+using IntervalArithmetic
+using ForwardDiff
+
+@testset "ForwardDiff" begin
+    x, w = 2.0, interval(-0.5, 0.5)
+    ϕ(t) = sin(x + (1+t)*w)
+    ϕ′(t) = cos(x + (1+t)*w) * w
+    ϕ′′(t) = -sin(x + (1+t)*w) * w^2
+    ϕ′′′(t) = -cos(x + (1+t)*w) * w^3
+    dϕ(t) = ForwardDiff.derivative(ϕ, t)
+    ddϕ(t) = ForwardDiff.derivative(dϕ, t)
+    dddϕ(t) = ForwardDiff.derivative(ddϕ, t)
+    @test ϕ′(0) ⊆ dϕ(0)
+    @test ϕ′′(0) ⊆ ddϕ(0)
+    @test ϕ′′′(0) ⊆ dddϕ(0)
+end

--- a/test/autodiff_tests/forwarddiff.jl
+++ b/test/autodiff_tests/forwarddiff.jl
@@ -6,12 +6,12 @@ using ForwardDiff
     x, w = 2.0, interval(-0.5, 0.5)
     ϕ(t) = sin(x + (1+t)*w)
     ϕ′(t) = cos(x + (1+t)*w) * w
-    ϕ′′(t) = -sin(x + (1+t)*w) * w^2
+    ϕ′′(t) = -sin(x + (1+t)*w) * w * w  # note w * w rather than w^2, since FD goes one order at a time
     ϕ′′′(t) = -cos(x + (1+t)*w) * w^3
     dϕ(t) = ForwardDiff.derivative(ϕ, t)
     ddϕ(t) = ForwardDiff.derivative(dϕ, t)
     dddϕ(t) = ForwardDiff.derivative(ddϕ, t)
-    @test ϕ′(0) ⊆ dϕ(0)
-    @test ϕ′′(0) ⊆ ddϕ(0)
-    @test ϕ′′′(0) ⊆ dddϕ(0)
+    @test ϕ′(0) ≛ dϕ(0)
+    @test ϕ′′(0) ≛ ddϕ(0)
+    @test ϕ′′′(0) ≛ dddϕ(0)
 end

--- a/test/autodiff_tests/runall.jl
+++ b/test/autodiff_tests/runall.jl
@@ -1,0 +1,1 @@
+include("forwarddiff.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,3 +26,6 @@ include_test("multidim_tests/multidim.jl")
 
 # ITF1788 tests
 include_test("test_ITF1788/run_ITF1788.jl")  # TODO fix these tests
+
+# Extensions
+include_test("autodiff_tests/runall.jl")


### PR DESCRIPTION
Because of the extensive changes on `master`, ForwardDiff no longer works with this package. This add an extension (Julia 1.9+) providing at least basic support.

Note that:
- this depends on https://github.com/JuliaDiff/ForwardDiff.jl/pull/667. I am not sure when there will be a new release of ForwardDiff, but the master branch is now `0.11-DEV`.
- you have to `dev ForwardDiff in the `test` folder
- because of https://github.com/JuliaLang/Pkg.jl/issues/3636, you either have to run these tests on `nightly` or we have to abandon `test/Project.toml` and copy everything to the `[extras]` section of the main `Project.toml`.

So obviously this can't be merged yet, but I thought it would be better to submit it now.