### PR TITLE
Update docs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![DOI](https://zenodo.org/badge/87007945.svg)](https://zenodo.org/badge/latestdoi/87007945)
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaintervals.github.io/IntervalArithmetic.jl/stable)
+[![Dev Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaintervals.github.io/IntervalArithmetic.jl/dev)
 
 IntervalArithmetic.jl is a Julia package for validated numerics in Julia. All calculations are carried out using [interval arithmetic](https://en.wikipedia.org/wiki/Interval_arithmetic) where quantities are treated as intervals. The final result is a rigorous enclosure of the true value.
 


### PR DESCRIPTION
I'm not sure why the release process isn't producing any docs at `stable` (or, in fact, for any previous versions). 

In the meantime, it seems better to link users to the dev docs rather than a dead link.

FWIW, I had a similar issue in my package some time ago (https://github.com/vtjeng/MIPVerify.jl/pull/116) but it seems to have to do with me using an old version of `Documenter`, which is not the issue you are having here.