### PR TITLE
Improve accuracy of `sinpi` and `cospi`

### DIFF
--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -185,7 +185,7 @@ function Base.cospi(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    isthin(x) & isinteger(2lo) && return zero(BareInterval{T}) # by-pass rounding to improve accuracy for 32 bit systems
+    isthin(x) & !isinteger(lo) & isinteger(2lo) && return zero(BareInterval{T}) # by-pass rounding to improve accuracy for 32 bit systems
 
     lo_quadrant = _quadrantpi(lo)
     hi_quadrant = _quadrantpi(hi)

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -10,7 +10,7 @@ _quadrant_down(x::T) where {T<:AbstractFloat} = _quadrant(x)
 _quadrant_up(x::T) where {T<:Rational} = _quadrant(float(T)(x, RoundUp))
 _quadrant_up(x::T) where {T<:AbstractFloat} = _quadrant(x)
 
-function _quadrant(x::T) where {T<:AbstractFloat}
+function _quadrant(x::AbstractFloat)
     x_mod2pi = rem2pi(x, RoundNearest)
     -2x_mod2pi > π && return 2 # [-π, -π/2)
     x_mod2pi < 0 && return 3 # [-π/2, 0)
@@ -18,7 +18,7 @@ function _quadrant(x::T) where {T<:AbstractFloat}
     return 1 # [π/2, π]
 end
 
-function _quadrantpi(x::T) where {T<:NumTypes} # for `sinpi` and `cospi`
+function _quadrantpi(x::NumTypes) # used in `sinpi` and `cospi`
     x_mod2 = rem(x, 2)
     -2x_mod2 > 1 && return 2 # [-π, -π/2)
     x_mod2 < 0 && return 3 # [-π/2, 0)
@@ -184,6 +184,8 @@ function Base.cospi(x::BareInterval{T}) where {T<:NumTypes}
     d ≥ 2 && return _unsafe_bareinterval(T, -one(T), one(T))
 
     lo, hi = bounds(x)
+
+    isthin(x) & isinteger(2lo) && return zero(BareInterval{T}) # by-pass rounding to improve accuracy for 32 bit systems
 
     lo_quadrant = _quadrantpi(lo)
     hi_quadrant = _quadrantpi(hi)

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -12,7 +12,7 @@ function _quadrant(x::T) where {T<:AbstractFloat}
     return 1 # [π/2, π]
 end
 
-function _quadrantpi(x::T) where {T<:AbstractFloat} # for `sinpi` and `cospi`
+function _quadrantpi(x::T) where {T<:NumTypes} # for `sinpi` and `cospi`
     x_mod2 = rem(x, 2)
     -2x_mod2 > 1 && return 2 # [-π, -π/2)
     x_mod2 < 0 && return 3 # [-π/2, 0)

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -4,6 +4,12 @@
 
 # helper functions
 
+_quadrant_down(x::T) where {T<:Rational} = _quadrant(float(T)(x, RoundDown))
+_quadrant_down(x::T) where {T<:AbstractFloat} = _quadrant(x)
+
+_quadrant_up(x::T) where {T<:Rational} = _quadrant(float(T)(x, RoundUp))
+_quadrant_up(x::T) where {T<:AbstractFloat} = _quadrant(x)
+
 function _quadrant(x::T) where {T<:AbstractFloat}
     x_mod2pi = rem2pi(x, RoundNearest)
     -2x_mod2pi > π && return 2 # [-π, -π/2)
@@ -48,8 +54,8 @@ function Base.sin(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
 
     if lo_quadrant == hi_quadrant
         d ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
@@ -137,8 +143,8 @@ function Base.cos(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
 
     if lo_quadrant == hi_quadrant
         d ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
@@ -224,8 +230,8 @@ function Base.tan(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
     lo_quadrant_mod = mod(lo_quadrant, 2)
     hi_quadrant_mod = mod(hi_quadrant, 2)
 
@@ -260,8 +266,8 @@ function Base.cot(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
 
     if (lo_quadrant == 2 || lo_quadrant == 3) && hi == 0
         return @round(T, typemin(T), cot(lo)) # singularity from the left
@@ -290,8 +296,8 @@ function Base.sec(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
 
     if lo_quadrant == hi_quadrant
         (lo_quadrant == 0) | (lo_quadrant == 1) && return @round(T, sec(lo), sec(hi)) # increasing
@@ -326,8 +332,8 @@ function Base.csc(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant(lo)
-    hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant_down(lo)
+    hi_quadrant = _quadrant_up(hi)
 
     if (lo_quadrant == 2 || lo_quadrant == 3) && hi == 0
         # singularity from the left

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -210,19 +210,10 @@ for f ∈ CRlibm.functions
             #     prevfloat($f(x))
             # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
             #     nextfloat($f(x))
-            if Int == Int32 # to avoid StackOverflow; for 32 bit systems, CRlibm.jl shadows MPFR and methods for `BigFloat` result in StackOverflow
-                function $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
-                    bigx = _bigequiv(x)
-                    return setrounding(BigFloat, r) do
-                        return $f(bigx)
-                    end
-                end
-            else
-                $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
-                function $f_round(::IntervalRounding{:slow}, x::BigFloat, r::RoundingMode)
-                    return setrounding(BigFloat, r) do
-                        return $f(x)
-                    end
+            $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
+            function $f_round(::IntervalRounding{:slow}, x::BigFloat, r::RoundingMode)
+                return setrounding(BigFloat, r) do
+                    return $f(x)
                 end
             end
             $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -200,18 +200,23 @@ end
 
 for f ∈ CRlibm.functions
     if isdefined(Base, f)
-        g = Symbol(:_, f, :_round)
+        f_round = Symbol(:_, f, :_round)
 
         @eval begin
-            $g(x::NumTypes, r::RoundingMode) = $g(interval_rounding(), float(x), r) # rationals are converted to floats
+            $f_round(x::NumTypes, r::RoundingMode) = $f_round(interval_rounding(), float(x), r) # rationals are converted to floats
 
-            $g(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $g(IntervalRounding{:slow}(), x, r)
-            # $g(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
+            $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
+            # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
             #     prevfloat($f(x))
-            # $g(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
+            # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
             #     nextfloat($f(x))
-            $g(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
-            $g(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
+            $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
+            function $f_round(::IntervalRounding{:slow}, x::BigFloat, r::RoundingMode)
+                return setrounding(BigFloat, r) do
+                    return $f(x)
+                end
+            end
+            $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
         end
     end
 end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -210,10 +210,19 @@ for f ∈ CRlibm.functions
             #     prevfloat($f(x))
             # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
             #     nextfloat($f(x))
-            $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
-            function $f_round(::IntervalRounding{:slow}, x::BigFloat, r::RoundingMode)
-                return setrounding(BigFloat, r) do
-                    return $f(x)
+            if Int == Int32 && f ∈ (:sinpi, :cospi) # to avoid StackOverflow for 32 bit systems; CRlibm.jl shadows MPFR which does not include `sinpi` and `cospi`
+                function $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
+                    bigx = _bigequiv(x)
+                    return setrounding(BigFloat, r) do
+                        return $f(bigx)
+                    end
+                end
+            else
+                $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode) = CRlibm.$f(x, r)
+                function $f_round(::IntervalRounding{:slow}, x::BigFloat, r::RoundingMode)
+                    return setrounding(BigFloat, r) do
+                        return $f(x)
+                    end
                 end
             end
             $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -42,6 +42,8 @@ end
     @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
     @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
+    @test isthin(sinpi(interval(1, 1)), 0)
+    @test isthin(sinpi(interval(0.5, 0.5)), 1)
 end
 
 @testset "cospi" begin
@@ -50,6 +52,8 @@ end
     @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
     @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
+    @test isthin(cospi(interval(1, 1)), -1)
+    @test isthin(cospi(interval(0.5, 0.5)), 0)
 end
 
 @testset "sincospi" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -42,8 +42,10 @@ end
     @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
     @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
-    @test isthin(sinpi(interval(1, 1)), 0)
-    @test isthin(sinpi(interval(0.5, 0.5)), 1)
+    @test isthin(sinpi(interval(1.0)), 0)
+    @test isthin(sinpi(interval(2.0)), 0)
+    @test isthin(sinpi(interval(0.5)), 1)
+    @test isthin(sinpi(interval(1.5)), -1)
 end
 
 @testset "cospi" begin
@@ -52,8 +54,10 @@ end
     @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
     @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
-    @test isthin(cospi(interval(1, 1)), -1)
-    @test isthin(cospi(interval(0.5, 0.5)), 0)
+    @test isthin(cospi(interval(1.0)), -1)
+    @test isthin(cospi(interval(2.0)), 1)
+    @test isthin(cospi(interval(0.5)), 0)
+    @test isthin(cospi(interval(1.5)), 0)
 end
 
 @testset "sincospi" begin


### PR DESCRIPTION
This PR is essentially a revival of the PR #421 which got forgotten unfortunately.
Closes #381; closes #412.

This PR also refactors the code in trigonometric.jl; the code is about 200 lines shorter.