### PR TITLE
Allow pointwise equality

### DIFF
--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -376,4 +376,4 @@ function isthininteger(x::Interval)
     return isthininteger(bareinterval(x))
 end
 
-isthininteger(x::Complex) = isthininteger(real(x)) & isthininteger(imag(x))
+isthininteger(x::Complex) = isthininteger(real(x)) & isthinzero(imag(x))

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -107,9 +107,6 @@ for T ∈ (:BareInterval, :Interval)
         Base.isnan(::$T) =
             throw(ArgumentError("`isnan` is purposely not supported for intervals. See instead `isnai`"))
 
-        Base.isinteger(::$T) =
-            throw(ArgumentError("`isinteger` is purposely not supported for intervals. See instead `isthininteger`"))
-
         Base.intersect(::$T) =
             throw(ArgumentError("`intersect` is purposely not supported for intervals. See instead `intersect_interval`"))
 
@@ -130,3 +127,38 @@ for T ∈ (:BareInterval, :Interval)
             throw(ArgumentError("`setdiff!` is purposely not supported for intervals. See instead `interiordiff`"))
     end
 end
+
+# allow pointwise equality
+
+Base.:(==)(x::BareInterval, y::Number) = inf(x) == sup(x) == y
+Base.:(==)(x::Number, y::BareInterval) = inf(x) == sup(x) == y
+function Base.:(==)(x::Interval, y::Number)
+    isnai(x) && return false
+    return ==(bareinterval(x), y)
+end
+function Base.:(==)(x::Number, y::Interval)
+    isnai(x) && return false
+    return ==(bareinterval(x), y)
+end
+Base.:(==)(x::Complex{<:Interval}, y::Number) = ==(real(x), y) & ==(imag(x), y)
+Base.:(==)(x::Number, y::Complex{<:Interval}) = ==(x, real(y)) & ==(x, imag(y))
+Base.:(==)(::Complex{<:Interval}, ::Complex{<:Interval}) = throw(ArgumentError("`==` is purposely not supported for intervals. See instead `isequal_interval`"))
+
+Base.iszero(x::BareInterval) = iszero(inf(x)) & iszero(sup(x))
+function Base.iszero(x::Interval)
+    isnai(x) && return false
+    return iszero(bareinterval(x))
+end
+
+Base.isone(x::BareInterval) = isone(inf(x)) & isone(sup(x))
+function Base.isone(x::Interval)
+    isnai(x) && return false
+    return isone(bareinterval(x))
+end
+
+Base.isinteger(x::BareInterval) = (inf(x) == sup(x)) & isinteger(inf(x))
+function Base.isinteger(x::Interval)
+    isnai(x) && return false
+    return isinteger(bareinterval(x))
+end
+Base.isinteger(x::Complex{<:Interval}) = isinteger(real(x)) & iszero(imag(x))

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -339,7 +339,10 @@
         @test_throws ArgumentError isempty(x)
         @test_throws ArgumentError isfinite(x)
         @test_throws ArgumentError isnan(x)
-        @test_throws ArgumentError isinteger(x)
+        @test isinteger(x)
+        @test x == 1
+        @test isone(x)
+        @test !iszero(x)
     end
 
 end

--- a/test/interval_tests/forwarddiff.jl
+++ b/test/interval_tests/forwarddiff.jl
@@ -46,7 +46,7 @@ end
         dψ(t)   = ForwardDiff.derivative(ψ, t)
         ddψ(t)  = ForwardDiff.derivative(dψ, t)
         dddψ(t) = ForwardDiff.derivative(ddψ, t)
-        @test ψ′(0)   === dψ(0)   && !isguaranteed(ψ′(0))
+        @test        ψ′(0)   === dψ(0)   && !isguaranteed(ψ′(0))
         @test_broken ψ′′(0)  === ddψ(0)  && !isguaranteed(ψ′′(0)) # rely on `Interval{T}(::Real)` being defined
         @test_broken ψ′′′(0) === dddψ(0) && !isguaranteed(ψ′′′(0)) # rely on `Interval{T}(::Real)` being defined
         t₀ = interval(0)
@@ -62,6 +62,6 @@ end
 
         # g(x) = 2^x # not guaranteed
 
-        @test_broken f′(0) === df(0)
+        @test f′(0) === df(0)
     end
 end


### PR DESCRIPTION
I gained a better feeling of all the changes we made in v0.22 after updating a bunch of code I have.

One painful item was dealing with `iszero` and `isone`, which both @lbenet and @timholy raised concerns about. For instance, in PR #586, the removal of `iszero` broke ForwardDiff compatibility. At the time, I felt that this was not so bad since there was a potential hook.

Yet, I also realised that this also breaks SparseArrays which is presumably much more difficult to fix (it does not seem realistic to ask the entire ecosystem to provide us for a hook...). E.g

```Julia
julia> C = interval(sparse(rand(2, 2)))
2×2 SparseMatrixCSC{Interval{Float64}, Int64} with 4 stored entries:
 [0.440162, 0.440163]_com  [0.886892, 0.886893]_com
 [0.127834, 0.127836]_com  [0.372157, 0.372158]_com

julia> C .+= C
ERROR: ArgumentError: `==` is purposely not supported for intervals. See instead `isequal_interval`
...
```

Additionally, because `iszero` and `isone` are **pointwise by nature**, they can not yield ambiguous answers: the interval is, or not, a zero/one singleton.
This is in stark contrast with other boolean operations which are rightfully disallowed; to illustrate:
- `<` also implies some ordering, which may lead to ambiguous answers
- `isfinite` may be ambiguous depending on the flavour (but could be brought back by using @Kolaru's flavour mechanism...)
- `isnan` which collides with `isnai`

Therefore, I am proposing to bring back `iszero` and `isone`. Moreover, our function `isthin(::Interval, ::Number)` is by definition just a generalisation of `isthinzero` and `isthinone` for any `Number`. Thus, `==(::Interval, ::Number)` is safe if `iszero` and `isone` are considered safe.
Lastly, I think that `isinteger` is also safe since integers are necessarily finite.

## Note

I think this is not a breaking PR as `isthinzero`/`isthinone`/`isthin`/`isthininteger` would still be defined and exported.
However, if we do end up liking these changes by the end of 0.22; I think we ought to remove `isthinzero`/`isthinone`/`isthin`/`isthininteger` for the 1.0 release as we should not have distinct functions do the same operation.