### PR TITLE
Properly closed interval boxes for other backends than GR

### DIFF
--- a/ext/IntervalArithmeticRecipesBaseExt.jl
+++ b/ext/IntervalArithmeticRecipesBaseExt.jl
@@ -10,8 +10,8 @@ using IntervalArithmetic, RecipesBase
 
     x, y = v
 
-    x = [inf(x), sup(x), sup(x), inf(x)]
-    y = [inf(y), inf(y), sup(y), sup(y)]
+    x = [inf(x), sup(x), sup(x), inf(x), inf(x)]
+    y = [inf(y), inf(y), sup(y), sup(y), inf(y)]
 
     return x, y
 end
@@ -29,8 +29,8 @@ end
     for vᵢ ∈ v
         x, y = vᵢ
         # use NaNs to separate
-        append!(xs, [inf(x), sup(x), sup(x), inf(x), NaN])
-        append!(ys, [inf(y), inf(y), sup(y), sup(y), NaN])
+        append!(xs, [inf(x), sup(x), sup(x), inf(x), inf(x), NaN])
+        append!(ys, [inf(y), inf(y), sup(y), sup(y), inf(y), NaN])
     end
 
     return xs, ys


### PR DESCRIPTION
When plotting an interval box with `Plots.jl` and the `GR` backend, the produced rectangle has borders on all four sides. However, when using other backends like `UnicodePlots`, `PGFPlotsX` or `PythonPlots`, the left border is missing (left side in the image below). This patch resolves the issue (right side):

![unicodeplots_interval](https://github.com/JuliaIntervals/IntervalArithmetic.jl/assets/30211270/6d0f8888-a49f-4947-b719-eea2b1679e72)

