### PR TITLE
(re)Introduce scaling factor for mid

### DIFF
--- a/src/intervals/interval_operations/bisect.jl
+++ b/src/intervals/interval_operations/bisect.jl
@@ -11,7 +11,7 @@ Split the `i`-th component of a vector `x` at a relative position `α`, where
 function bisect(x::BareInterval{T}, α::Real = 0.5) where {T<:NumTypes}
     0 ≤ α ≤ 1 || return throw(DomainError(α, "`bisect` only accepts a relative position between 0 and 1"))
     isatomic(x) && return (x, emptyinterval(BareInterval{T}))
-    m = _relpoint(x, α)
+    m = mid(x, α)
     return (_unsafe_bareinterval(T, inf(x), m), _unsafe_bareinterval(T, m, sup(x)))
 end
 
@@ -28,41 +28,6 @@ function bisect(x::AbstractVector, i::Integer, α::Real = 0.5)
     x₂ = copy(x)
     x₁[i], x₂[i] = bisect(x[i], α)
     return (x₁, x₂)
-end
-
-# helper functions for bisection
-
-function _relpoint(x::BareInterval{T}, α::Real) where {T<:AbstractFloat}
-    α == 0.5 && return mid(x)
-    isempty_interval(x) && return convert(T, NaN)
-    if isentire_interval(x)
-        α > 0.5 && return prevfloat(typemax(T))
-        return nextfloat(typemin(T))
-    else
-        lo, hi = bounds(x)
-        lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
-        hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
-        β = convert(T, α)
-        midpoint = β * (hi - lo) + lo
-        isfinite(midpoint) && return _normalisezero(midpoint)
-        return _normalisezero((1 - β) * lo + β * hi)
-    end
-end
-function _relpoint(x::BareInterval{T}, α::Real) where {T<:Rational}
-    α == 0.5 && return mid(x)
-    isempty_interval(x) && return throw(ArgumentError("cannot compute the midpoint of empty intervals; cannot return a `Rational` NaN"))
-    if isentire_interval(x)
-        α > 0.5 && return prevfloat(typemax(T))
-        return nextfloat(typemin(T))
-    else
-        lo, hi = bounds(x)
-        lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
-        hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
-        β = convert(T, α)
-        midpoint = β * (hi - lo) + lo
-        isfinite(midpoint) && return _normalisezero(midpoint)
-        return _normalisezero((1 - β) * lo + β * hi)
-    end
 end
 
 """

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -84,43 +84,58 @@ Implement the `mid` function of the IEEE Standard 1788-2015 (Table 9.2).
 
 See also: [`inf`](@ref), [`sup`](@ref), [`bounds`](@ref), [`diam`](@ref),
 [`radius`](@ref) and [`midradius`](@ref).
+
+
+    mid(x, α)
+
+Relative midpoint of `x`, for `α` between 0 and 1.
+
+`mid(x, 0)` is the lower bound of the interval, `mid(x, 1)` the upper bound,
+and `mid(x, 0.5)` the midpoint.
 """
-function mid(x::BareInterval{T}) where {T<:AbstractFloat}
+function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
     isempty_interval(x) && return convert(T, NaN)
-    isentire_interval(x) && return zero(T)
-    lo, hi = bounds(x)
-    lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
-    hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
-    midpoint = (lo + hi) / 2
-    isfinite(midpoint) && return _normalisezero(midpoint)
-    # fallback in case of overflow
-    # cannot be the default, since it does not pass several IEEE 1788-2015 tests for small floats
-    return _normalisezero(lo / 2 + hi / 2)
+    if isentire_interval(x)
+        α == 0.5 && return zero(T)
+        α > 0.5 && return prevfloat(typemax(T))
+        return nextfloat(typemin(T))
+    else
+        lo, hi = bounds(x)
+        lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
+        hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
+        β = convert(T, α)
+        midpoint = β * (hi + lo * (1/β - 1)) # Exactly 0.5 * (hi + lo) for β = 0.5
+        isfinite(midpoint) && return _normalisezero(midpoint)
+        return _normalisezero((1 - β) * lo + β * hi)
+    end
 end
-function mid(x::BareInterval{T}) where {T<:Rational}
+function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
     isempty_interval(x) && return throw(ArgumentError("cannot compute the midpoint of empty intervals; cannot return a `Rational` NaN"))
-    isentire_interval(x) && return zero(T)
-    lo, hi = bounds(x)
-    lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
-    hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
-    midpoint = (lo + hi) / 2
-    isfinite(midpoint) && return _normalisezero(midpoint)
-    # fallback in case of overflow
-    # cannot be the default, since it does not pass several IEEE 1788-2015 tests for small floats
-    return _normalisezero(lo / 2 + hi / 2)
+    if isentire_interval(x)
+        α == 0.5 && return zero(T)
+        α > 0.5 && return prevfloat(typemax(T))
+        return nextfloat(typemin(T))
+    else
+        lo, hi = bounds(x)
+        lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
+        hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
+        β = convert(T, α)
+        midpoint = β * (hi - lo) + lo
+        isfinite(midpoint) && return _normalisezero(midpoint)
+        return _normalisezero((1 - β) * lo + β * hi)
+    end
 end
-
-function mid(x::Interval{T}) where {T<:AbstractFloat}
+function mid(x::Interval{T}, α = 0.5) where {T<:AbstractFloat}
     isnai(x) && return convert(T, NaN)
-    return mid(bareinterval(x))
+    return mid(bareinterval(x), α)
 end
-function mid(x::Interval{<:Rational})
+function mid(x::Interval{<:Rational}, α = 1//2)
     isnai(x) && return throw(ArgumentError("cannot compute the midpoint of an NaI; cannot return a `Rational` NaN"))
-    return mid(bareinterval(x))
+    return mid(bareinterval(x), α)
 end
 
-mid(x::Real) = mid(interval(x))
-mid(x::Complex) = complex(mid(real(x)), mid(imag(x)))
+mid(x::Real, α = 0.5) = mid(interval(x), α)
+mid(x::Complex, α = 0.5) = complex(mid(real(x), α), mid(imag(x), α))
 
 """
     diam(x)

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -94,6 +94,7 @@ Relative midpoint of `x`, for `α` between 0 and 1.
 and `mid(x, 0.5)` the midpoint.
 """
 function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
+    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
     isempty_interval(x) && return convert(T, NaN)
     if isentire_interval(x)
         α == 0.5 && return zero(T)
@@ -110,6 +111,7 @@ function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
     end
 end
 function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
+    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
     isempty_interval(x) && return throw(ArgumentError("cannot compute the midpoint of empty intervals; cannot return a `Rational` NaN"))
     if isentire_interval(x)
         α == 0.5 && return zero(T)
@@ -126,10 +128,12 @@ function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
     end
 end
 function mid(x::Interval{T}, α = 0.5) where {T<:AbstractFloat}
+    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
     isnai(x) && return convert(T, NaN)
     return mid(bareinterval(x), α)
 end
 function mid(x::Interval{<:Rational}, α = 1//2)
+    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
     isnai(x) && return throw(ArgumentError("cannot compute the midpoint of an NaI; cannot return a `Rational` NaN"))
     return mid(bareinterval(x), α)
 end

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -184,6 +184,11 @@
     @testset "mid with α" begin
         @test_throws DomainError mid(interval(1, 2), 1.2)
         @test_throws DomainError mid(interval(1, 2), -0.7)
+        @test mid(interval(0, 1), 0.75) == 0.75
+        @test mid(interval(0, 1000), 0.125) == 125
+        @test mid(interval(1, Inf), 0.75) > 0
+        @test mid(interval(-Inf, Inf), 0.75) > 0
+        @test mid(interval(-Inf, Inf), 0.25) < 0
     end
 
     @testset "mid with large floats" begin

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -181,6 +181,11 @@
         @test isnan(mid(emptyinterval()))
     end
 
+    @testset "mid with α" begin
+        @test_throws DomainError mid(interval(1, 2), 1.2)
+        @test_throws DomainError mid(interval(1, 2), -0.7)
+    end
+
     @testset "mid with large floats" begin
         @test mid(interval(0.8e308, 1.2e308)) == 1e308
         @test mid(interval(-1e308, 1e308)) == 0


### PR DESCRIPTION
I am looking into updating IntervalRootFinding.jl for v0.22.

One think that disappeared that we need is `scaled_mid`.

This PR reintroduces it by giving `mid` an optional argument.

Technically it makes the default `mid` a bit slower (4 flops and 1 division, instead of 2 flops). I can split the default if it is somehow very critical for someone.

The new formula looks weird, but that's what we need to pass the test suite.