### PR TITLE
Construction of interval when mixing real and complex arguments

### DIFF
--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -481,9 +481,9 @@ end
 _interval_infsup(::Type{T}, a::Complex, b::Complex, d::Decoration = com) where {T<:NumTypes} =
     complex(_interval_infsup(T, real(a), real(b), d), _interval_infsup(T, imag(a), imag(b), d))
 _interval_infsup(::Type{T}, a::Complex, b, d::Decoration = com) where {T<:NumTypes} =
-    complex(_interval_infsup(T, real(a), b, d), _interval_infsup(T, imag(a), imag(a), d))
+    complex(_interval_infsup(T, real(a), real(b), d), _interval_infsup(T, imag(a), imag(b), d))
 _interval_infsup(::Type{T}, a, b::Complex, d::Decoration = com) where {T<:NumTypes} =
-    complex(_interval_infsup(T, a, real(b), d), _interval_infsup(T, imag(b), imag(b), d))
+    complex(_interval_infsup(T, real(a), real(b), d), _interval_infsup(T, imag(a), imag(b), d))
 
 # midpoint constructors
 

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -20,6 +20,9 @@
     @test isequal_interval(intersect_interval(c, hull(a, b)), complex(interval(0, 3), interval(1, 2)))
     @test isempty_interval(intersect_interval(a, b))
     @test isdisjoint_interval(a, b)
+
+    @test isequal_interval(interval(-1 - im, 0), interval(-1 - im, 0 + 0im))
+    @test isequal_interval(interval(0, 1 + im), interval(0 + 0im, 1 + im))
 end
 
 @testset "Inverse roots of unity" begin


### PR DESCRIPTION
When constructing an interval from one real and one complex argument I expected it to treat the imaginary part of the real argument as zero. What happens is instead that it takes the imaginary part of the interval to only depend on the complex argument, e.g.
```julia
julia> interval(0, complex(1, 1))
[0.0, 1.0]_com + ([1.0, 1.0]_com)im
```
Compare this to what we get if we make the first argument complex
```julia
julia> interval(complex(0), complex(1, 1))
[0.0, 1.0]_com + ([0.0, 1.0]_com)im
```

This behavior could of course be by design, but since there are no tests for it I would guess that it is just a mistake. Since we have `isequal(0, complex(0))` it seems natural that they would both give the same result.

This PR changes it so that the real argument is treated as a complex argument with imaginary part zero. So we would get identical results for the two above constructors. Feel free to discard this if the original behavior is indeed intended.

I also noticed that there are no constructors for `BareInterval` from `Complex`. This would maybe be by design though? Since in general `BareInterval` is intended to be very "bare".