### PR TITLE
intervals: pass precision to `BigFloat` instead of changing globally

### DIFF
--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -8,9 +8,7 @@ Create a `BigFloat` with the same underlying precision.
 """
 function _bigequiv(x::T) where {T<:NumTypes}
     lock(precision_lock) do
-        setprecision(precision(float(T))) do
-            return BigFloat(x)
-        end
+        BigFloat(x, precision = precision(float(T)))
     end
 end
 


### PR DESCRIPTION
Taking the lock is still necessary after this change. It'd be necessary to audit all `BigFloat` methods to prove otherwise. Also see https://github.com/JuliaLang/julia/pull/49749, which fixes some of them in Julia `Base`.