### PR TITLE
Fix thread-safe in rounding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
 version = "0.22.5"
 
 [deps]
-CRlibm = "96374032-68de-5a5b-8d9e-752f78720389"
+CRlibm_jll = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"
 RoundingEmulator = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
 
 [weakdeps]
@@ -16,7 +16,7 @@ IntervalArithmeticDiffRulesExt = "DiffRules"
 IntervalArithmeticRecipesBaseExt = "RecipesBase"
 
 [compat]
-CRlibm = "1"
+CRlibm_jll = "1"
 DiffRules = "1"
 RecipesBase = "1"
 RoundingEmulator = "0.2"

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -1,12 +1,8 @@
 module IntervalArithmetic
 
-import CRlibm
+import CRlibm_jll
 import RoundingEmulator
 import Base.MPFR
-
-function __init__()
-    setrounding(BigFloat, RoundNearest)
-end
 
 #
 

--- a/src/intervals/arithmetic/basic.jl
+++ b/src/intervals/arithmetic/basic.jl
@@ -236,12 +236,14 @@ end
 
 Implement the `sqrt` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.sqrt(x::BareInterval{T}) where {T<:NumTypes}
+function Base.sqrt(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, zero(T), typemax(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) && return x
     return @round(T, sqrt(inf(x)), sqrt(sup(x)))
 end
+
+Base.sqrt(x::BareInterval{<:Rational}) = sqrt(float(x))
 
 function Base.sqrt(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, zero(T), typemax(T))

--- a/src/intervals/arithmetic/hyperbolic.jl
+++ b/src/intervals/arithmetic/hyperbolic.jl
@@ -10,10 +10,12 @@ for f ∈ (:sinh, :tanh, :asinh)
 
         Implement the `$($f)` function of the IEEE Standard 1788-2015 (Table 9.1).
         """
-        function Base.$f(x::BareInterval{T}) where {T<:NumTypes}
+        function Base.$f(x::BareInterval{T}) where {T<:AbstractFloat}
             isempty_interval(x) && return x
             return @round(T, $f(inf(x)), $f(sup(x)))
         end
+
+        Base.$f(x::BareInterval{<:Rational}) = $f(float(x))
 
         function Base.$f(x::Interval)
             r = $f(bareinterval(x))
@@ -29,10 +31,12 @@ end
 
 Implement the `cosh` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.cosh(x::BareInterval{T}) where {T<:NumTypes}
+function Base.cosh(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     return @round(T, cosh(mig(x)), cosh(mag(x)))
 end
+
+Base.cosh(x::BareInterval{<:Rational}) = cosh(float(x))
 
 function Base.cosh(x::Interval)
     r = cosh(bareinterval(x))
@@ -46,7 +50,7 @@ end
 
 Implement the `coth` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.coth(x::BareInterval{T}) where {T<:NumTypes}
+function Base.coth(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     isthinzero(x) && return emptyinterval(BareInterval{T})
     lo, hi = bounds(x)
@@ -60,6 +64,8 @@ function Base.coth(x::BareInterval{T}) where {T<:NumTypes}
         return @round(T, coth(hi), coth(lo))
     end
 end
+
+Base.coth(x::BareInterval{<:Rational}) = coth(float(x))
 
 function Base.coth(x::Interval)
     bx = bareinterval(x)
@@ -75,7 +81,7 @@ end
 
 Implement the `sech` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.sech(x::BareInterval{T}) where {T<:NumTypes}
+function Base.sech(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     lo, hi = bounds(x)
     if lo ≥ 0 # decreasing function
@@ -86,6 +92,8 @@ function Base.sech(x::BareInterval{T}) where {T<:NumTypes}
         return @round(T, min(sech(lo), sech(hi)), one(T))
     end
 end
+
+Base.sech(x::BareInterval{<:Rational}) = sech(float(x))
 
 function Base.sech(x::Interval)
     r = sech(bareinterval(x))
@@ -99,7 +107,7 @@ end
 
 Implement the `csch` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.csch(x::BareInterval{T}) where {T<:NumTypes}
+function Base.csch(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     isthinzero(x) && return emptyinterval(BareInterval{T})
     lo, hi = bounds(x)
@@ -113,6 +121,8 @@ function Base.csch(x::BareInterval{T}) where {T<:NumTypes}
         return @round(T, csch(hi), csch(lo))
     end
 end
+
+Base.csch(x::BareInterval{<:Rational}) = csch(float(x))
 
 function Base.csch(x::Interval)
     bx = bareinterval(x)
@@ -128,12 +138,14 @@ end
 
 Implement the `acosh` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.acosh(x::BareInterval{T}) where {T<:NumTypes}
+function Base.acosh(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, one(T), typemax(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) && return x
     return @round(T, acosh(inf(x)), acosh(sup(x)))
 end
+
+Base.acosh(x::BareInterval{<:Rational}) = acosh(float(x))
 
 function Base.acosh(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, one(T), typemax(T))
@@ -150,7 +162,7 @@ end
 
 Implement the `atanh` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.atanh(x::BareInterval{T}) where {T<:NumTypes}
+function Base.atanh(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) && return x
@@ -158,6 +170,8 @@ function Base.atanh(x::BareInterval{T}) where {T<:NumTypes}
     res_lo, res_hi = bounds(@round(T, atanh(lo), atanh(hi)))
     return bareinterval(T, res_lo, res_hi)
 end
+
+Base.atanh(x::BareInterval{<:Rational}) = atanh(float(x))
 
 function Base.atanh(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
@@ -174,7 +188,7 @@ end
 
 Implement the `acoth` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.acoth(x::BareInterval{T}) where {T<:NumTypes}
+function Base.acoth(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     singular_domain = _unsafe_bareinterval(T, -one(T), one(T))
     issubset_interval(x, singular_domain) && return emptyinterval(BareInterval{T})
@@ -191,6 +205,8 @@ function Base.acoth(x::BareInterval{T}) where {T<:NumTypes}
         return @round(T, acoth(hi), acoth(lo))
     end
 end
+
+Base.acoth(x::BareInterval{<:Rational}) = acoth(float(x))
 
 function Base.acoth(x::Interval{T}) where {T<:NumTypes}
     singular_domain = _unsafe_bareinterval(T, -one(T), one(T))

--- a/src/intervals/arithmetic/power.jl
+++ b/src/intervals/arithmetic/power.jl
@@ -255,7 +255,7 @@ Compute the real `n`-th root of `x`.
 
 Implement the `rootn` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function rootn(x::BareInterval{T}, n::Integer) where {T<:NumTypes}
+function rootn(x::BareInterval{T}, n::Integer) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     n == 0 && return emptyinterval(BareInterval{T})
     n == 1 && return x
@@ -268,6 +268,8 @@ function rootn(x::BareInterval{T}, n::Integer) where {T<:NumTypes}
 
     return @round(T, rootn(inf(x), n), rootn(sup(x), n))
 end
+
+rootn(x::BareInterval{<:Rational}) = rootn(float(x))
 
 function rootn(x::Interval{T}, n::Integer) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, ifelse(iseven(n), zero(T), typemin(T)), typemax(T))
@@ -395,10 +397,12 @@ end
 
 for f ∈ (:cbrt, :exp, :exp2, :exp10, :expm1)
     @eval begin
-        function Base.$f(x::BareInterval{T}) where {T<:NumTypes}
+        function Base.$f(x::BareInterval{T}) where {T<:AbstractFloat}
             isempty_interval(x) && return x
             return @round(T, $f(inf(x)), $f(sup(x)))
         end
+
+        Base.$f(x::BareInterval{<:Rational}) = $f(float(x))
 
         function Base.$f(x::Interval)
             bx = bareinterval(x)
@@ -413,12 +417,14 @@ end
 
 for f ∈ (:log, :log2, :log10)
     @eval begin
-        function Base.$f(x::BareInterval{T}) where {T<:NumTypes}
+        function Base.$f(x::BareInterval{T}) where {T<:AbstractFloat}
             domain = _unsafe_bareinterval(T, zero(T), typemax(T))
             x = intersect_interval(x, domain)
             isempty_interval(x) | (sup(x) == 0) && return emptyinterval(BareInterval{T})
             return @round(T, $f(inf(x)), $f(sup(x)))
         end
+
+        Base.$f(x::BareInterval{<:Rational}) = $f(float(x))
 
         function Base.$f(x::Interval{T}) where {T<:NumTypes}
             domain = _unsafe_bareinterval(T, zero(T), typemax(T))
@@ -431,12 +437,14 @@ for f ∈ (:log, :log2, :log10)
     end
 end
 
-function Base.log1p(x::BareInterval{T}) where {T<:NumTypes}
+function Base.log1p(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, -one(T), typemax(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) | (sup(x) == -1) && return emptyinterval(BareInterval{T})
     return @round(T, log1p(inf(x)), log1p(sup(x)))
 end
+
+Base.log1p(x::BareInterval{<:Rational}) = log1p(float(x))
 
 function Base.log1p(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, -one(T), typemax(T))

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -94,7 +94,7 @@ end
 # not in the IEEE Standard 1788-2015
 
 if Int == Int32 && VERSION < v"1.10"
-    Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat} = sin(x * interval(T, π))
+    Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat} = sin(x * bareinterval(T, π))
 else
     function Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat}
         isempty_interval(x) && return x
@@ -190,7 +190,7 @@ end
 # not in the IEEE Standard 1788-2015
 
 if Int == Int32 && VERSION < v"1.10"
-    Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat} = cos(x * interval(T, π))
+    Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat} = cos(x * bareinterval(T, π))
 else
     function Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat}
         isempty_interval(x) && return x

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -127,6 +127,10 @@ function Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat}
     end
 end
 
+if Int == Int32 && VERSION < v"1.10"
+    Base.sinpi(x::BareInterval{Float32}) = sin(x * interval(T, π))
+end
+
 Base.sinpi(x::BareInterval{<:Rational}) = sinpi(float(x))
 
 function Base.sinpi(x::Interval)
@@ -219,6 +223,10 @@ function Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat}
         return _unsafe_bareinterval(T, -one(T), one(T))
 
     end
+end
+
+if Int == Int32 && VERSION < v"1.10"
+    Base.cospi(x::BareInterval{Float32}) = cos(x * interval(T, π))
 end
 
 Base.cospi(x::BareInterval{<:Rational}) = cospi(float(x))

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -242,8 +242,8 @@ function Base.tan(x::BareInterval{T}) where {T<:AbstractFloat}
 
     lo, hi = bounds(x)
 
-    @show lo_quadrant = _quadrant(lo)
-    @show hi_quadrant = _quadrant(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
     lo_quadrant_mod = mod(lo_quadrant, 2)
     hi_quadrant_mod = mod(hi_quadrant, 2)
 

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -93,42 +93,42 @@ end
 
 # not in the IEEE Standard 1788-2015
 
-function Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat}
-    isempty_interval(x) && return x
-
-    d = diam(x)
-    d ≥ 2 && return _unsafe_bareinterval(T, -one(T), one(T))
-
-    lo, hi = bounds(x)
-
-    lo_quadrant = _quadrantpi(lo)
-    hi_quadrant = _quadrantpi(hi)
-
-    if lo_quadrant == hi_quadrant
-        d ≥ 1 && return _unsafe_bareinterval(T, -one(T), one(T))
-        (lo_quadrant == 1) | (lo_quadrant == 2) && return @round(T, sinpi(hi), sinpi(lo)) # decreasing
-        return @round(T, sinpi(lo), sinpi(hi))
-
-    elseif lo_quadrant == 3 && hi_quadrant == 0
-        return @round(T, sinpi(lo), sinpi(hi)) # increasing
-
-    elseif lo_quadrant == 1 && hi_quadrant == 2
-        return @round(T, sinpi(hi), sinpi(lo)) # decreasing
-
-    elseif (lo_quadrant == 0 || lo_quadrant == 3) && (hi_quadrant == 1 || hi_quadrant == 2)
-        return @round(T, min(sinpi(lo), sinpi(hi)), one(T))
-
-    elseif (lo_quadrant == 1 || lo_quadrant == 2) && (hi_quadrant == 3 || hi_quadrant == 0)
-        return @round(T, -one(T), max(sinpi(lo), sinpi(hi)))
-
-    else # (lo_quadrant == 0 && hi_quadrant == 3) || (lo_quadrant == 2 && hi_quadrant == 1)
-        return _unsafe_bareinterval(T, -one(T), one(T))
-
-    end
-end
-
 if Int == Int32 && VERSION < v"1.10"
-    Base.sinpi(x::BareInterval{Float32}) = sin(x * interval(T, π))
+    Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat} = sin(x * interval(T, π))
+else
+    function Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat}
+        isempty_interval(x) && return x
+
+        d = diam(x)
+        d ≥ 2 && return _unsafe_bareinterval(T, -one(T), one(T))
+
+        lo, hi = bounds(x)
+
+        lo_quadrant = _quadrantpi(lo)
+        hi_quadrant = _quadrantpi(hi)
+
+        if lo_quadrant == hi_quadrant
+            d ≥ 1 && return _unsafe_bareinterval(T, -one(T), one(T))
+            (lo_quadrant == 1) | (lo_quadrant == 2) && return @round(T, sinpi(hi), sinpi(lo)) # decreasing
+            return @round(T, sinpi(lo), sinpi(hi))
+
+        elseif lo_quadrant == 3 && hi_quadrant == 0
+            return @round(T, sinpi(lo), sinpi(hi)) # increasing
+
+        elseif lo_quadrant == 1 && hi_quadrant == 2
+            return @round(T, sinpi(hi), sinpi(lo)) # decreasing
+
+        elseif (lo_quadrant == 0 || lo_quadrant == 3) && (hi_quadrant == 1 || hi_quadrant == 2)
+            return @round(T, min(sinpi(lo), sinpi(hi)), one(T))
+
+        elseif (lo_quadrant == 1 || lo_quadrant == 2) && (hi_quadrant == 3 || hi_quadrant == 0)
+            return @round(T, -one(T), max(sinpi(lo), sinpi(hi)))
+
+        else # (lo_quadrant == 0 && hi_quadrant == 3) || (lo_quadrant == 2 && hi_quadrant == 1)
+            return _unsafe_bareinterval(T, -one(T), one(T))
+
+        end
+    end
 end
 
 Base.sinpi(x::BareInterval{<:Rational}) = sinpi(float(x))
@@ -189,44 +189,44 @@ end
 
 # not in the IEEE Standard 1788-2015
 
-function Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat}
-    isempty_interval(x) && return x
-
-    d = diam(x)
-    d ≥ 2 && return _unsafe_bareinterval(T, -one(T), one(T))
-
-    lo, hi = bounds(x)
-
-    isthin(x) & !isinteger(lo) & isinteger(2lo) && return zero(BareInterval{T}) # by-pass rounding to improve accuracy for 32 bit systems
-
-    lo_quadrant = _quadrantpi(lo)
-    hi_quadrant = _quadrantpi(hi)
-
-    if lo_quadrant == hi_quadrant
-        d ≥ 1 && return _unsafe_bareinterval(T, -one(T), one(T))
-        (lo_quadrant == 2) | (lo_quadrant == 3) && return @round(T, cospi(lo), cospi(hi)) # increasing
-        return @round(T, cospi(hi), cospi(lo))
-
-    elseif lo_quadrant == 2 && hi_quadrant == 3
-        return @round(T, cospi(lo), cospi(hi))
-
-    elseif lo_quadrant == 0 && hi_quadrant == 1
-        return @round(T, cospi(hi), cospi(lo))
-
-    elseif (lo_quadrant == 2 || lo_quadrant == 3) && (hi_quadrant == 0 || hi_quadrant == 1)
-        return @round(T, min(cospi(lo), cospi(hi)), one(T))
-
-    elseif (lo_quadrant == 0 || lo_quadrant == 1) && (hi_quadrant == 2 || hi_quadrant == 3)
-        return @round(T, -one(T), max(cospi(lo), cospi(hi)))
-
-    else # (lo_quadrant == 3 && hi_quadrant == 2) || (lo_quadrant == 1 && hi_quadrant == 0)
-        return _unsafe_bareinterval(T, -one(T), one(T))
-
-    end
-end
-
 if Int == Int32 && VERSION < v"1.10"
-    Base.cospi(x::BareInterval{Float32}) = cos(x * interval(T, π))
+    Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat} = cos(x * interval(T, π))
+else
+    function Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat}
+        isempty_interval(x) && return x
+
+        d = diam(x)
+        d ≥ 2 && return _unsafe_bareinterval(T, -one(T), one(T))
+
+        lo, hi = bounds(x)
+
+        isthin(x) & !isinteger(lo) & isinteger(2lo) && return zero(BareInterval{T}) # by-pass rounding to improve accuracy for 32 bit systems
+
+        lo_quadrant = _quadrantpi(lo)
+        hi_quadrant = _quadrantpi(hi)
+
+        if lo_quadrant == hi_quadrant
+            d ≥ 1 && return _unsafe_bareinterval(T, -one(T), one(T))
+            (lo_quadrant == 2) | (lo_quadrant == 3) && return @round(T, cospi(lo), cospi(hi)) # increasing
+            return @round(T, cospi(hi), cospi(lo))
+
+        elseif lo_quadrant == 2 && hi_quadrant == 3
+            return @round(T, cospi(lo), cospi(hi))
+
+        elseif lo_quadrant == 0 && hi_quadrant == 1
+            return @round(T, cospi(hi), cospi(lo))
+
+        elseif (lo_quadrant == 2 || lo_quadrant == 3) && (hi_quadrant == 0 || hi_quadrant == 1)
+            return @round(T, min(cospi(lo), cospi(hi)), one(T))
+
+        elseif (lo_quadrant == 0 || lo_quadrant == 1) && (hi_quadrant == 2 || hi_quadrant == 3)
+            return @round(T, -one(T), max(cospi(lo), cospi(hi)))
+
+        else # (lo_quadrant == 3 && hi_quadrant == 2) || (lo_quadrant == 1 && hi_quadrant == 0)
+            return _unsafe_bareinterval(T, -one(T), one(T))
+
+        end
+    end
 end
 
 Base.cospi(x::BareInterval{<:Rational}) = cospi(float(x))

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -4,29 +4,23 @@
 
 # helper functions
 
-_quadrant_down(x::T) where {T<:Rational} = _quadrant(float(T)(x, RoundDown))
-_quadrant_down(x::T) where {T<:AbstractFloat} = _quadrant(x)
-
-_quadrant_up(x::T) where {T<:Rational} = _quadrant(float(T)(x, RoundUp))
-_quadrant_up(x::T) where {T<:AbstractFloat} = _quadrant(x)
-
 function _quadrant(x::AbstractFloat)
-    x_mod2pi = rem2pi(x, RoundNearest)
-    -2x_mod2pi > π && return 2 # [-π, -π/2)
-    x_mod2pi < 0 && return 3 # [-π/2, 0)
-    2x_mod2pi < π && return 0 # [0, π/2)
+    r = rem2pi(x, RoundNearest)
+    -2r > π && return 2 # [-π, -π/2)
+    r   < 0 && return 3 # [-π/2, 0)
+    2r  < π && return 0 # [0, π/2)
     return 1 # [π/2, π]
 end
 
-function _quadrantpi(x::NumTypes) # used in `sinpi` and `cospi`
-    x_mod2 = rem(x, 2)
-    2x_mod2 < -3 && return 0 # [-2π, -3π/2)
-    x_mod2 < -1 && return 1 # [-3π/2, -π)
-    2x_mod2 < -1 && return 2 # [-π, -π/2)
-    x_mod2 < 0 && return 3 # [-π/2, 0)
-    2x_mod2 < 1 && return 0 # [0, π/2)
-    x_mod2 < 1 && return 1 # [π/2, π)
-    2x_mod2 < 3 && return 2 # [π, 3π/2)
+function _quadrantpi(x::AbstractFloat) # used in `sinpi` and `cospi`
+    r = rem(x, 2)
+    2r < -3 && return 0 # [-2π, -3π/2)
+    r  < -1 && return 1 # [-3π/2, -π)
+    2r < -1 && return 2 # [-π, -π/2)
+    r  <  0 && return 3 # [-π/2, 0)
+    2r <  1 && return 0 # [0, π/2)
+    r  <  1 && return 1 # [π/2, π)
+    2r <  3 && return 2 # [π, 3π/2)
     return 3 # [3π/2, 2π]
 end
 
@@ -55,17 +49,16 @@ Base.cosd(x::Interval{T}) where {T<:NumTypes} = cospi(x / interval(T, 180))
 
 Implement the `sin` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.sin(x::BareInterval{T}) where {T<:NumTypes}
+function Base.sin(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     d = diam(x)
-    inf_two_pi = _mul_round(convert(T, 2), inf(bareinterval(T, π)), RoundDown)
-    d ≥ inf_two_pi && return _unsafe_bareinterval(T, -one(T), one(T))
+    d/2 ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
 
     if lo_quadrant == hi_quadrant
         d ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
@@ -90,6 +83,8 @@ function Base.sin(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.sin(x::BareInterval{<:Rational}) = sin(float(x))
+
 function Base.sin(x::Interval)
     @inline r = sin(bareinterval(x))
     d = min(decoration(x), decoration(r))
@@ -98,7 +93,7 @@ end
 
 # not in the IEEE Standard 1788-2015
 
-function Base.sinpi(x::BareInterval{T}) where {T<:NumTypes}
+function Base.sinpi(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     d = diam(x)
@@ -132,6 +127,8 @@ function Base.sinpi(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.sinpi(x::BareInterval{<:Rational}) = sinpi(float(x))
+
 function Base.sinpi(x::Interval)
     r = sinpi(bareinterval(x))
     d = min(decoration(x), decoration(r))
@@ -144,17 +141,16 @@ end
 
 Implement the `cos` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.cos(x::BareInterval{T}) where {T<:NumTypes}
+function Base.cos(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     d = diam(x)
-    inf_two_pi = _mul_round(convert(T, 2), inf(bareinterval(T, π)), RoundDown)
-    d ≥ inf_two_pi && return _unsafe_bareinterval(T, -one(T), one(T))
+    d/2 ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
 
     if lo_quadrant == hi_quadrant
         d ≥ π && return _unsafe_bareinterval(T, -one(T), one(T))
@@ -179,6 +175,8 @@ function Base.cos(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.cos(x::BareInterval{<:Rational}) = cos(float(x))
+
 function Base.cos(x::Interval)
     @inline r = cos(bareinterval(x))
     d = min(decoration(x), decoration(r))
@@ -187,7 +185,7 @@ end
 
 # not in the IEEE Standard 1788-2015
 
-function Base.cospi(x::BareInterval{T}) where {T<:NumTypes}
+function Base.cospi(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     d = diam(x)
@@ -223,6 +221,8 @@ function Base.cospi(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.cospi(x::BareInterval{<:Rational}) = cospi(float(x))
+
 function Base.cospi(x::Interval)
     r = cospi(bareinterval(x))
     d = min(decoration(x), decoration(r))
@@ -235,15 +235,15 @@ end
 
 Implement the `tan` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.tan(x::BareInterval{T}) where {T<:NumTypes}
+function Base.tan(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     diam(x) > π && return entireinterval(BareInterval{T})
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    @show lo_quadrant = _quadrant(lo)
+    @show hi_quadrant = _quadrant(hi)
     lo_quadrant_mod = mod(lo_quadrant, 2)
     hi_quadrant_mod = mod(hi_quadrant, 2)
 
@@ -255,6 +255,8 @@ function Base.tan(x::BareInterval{T}) where {T<:NumTypes}
 
     end
 end
+
+Base.tan(x::BareInterval{<:Rational}) = tan(float(x))
 
 function Base.tan(x::Interval)
     @inline r = tan(bareinterval(x))
@@ -269,7 +271,7 @@ end
 
 Implement the `cot` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.cot(x::BareInterval{T}) where {T<:NumTypes}
+function Base.cot(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     diam(x) > π && return entireinterval(BareInterval{T})
@@ -278,8 +280,8 @@ function Base.cot(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
 
     if (lo_quadrant == 2 || lo_quadrant == 3) && hi == 0
         return @round(T, typemin(T), cot(lo)) # singularity from the left
@@ -293,6 +295,8 @@ function Base.cot(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.cot(x::BareInterval{<:Rational}) = cot(float(x))
+
 # automatically defined for `Interval` since it is a subtype of `Real`
 
 """
@@ -301,15 +305,15 @@ end
 
 Implement the `sec` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.sec(x::BareInterval{T}) where {T<:NumTypes}
+function Base.sec(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     diam(x) > π && return entireinterval(BareInterval{T})
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
 
     if lo_quadrant == hi_quadrant
         (lo_quadrant == 0) | (lo_quadrant == 1) && return @round(T, sec(lo), sec(hi)) # increasing
@@ -327,6 +331,8 @@ function Base.sec(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.sec(x::BareInterval{<:Rational}) = sec(float(x))
+
 # automatically defined for `Interval` since it is a subtype of `Real`
 
 """
@@ -335,7 +341,7 @@ end
 
 Implement the `csc` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.csc(x::BareInterval{T}) where {T<:NumTypes}
+function Base.csc(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
 
     diam(x) > π && return entireinterval(BareInterval{T})
@@ -344,8 +350,8 @@ function Base.csc(x::BareInterval{T}) where {T<:NumTypes}
 
     lo, hi = bounds(x)
 
-    lo_quadrant = _quadrant_down(lo)
-    hi_quadrant = _quadrant_up(hi)
+    lo_quadrant = _quadrant(lo)
+    hi_quadrant = _quadrant(hi)
 
     if (lo_quadrant == 2 || lo_quadrant == 3) && hi == 0
         # singularity from the left
@@ -368,6 +374,8 @@ function Base.csc(x::BareInterval{T}) where {T<:NumTypes}
     end
 end
 
+Base.csc(x::BareInterval{<:Rational}) = csc(float(x))
+
 # automatically defined for `Interval` since it is a subtype of `Real`
 
 """
@@ -376,12 +384,14 @@ end
 
 Implement the `asin` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.asin(x::BareInterval{T}) where {T<:NumTypes}
+function Base.asin(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) && return x
     return @round(T, asin(inf(x)), asin(sup(x)))
 end
+
+Base.asin(x::BareInterval{<:Rational}) = asin(float(x))
 
 function Base.asin(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
@@ -398,12 +408,14 @@ end
 
 Implement the `acos` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.acos(x::BareInterval{T}) where {T<:NumTypes}
+function Base.acos(x::BareInterval{T}) where {T<:AbstractFloat}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
     x = intersect_interval(x, domain)
     isempty_interval(x) && return x
     return @round(T, acos(sup(x)), acos(inf(x)))
 end
+
+Base.acos(x::BareInterval{<:Rational}) = acos(float(x))
 
 function Base.acos(x::Interval{T}) where {T<:NumTypes}
     domain = _unsafe_bareinterval(T, -one(T), one(T))
@@ -420,10 +432,12 @@ end
 
 Implement the `atan` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.atan(x::BareInterval{T}) where {T<:NumTypes}
+function Base.atan(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     return @round(T, atan(inf(x)), atan(sup(x)))
 end
+
+Base.atan(x::BareInterval{<:Rational}) = atan(float(x))
 
 function Base.atan(x::Interval)
     r = atan(bareinterval(x))
@@ -437,10 +451,12 @@ end
 
 Implement the `acot` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.acot(x::BareInterval{T}) where {T<:NumTypes}
+function Base.acot(x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) && return x
     return @round(T, acot(sup(x)), acot(inf(x)))
 end
+
+Base.acot(x::BareInterval{<:Rational}) = acot(float(x))
 
 # automatically defined for `Interval` since it is a subtype of `Real`
 
@@ -450,7 +466,7 @@ end
 
 Implement the `atan2` function of the IEEE Standard 1788-2015 (Table 9.1).
 """
-function Base.atan(y::BareInterval{T}, x::BareInterval{T}) where {T<:NumTypes}
+function Base.atan(y::BareInterval{T}, x::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(y) && return y
     isempty_interval(x) && return x
 
@@ -496,6 +512,8 @@ function Base.atan(y::BareInterval{T}, x::BareInterval{T}) where {T<:NumTypes}
         end
     end
 end
+
+Base.atan(y::BareInterval{T}, x::BareInterval{T}) where {T<:Rational} = atan(float(y), float(x))
 
 Base.atan(y::BareInterval, x::BareInterval) = atan(promote(y, x)...)
 

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -76,25 +76,19 @@ end
 bounds(x::Real) = bounds(interval(x))
 
 """
-    mid(x)
+    mid(x, α = 0.5)
 
-Midpoint of `x`.
+Relative midpoint of `x`, for `α` between 0 and 1 such that `mid(x, 0)` is the
+lower bound of the interval, `mid(x, 1)` its upper bound, and `mid(x, 0.5)` its
+midpoint.
 
 Implement the `mid` function of the IEEE Standard 1788-2015 (Table 9.2).
 
 See also: [`inf`](@ref), [`sup`](@ref), [`bounds`](@ref), [`diam`](@ref),
 [`radius`](@ref) and [`midradius`](@ref).
-
-
-    mid(x, α)
-
-Relative midpoint of `x`, for `α` between 0 and 1.
-
-`mid(x, 0)` is the lower bound of the interval, `mid(x, 1)` the upper bound,
-and `mid(x, 0.5)` the midpoint.
 """
 function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
-    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
+    0 ≤ α ≤ 1 || throw(DomainError(α, "α must be between 0 and 1"))
     isempty_interval(x) && return convert(T, NaN)
     if isentire_interval(x)
         α == 0.5 && return zero(T)
@@ -105,13 +99,13 @@ function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
         lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
         hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
         β = convert(T, α)
-        midpoint = β * (hi + lo * (1/β - 1)) # Exactly 0.5 * (hi + lo) for β = 0.5
+        midpoint = β * (hi + lo * (1/β - 1)) # exactly 0.5 * (hi + lo) for β = 0.5
         isfinite(midpoint) && return _normalisezero(midpoint)
         return _normalisezero((1 - β) * lo + β * hi)
     end
 end
 function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
-    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
+    0 ≤ α ≤ 1 || throw(DomainError(α, "α must be between 0 and 1"))
     isempty_interval(x) && return throw(ArgumentError("cannot compute the midpoint of empty intervals; cannot return a `Rational` NaN"))
     if isentire_interval(x)
         α == 0.5 && return zero(T)
@@ -127,13 +121,14 @@ function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
         return _normalisezero((1 - β) * lo + β * hi)
     end
 end
+
 function mid(x::Interval{T}, α = 0.5) where {T<:AbstractFloat}
-    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
+    0 ≤ α ≤ 1 || throw(DomainError(α, "α must be between 0 and 1"))
     isnai(x) && return convert(T, NaN)
     return mid(bareinterval(x), α)
 end
 function mid(x::Interval{<:Rational}, α = 1//2)
-    !(0 <= α <= 1) && throw(DomainError(α, "α must be between 0 and 1"))
+    0 ≤ α ≤ 1 || throw(DomainError(α, "α must be between 0 and 1"))
     isnai(x) && return throw(ArgumentError("cannot compute the midpoint of an NaI; cannot return a `Rational` NaN"))
     return mid(bareinterval(x), α)
 end

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -25,14 +25,17 @@ for (f, fname) ∈ ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div))
 
         $g(::IntervalRounding, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} =
             $g(IntervalRounding{:slow}(), x, y, r)
+
         # $g(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Down}) where {T<:AbstractFloat} =
         #     prevfloat($f(x, y))
         # $g(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Up}) where {T<:AbstractFloat} =
         #     nextfloat($f(x, y))
+
         $g(::IntervalRounding{:tight}, x::T, y::T, ::RoundingMode{:Down}) where {T<:Union{Float32,Float64}} =
             RoundingEmulator.$(Symbol(fname, :_down))(x, y)
         $g(::IntervalRounding{:tight}, x::T, y::T, ::RoundingMode{:Up}) where {T<:Union{Float32,Float64}} =
             RoundingEmulator.$(Symbol(fname, :_up))(x, y)
+
         function $g(::IntervalRounding{:slow}, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat}
             prec = max(precision(x), precision(y))
             bigx = BigFloat(x; precision = prec)
@@ -46,6 +49,7 @@ for (f, fname) ∈ ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div))
             )::Int32
             return bigz
         end
+
         $g(::IntervalRounding{:none}, x::T, y::T, ::RoundingMode) where {T<:AbstractFloat} = $f(x, y)
     end
 end
@@ -59,10 +63,12 @@ _pow_round(x::Rational, n::Integer, ::RoundingMode) = ^(x, n) # exact operation
 
 _pow_round(::IntervalRounding, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} =
     _pow_round(IntervalRounding{:slow}(), x, y, r)
+
 # _pow_round(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Down}) where {T<:AbstractFloat} =
 #     prevfloat(^(x, y))
 # _pow_round(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Up}) where {T<:AbstractFloat} =
 #     nextfloat(^(x, y))
+
 function _pow_round(::IntervalRounding{:slow}, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat}
     prec = max(precision(x), precision(y))
     bigx = BigFloat(x; precision = prec)
@@ -76,6 +82,7 @@ function _pow_round(::IntervalRounding{:slow}, x::T, y::T, r::RoundingMode) wher
     )::Int32
     return bigz
 end
+
 _pow_round(::IntervalRounding{:none}, x::T, y::T, ::RoundingMode) where {T<:AbstractFloat} = ^(x, y)
 
 #
@@ -85,14 +92,17 @@ _inv_round(x::Rational, ::RoundingMode) = inv(x) # exact operation
 
 _inv_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) =
     _inv_round(IntervalRounding{:slow}(), x, r)
+
 # _inv_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
 #     prevfloat(inv(x))
 # _inv_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
 #     nextfloat(inv(x))
+
 _inv_round(::IntervalRounding{:tight}, x::Union{Float32,Float64}, ::RoundingMode{:Down}) =
     RoundingEmulator.div_down(one(x), x)
 _inv_round(::IntervalRounding{:tight}, x::Union{Float32,Float64}, ::RoundingMode{:Up}) =
     RoundingEmulator.div_up(one(x), x)
+
 function _inv_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
     prec = precision(x)
     bigx = BigFloat(x; precision = prec)
@@ -105,6 +115,7 @@ function _inv_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode
     )::Int32
     return bigz
 end
+
 _inv_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = inv(x)
 
 #
@@ -113,14 +124,17 @@ _sqrt_round(x::AbstractFloat, r::RoundingMode) = _sqrt_round(interval_rounding()
 
 _sqrt_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) =
     _sqrt_round(IntervalRounding{:slow}(), x, r)
+
 # _sqrt_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
 #     prevfloat(sqrt(x))
 # _sqrt_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
 #     nextfloat(sqrt(x))
+
 _sqrt_round(::IntervalRounding{:tight}, x::Union{Float32,Float64}, ::RoundingMode{:Down}) =
     RoundingEmulator.sqrt_down(x)
 _sqrt_round(::IntervalRounding{:tight}, x::Union{Float32,Float64}, ::RoundingMode{:Up}) =
     RoundingEmulator.sqrt_up(x)
+
 function _sqrt_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
     prec = precision(x)
     bigx = BigFloat(x; precision = prec)
@@ -132,6 +146,7 @@ function _sqrt_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMod
     )::Int32
     return bigz
 end
+
 _sqrt_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = sqrt(x)
 
 #
@@ -140,10 +155,12 @@ _rootn_round(x::AbstractFloat, n::Integer, r::RoundingMode) = _rootn_round(inter
 
 _rootn_round(::IntervalRounding, x::AbstractFloat, n::Integer, r::RoundingMode) =
     _rootn_round(IntervalRounding{:slow}(), x, n, r)
+
 # _rootn_round(::IntervalRounding{:fast}, x::AbstractFloat, n::Integer, ::RoundingMode{:Down}) =
 #     prevfloat(x^(1//n))
 # _rootn_round(::IntervalRounding{:fast}, x::AbstractFloat, n::Integer, ::RoundingMode{:Up}) =
 #     nextfloat(x^(1//n))
+
 function _rootn_round(::IntervalRounding{:slow}, x::AbstractFloat, n::Integer, r::RoundingMode)
     prec = precision(x)
     bigx = BigFloat(x; precision = prec)
@@ -156,6 +173,7 @@ function _rootn_round(::IntervalRounding{:slow}, x::AbstractFloat, n::Integer, r
     )::Int32
     return bigz
 end
+
 _rootn_round(::IntervalRounding{:none}, x::AbstractFloat, n::Integer, ::RoundingMode) = x^(1//n)
 
 #
@@ -164,10 +182,12 @@ _atan_round(x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} = _atan_round(
 
 _atan_round(::IntervalRounding, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} =
     _atan_round(IntervalRounding{:slow}(), x, y, r)
+
 # _atan_round(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Down}) where {T<:AbstractFloat} =
 #     prevfloat(atan(x, y))
 # _atan_round(::IntervalRounding{:fast}, x::T, y::T, ::RoundingMode{:Up}) where {T<:AbstractFloat} =
 #     nextfloat(atan(x, y))
+
 function _atan_round(::IntervalRounding{:slow}, x::T, y::T, r::RoundingMode) where {T<:AbstractFloat}
     prec = max(precision(x), precision(y))
     bigx = BigFloat(x; precision = prec)
@@ -181,6 +201,7 @@ function _atan_round(::IntervalRounding{:slow}, x::T, y::T, r::RoundingMode) whe
     )::Int32
     return bigz
 end
+
 _atan_round(::IntervalRounding{:none}, x::T, y::T, ::RoundingMode) where {T<:AbstractFloat} = atan(x, y)
 
 #
@@ -193,10 +214,12 @@ for f ∈ [:cbrt, :exp2, :exp10, :cot, :sec, :csc, :tanh, :coth, :sech, :csch, :
         $f_round(x::AbstractFloat, r::RoundingMode) = $f_round(interval_rounding(), x, r)
 
         $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
+
         # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
         #     prevfloat($f(x))
         # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
         #     nextfloat($f(x))
+
         function $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
             prec = precision(x)
             bigx = BigFloat(x; precision = prec)
@@ -208,6 +231,7 @@ for f ∈ [:cbrt, :exp2, :exp10, :cot, :sec, :csc, :tanh, :coth, :sech, :csch, :
             )::Int32
             return bigz
         end
+
         $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
     end
 end
@@ -220,10 +244,12 @@ for (f, g) ∈ [(:acot, :atan), (:acoth, :atanh)]
         $f_round(x::AbstractFloat, r::RoundingMode) = $f_round(interval_rounding(), x, r)
 
         $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
+
         # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
         #     prevfloat($f(x))
         # $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
         #     nextfloat($f(x))
+
         function $f_round(ir::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode{:Down})
             prec = precision(x)
             bigx = BigFloat(x; precision = prec + 10)
@@ -250,6 +276,7 @@ for (f, g) ∈ [(:acot, :atan), (:acoth, :atanh)]
             bigw = $g_round(ir, bigz, r)
             return BigFloat(bigw, r; precision = prec)
         end
+
         $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
     end
 end
@@ -263,15 +290,17 @@ for f ∈ [:exp, :expm1, :log, :log1p, :log2, :log10, :sin, :cos, :tan, :asin, :
         crlibm_f_u = string(f, "_ru")
         mpfr_f = Symbol(:mpfr_, f)
 
-        @eval $f_round(x::AbstractFloat, r::RoundingMode) = $f_round(interval_rounding(), x, r)
+        if Int == Int32 # issues with CRlibm for 32 bit systems, use MPFR (only available since Julia v1.10)
+            if VERSION ≥ v"1.10" || f ∉ (:sinpi, :cospi)
+                @eval $f_round(x::AbstractFloat, r::RoundingMode) = $f_round(interval_rounding(), x, r)
 
-        @eval $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
-        # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
-        #     prevfloat($f(x))
-        # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
-        #     nextfloat($f(x))
-        if Int == Int32 && f ∈ (:sinpi, :cospi) # issues with CRlibm for 32 bit systems, use MPFR (only available since Julia v1.10)
-            if VERSION ≥ v"1.10"
+                @eval $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
+
+                # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
+                #     prevfloat($f(x))
+                # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
+                #     nextfloat($f(x))
+
                 @eval function $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
                     prec = precision(x)
                     bigx = BigFloat(x; precision = prec)
@@ -283,8 +312,19 @@ for f ∈ [:exp, :expm1, :log, :log1p, :log2, :log10, :sin, :cos, :tan, :asin, :
                     )::Int32
                     return bigz
                 end
+
+                @eval $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
             end
         else
+            @eval $f_round(x::AbstractFloat, r::RoundingMode) = $f_round(interval_rounding(), x, r)
+
+            @eval $f_round(::IntervalRounding, x::AbstractFloat, r::RoundingMode) = $f_round(IntervalRounding{:slow}(), x, r)
+
+            # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Down}) =
+            #     prevfloat($f(x))
+            # @eval $f_round(::IntervalRounding{:fast}, x::AbstractFloat, ::RoundingMode{:Up}) =
+            #     nextfloat($f(x))
+
             @eval $f_round(::IntervalRounding{:tight}, x::Float16, r::RoundingMode) = Float16($f_round(Float64(x), r), r)
             @eval $f_round(::IntervalRounding{:tight}, x::Float32, r::RoundingMode) = Float32($f_round(Float64(x), r), r)
             @eval $f_round(::IntervalRounding{:tight}, x::Float64, r::RoundingMode{:Down}) = ccall(($crlibm_f_d, CRlibm_jll.libcrlibm), Float64, (Float64,), x)
@@ -301,8 +341,9 @@ for f ∈ [:exp, :expm1, :log, :log1p, :log2, :log10, :sin, :cos, :tan, :asin, :
                 )::Int32
                 return bigz
             end
+
+            @eval $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
         end
-        @eval $f_round(::IntervalRounding{:none}, x::AbstractFloat, ::RoundingMode) = $f(x)
     end
 end
 

--- a/src/intervals/rounding.jl
+++ b/src/intervals/rounding.jl
@@ -283,10 +283,10 @@ for f ∈ [:exp, :expm1, :log, :log1p, :log2, :log10, :sin, :cos, :tan, :asin, :
                 return bigz
             end
         else
-            @eval $f_round(::IntervalRounding{:slow}, x::Float16, r::RoundingMode) = Float16($f_round(Float64(x), r), r)
-            @eval $f_round(::IntervalRounding{:slow}, x::Float32, r::RoundingMode) = Float32($f_round(Float64(x), r), r)
-            @eval $f_round(::IntervalRounding{:slow}, x::Float64, r::RoundingMode{:Down}) = ccall(($crlibm_f_d, CRlibm_jll.libcrlibm), Float64, (Float64,), x)
-            @eval $f_round(::IntervalRounding{:slow}, x::Float64, r::RoundingMode{:Up}) = ccall(($crlibm_f_u, CRlibm_jll.libcrlibm), Float64, (Float64,), x)
+            @eval $f_round(::IntervalRounding{:tight}, x::Float16, r::RoundingMode) = Float16($f_round(Float64(x), r), r)
+            @eval $f_round(::IntervalRounding{:tight}, x::Float32, r::RoundingMode) = Float32($f_round(Float64(x), r), r)
+            @eval $f_round(::IntervalRounding{:tight}, x::Float64, r::RoundingMode{:Down}) = ccall(($crlibm_f_d, CRlibm_jll.libcrlibm), Float64, (Float64,), x)
+            @eval $f_round(::IntervalRounding{:tight}, x::Float64, r::RoundingMode{:Up}) = ccall(($crlibm_f_u, CRlibm_jll.libcrlibm), Float64, (Float64,), x)
 
             @eval function $f_round(::IntervalRounding{:slow}, x::AbstractFloat, r::RoundingMode)
                 prec = precision(x)

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -25,10 +25,12 @@
     @test isequal_interval(interval(0, 1 + im), interval(0 + 0im, 1 + im))
 end
 
-@testset "Inverse roots of unity" begin
-    for i ∈ 0:99
-        @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
-            radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
+    @testset "Inverse roots of unity" begin
+        for i ∈ 0:99
+            @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
+                radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+        end
     end
 end
 

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -27,8 +27,13 @@ end
 
 @testset "Inverse roots of unity" begin
     for i ∈ 0:99
-        @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
-            radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+        if Int == Int32 && VERSION < v"1.10"
+            @test_broken issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
+                radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+        else
+            @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
+                radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+        end
     end
 end
 

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -25,12 +25,10 @@
     @test isequal_interval(interval(0, 1 + im), interval(0 + 0im, 1 + im))
 end
 
-if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
-    @testset "Inverse roots of unity" begin
-        for i ∈ 0:99
-            @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
-                radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
-        end
+@testset "Inverse roots of unity" begin
+    for i ∈ 0:99
+        @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
+            radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
     end
 end
 

--- a/test/interval_tests/complex.jl
+++ b/test/interval_tests/complex.jl
@@ -28,8 +28,8 @@ end
 @testset "Inverse roots of unity" begin
     for i ∈ 0:99
         if Int == Int32 && VERSION < v"1.10"
-            @test_broken issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
-                radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()
+            @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
+                radius( inv(cispi( interval(i)/interval(50) )) ) < 100eps()
         else
             @test issubset_interval(cispi( -interval(i)/interval(50) ), inv(cispi( interval(i)/interval(50) ))) &&
                 radius( inv(cispi( interval(i)/interval(50) )) ) < 10eps()

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -36,80 +36,78 @@ end
     @test issubset_interval(cos(interval(BigFloat, 1.3, 6.3)), cos(interval(1.3, 6.3)))
 end
 
-if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
-    @testset "sinpi" begin
-        @test isempty_interval(sinpi(emptyinterval()))
-        @test issubset_interval(interval(-1 , 0), sinpi(interval(1, 2)))
-        @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
-        @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
-        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
-        @test isthin(sinpi(interval(1.0)), 0)
-        @test isthin(sinpi(interval(2.0)), 0)
-        @test isthin(sinpi(interval(0.5)), 1)
-        @test isthin(sinpi(interval(1.5)), -1)
-    end
+@testset "sinpi" begin
+    @test isempty_interval(sinpi(emptyinterval()))
+    @test issubset_interval(interval(-1 , 0), sinpi(interval(1, 2)))
+    @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
+    @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
+    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
+    @test isthin(sinpi(interval(1.0)), 0)
+    @test isthin(sinpi(interval(2.0)), 0)
+    @test isthin(sinpi(interval(0.5)), 1)
+    @test isthin(sinpi(interval(1.5)), -1)
+end
 
-    @testset "sind" begin
-        @test isempty_interval(sind(emptyinterval()))
-        @test issubset_interval(interval(-1 , 0), sind(interval(180, 360)))
-        @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
-        @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
-        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
-        @test isthin(sind(interval(180)), 0)
-        @test isthin(sind(interval(360)), 0)
-        @test isthin(sind(interval(90)), 1)
-        @test isthin(sind(interval(270)), -1)
-    end
+@testset "sind" begin
+    @test isempty_interval(sind(emptyinterval()))
+    @test issubset_interval(interval(-1 , 0), sind(interval(180, 360)))
+    @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
+    @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
+    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
+    @test isthin(sind(interval(180)), 0)
+    @test isthin(sind(interval(360)), 0)
+    @test isthin(sind(interval(90)), 1)
+    @test isthin(sind(interval(270)), -1)
+end
 
-    @testset "cospi" begin
-        @test isempty_interval(cospi(emptyinterval()))
-        @test isequal_interval(cospi(interval(1, 2)), interval(-1 , 1))
-        @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
-        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
-        @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
-        @test isthin(cospi(interval(1.0)), -1)
-        @test isthin(cospi(interval(2.0)), 1)
-        @test isthin(cospi(interval(0.5)), 0)
-        @test isthin(cospi(interval(1.5)), 0)
-    end
+@testset "cospi" begin
+    @test isempty_interval(cospi(emptyinterval()))
+    @test isequal_interval(cospi(interval(1, 2)), interval(-1 , 1))
+    @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
+    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
+    @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
+    @test isthin(cospi(interval(1.0)), -1)
+    @test isthin(cospi(interval(2.0)), 1)
+    @test isthin(cospi(interval(0.5)), 0)
+    @test isthin(cospi(interval(1.5)), 0)
+end
 
-    @testset "cosd" begin
-        @test isempty_interval(cosd(emptyinterval()))
-        @test isequal_interval(cosd(interval(180, 360)), interval(-1 , 1))
-        @test issubset_interval(interval(-1 , 0), cosd(interval(90, 270)))
-        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cosd(interval(45, 135)))
-        @test isequal_interval(cosd(interval(-45, 45)), interval(1/sqrt(2) , 1))
-        @test isthin(cosd(interval(180)), -1)
-        @test isthin(cosd(interval(360)), 1)
-        @test isthin(cosd(interval(90)), 0)
-        @test isthin(cosd(interval(270)), 0)
-    end
+@testset "cosd" begin
+    @test isempty_interval(cosd(emptyinterval()))
+    @test isequal_interval(cosd(interval(180, 360)), interval(-1 , 1))
+    @test issubset_interval(interval(-1 , 0), cosd(interval(90, 270)))
+    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cosd(interval(45, 135)))
+    @test isequal_interval(cosd(interval(-45, 45)), interval(1/sqrt(2) , 1))
+    @test isthin(cosd(interval(180)), -1)
+    @test isthin(cosd(interval(360)), 1)
+    @test isthin(cosd(interval(90)), 0)
+    @test isthin(cosd(interval(270)), 0)
+end
 
-    @testset "sincospi" begin
-        x = sincospi(emptyinterval())
-        @test isempty_interval(x[1]) & isempty_interval(x[2])
-        x = sincospi(interval(1, 2))
-        @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
-        x = sincospi(interval(0.5, 1.5))
-        @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
-        x = sincospi(interval(0.25, 0.75))
-        @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
-        x = sincospi(interval(-0.25, 0.25))
-        @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
-    end
+@testset "sincospi" begin
+    x = sincospi(emptyinterval())
+    @test isempty_interval(x[1]) & isempty_interval(x[2])
+    x = sincospi(interval(1, 2))
+    @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
+    x = sincospi(interval(0.5, 1.5))
+    @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
+    x = sincospi(interval(0.25, 0.75))
+    @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
+    x = sincospi(interval(-0.25, 0.25))
+    @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
+end
 
-    @testset "sincosd" begin
-        x = sincosd(emptyinterval())
-        @test isempty_interval(x[1]) & isempty_interval(x[2])
-        x = sincosd(interval(180, 380))
-        @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
-        x = sincosd(interval(90, 270))
-        @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
-        x = sincosd(interval(45, 135))
-        @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
-        x = sincosd(interval(-45, 45))
-        @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
-    end
+@testset "sincosd" begin
+    x = sincosd(emptyinterval())
+    @test isempty_interval(x[1]) & isempty_interval(x[2])
+    x = sincosd(interval(180, 380))
+    @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
+    x = sincosd(interval(90, 270))
+    @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
+    x = sincosd(interval(45, 135))
+    @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
+    x = sincosd(interval(-45, 45))
+    @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
 end
 
 @testset "tan" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -42,10 +42,17 @@ end
     @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
     @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
-    @test isthin(sinpi(interval(1.0)), 0)
-    @test isthin(sinpi(interval(2.0)), 0)
-    @test isthin(sinpi(interval(0.5)), 1)
-    @test isthin(sinpi(interval(1.5)), -1)
+    if Int == Int32 && VERSION < v"1.10"
+        @test in_interval(0, sinpi(interval(1.0)))
+        @test in_interval(0, sinpi(interval(2.0)))
+        @test in_interval(1, sinpi(interval(0.5)))
+        @test in_interval(-1, sinpi(interval(1.5)))
+    else
+        @test isthin(sinpi(interval(1.0)), 0)
+        @test isthin(sinpi(interval(2.0)), 0)
+        @test isthin(sinpi(interval(0.5)), 1)
+        @test isthin(sinpi(interval(1.5)), -1)
+    end
 end
 
 @testset "sind" begin
@@ -66,10 +73,17 @@ end
     @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
     @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
-    @test isthin(cospi(interval(1.0)), -1)
-    @test isthin(cospi(interval(2.0)), 1)
-    @test isthin(cospi(interval(0.5)), 0)
-    @test isthin(cospi(interval(1.5)), 0)
+    if Int == Int32 && VERSION < v"1.10"
+        @test in_interval(-1, cospi(interval(1.0)))
+        @test in_interval(1, cospi(interval(2.0)))
+        @test in_interval(0, cospi(interval(0.5)))
+        @test in_interval(0, cospi(interval(1.5)))
+    else
+        @test isthin(cospi(interval(1.0)), -1)
+        @test isthin(cospi(interval(2.0)), 1)
+        @test isthin(cospi(interval(0.5)), 0)
+        @test isthin(cospi(interval(1.5)), 0)
+    end
 end
 
 @testset "cosd" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -36,16 +36,18 @@ end
     @test issubset_interval(cos(interval(BigFloat, 1.3, 6.3)), cos(interval(1.3, 6.3)))
 end
 
-@testset "sinpi" begin
-    @test isempty_interval(sinpi(emptyinterval()))
-    @test issubset_interval(interval(-1 , 0), sinpi(interval(1, 2)))
-    @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
-    @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
-    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
-    @test isthin(sinpi(interval(1.0)), 0)
-    @test isthin(sinpi(interval(2.0)), 0)
-    @test isthin(sinpi(interval(0.5)), 1)
-    @test isthin(sinpi(interval(1.5)), -1)
+if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
+    @testset "sinpi" begin
+        @test isempty_interval(sinpi(emptyinterval()))
+        @test issubset_interval(interval(-1 , 0), sinpi(interval(1, 2)))
+        @test isequal_interval(sinpi(interval(0.5, 1.5)), interval(-1 , 1))
+        @test issubset_interval(interval(1/sqrt(2) , 1), sinpi(interval(0.25, 0.75)))
+        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-0.25, 0.25)))
+        @test isthin(sinpi(interval(1.0)), 0)
+        @test isthin(sinpi(interval(2.0)), 0)
+        @test isthin(sinpi(interval(0.5)), 1)
+        @test isthin(sinpi(interval(1.5)), -1)
+    end
 end
 
 @testset "sind" begin
@@ -53,23 +55,25 @@ end
     @test issubset_interval(interval(-1 , 0), sind(interval(180, 360)))
     @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
     @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
-    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sinpi(interval(-45, 45)))
+    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
     @test isthin(sind(interval(180)), 0)
     @test isthin(sind(interval(360)), 0)
     @test isthin(sind(interval(90)), 1)
     @test isthin(sind(interval(270)), -1)
 end
 
-@testset "cospi" begin
-    @test isempty_interval(cospi(emptyinterval()))
-    @test isequal_interval(cospi(interval(1, 2)), interval(-1 , 1))
-    @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
-    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
-    @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
-    @test isthin(cospi(interval(1.0)), -1)
-    @test isthin(cospi(interval(2.0)), 1)
-    @test isthin(cospi(interval(0.5)), 0)
-    @test isthin(cospi(interval(1.5)), 0)
+if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
+    @testset "cospi" begin
+        @test isempty_interval(cospi(emptyinterval()))
+        @test isequal_interval(cospi(interval(1, 2)), interval(-1 , 1))
+        @test issubset_interval(interval(-1 , 0), cospi(interval(0.5, 1.5)))
+        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cospi(interval(0.25, 0.75)))
+        @test isequal_interval(cospi(interval(-0.25, 0.25)), interval(1/sqrt(2) , 1))
+        @test isthin(cospi(interval(1.0)), -1)
+        @test isthin(cospi(interval(2.0)), 1)
+        @test isthin(cospi(interval(0.5)), 0)
+        @test isthin(cospi(interval(1.5)), 0)
+    end
 end
 
 @testset "cosd" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -84,17 +84,19 @@ end
     @test isthin(cosd(interval(270)), 0)
 end
 
-@testset "sincospi" begin
-    x = sincospi(emptyinterval())
-    @test isempty_interval(x[1]) & isempty_interval(x[2])
-    x = sincospi(interval(1, 2))
-    @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
-    x = sincospi(interval(0.5, 1.5))
-    @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
-    x = sincospi(interval(0.25, 0.75))
-    @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
-    x = sincospi(interval(-0.25, 0.25))
-    @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
+if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
+    @testset "sincospi" begin
+        x = sincospi(emptyinterval())
+        @test isempty_interval(x[1]) & isempty_interval(x[2])
+        x = sincospi(interval(1, 2))
+        @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
+        x = sincospi(interval(0.5, 1.5))
+        @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
+        x = sincospi(interval(0.25, 0.75))
+        @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
+        x = sincospi(interval(-0.25, 0.25))
+        @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
+    end
 end
 
 @testset "sincosd" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -48,21 +48,19 @@ if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
         @test isthin(sinpi(interval(0.5)), 1)
         @test isthin(sinpi(interval(1.5)), -1)
     end
-end
 
-@testset "sind" begin
-    @test isempty_interval(sind(emptyinterval()))
-    @test issubset_interval(interval(-1 , 0), sind(interval(180, 360)))
-    @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
-    @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
-    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
-    @test isthin(sind(interval(180)), 0)
-    @test isthin(sind(interval(360)), 0)
-    @test isthin(sind(interval(90)), 1)
-    @test isthin(sind(interval(270)), -1)
-end
+    @testset "sind" begin
+        @test isempty_interval(sind(emptyinterval()))
+        @test issubset_interval(interval(-1 , 0), sind(interval(180, 360)))
+        @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
+        @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
+        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
+        @test isthin(sind(interval(180)), 0)
+        @test isthin(sind(interval(360)), 0)
+        @test isthin(sind(interval(90)), 1)
+        @test isthin(sind(interval(270)), -1)
+    end
 
-if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
     @testset "cospi" begin
         @test isempty_interval(cospi(emptyinterval()))
         @test isequal_interval(cospi(interval(1, 2)), interval(-1 , 1))
@@ -74,21 +72,19 @@ if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
         @test isthin(cospi(interval(0.5)), 0)
         @test isthin(cospi(interval(1.5)), 0)
     end
-end
 
-@testset "cosd" begin
-    @test isempty_interval(cosd(emptyinterval()))
-    @test isequal_interval(cosd(interval(180, 360)), interval(-1 , 1))
-    @test issubset_interval(interval(-1 , 0), cosd(interval(90, 270)))
-    @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cosd(interval(45, 135)))
-    @test isequal_interval(cosd(interval(-45, 45)), interval(1/sqrt(2) , 1))
-    @test isthin(cosd(interval(180)), -1)
-    @test isthin(cosd(interval(360)), 1)
-    @test isthin(cosd(interval(90)), 0)
-    @test isthin(cosd(interval(270)), 0)
-end
+    @testset "cosd" begin
+        @test isempty_interval(cosd(emptyinterval()))
+        @test isequal_interval(cosd(interval(180, 360)), interval(-1 , 1))
+        @test issubset_interval(interval(-1 , 0), cosd(interval(90, 270)))
+        @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cosd(interval(45, 135)))
+        @test isequal_interval(cosd(interval(-45, 45)), interval(1/sqrt(2) , 1))
+        @test isthin(cosd(interval(180)), -1)
+        @test isthin(cosd(interval(360)), 1)
+        @test isthin(cosd(interval(90)), 0)
+        @test isthin(cosd(interval(270)), 0)
+    end
 
-if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
     @testset "sincospi" begin
         x = sincospi(emptyinterval())
         @test isempty_interval(x[1]) & isempty_interval(x[2])
@@ -101,19 +97,19 @@ if (Int != Int32 && VERSION < v"1.10") || VERSION ≥ v"1.10"
         x = sincospi(interval(-0.25, 0.25))
         @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
     end
-end
 
-@testset "sincosd" begin
-    x = sincosd(emptyinterval())
-    @test isempty_interval(x[1]) & isempty_interval(x[2])
-    x = sincosd(interval(180, 380))
-    @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
-    x = sincosd(interval(90, 270))
-    @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
-    x = sincosd(interval(45, 135))
-    @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
-    x = sincosd(interval(-45, 45))
-    @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
+    @testset "sincosd" begin
+        x = sincosd(emptyinterval())
+        @test isempty_interval(x[1]) & isempty_interval(x[2])
+        x = sincosd(interval(180, 380))
+        @test issubset_interval(interval(-1, 0), x[1]) & isequal_interval(x[2], interval(-1, 1))
+        x = sincosd(interval(90, 270))
+        @test isequal_interval(x[1], interval(-1, 1)) & issubset_interval(interval(-1, 0), x[2])
+        x = sincosd(interval(45, 135))
+        @test issubset_interval(interval(1/sqrt(2), 1), x[1]) & issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[2])
+        x = sincosd(interval(-45, 45))
+        @test issubset_interval(interval(-1/sqrt(2), 1/sqrt(2)), x[1]) & isequal_interval(x[2], interval(1/sqrt(2), 1))
+    end
 end
 
 @testset "tan" begin

--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -61,10 +61,17 @@ end
     @test isequal_interval(sind(interval(90, 270)), interval(-1 , 1))
     @test issubset_interval(interval(1/sqrt(2) , 1), sind(interval(45, 135)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), sind(interval(-45, 45)))
-    @test isthin(sind(interval(180)), 0)
-    @test isthin(sind(interval(360)), 0)
-    @test isthin(sind(interval(90)), 1)
-    @test isthin(sind(interval(270)), -1)
+    if Int == Int32 && VERSION < v"1.10"
+        @test in_interval(0, sind(interval(180)))
+        @test in_interval(0, sind(interval(360)))
+        @test in_interval(1, sind(interval(90)))
+        @test in_interval(-1, sind(interval(270)))
+    else
+        @test isthin(sind(interval(180)), 0)
+        @test isthin(sind(interval(360)), 0)
+        @test isthin(sind(interval(90)), 1)
+        @test isthin(sind(interval(270)), -1)
+    end
 end
 
 @testset "cospi" begin
@@ -92,10 +99,17 @@ end
     @test issubset_interval(interval(-1 , 0), cosd(interval(90, 270)))
     @test issubset_interval(interval(-1/sqrt(2) , 1/sqrt(2)), cosd(interval(45, 135)))
     @test isequal_interval(cosd(interval(-45, 45)), interval(1/sqrt(2) , 1))
-    @test isthin(cosd(interval(180)), -1)
-    @test isthin(cosd(interval(360)), 1)
-    @test isthin(cosd(interval(90)), 0)
-    @test isthin(cosd(interval(270)), 0)
+    if Int == Int32 && VERSION < v"1.10"
+        @test in_interval(-1, cosd(interval(180)))
+        @test in_interval(1, cosd(interval(360)))
+        @test in_interval(0, cosd(interval(90)))
+        @test in_interval(0, cosd(interval(270)))
+    else
+        @test isthin(cosd(interval(180)), -1)
+        @test isthin(cosd(interval(360)), 1)
+        @test isthin(cosd(interval(90)), 0)
+        @test isthin(cosd(interval(270)), 0)
+    end
 end
 
 @testset "sincospi" begin


### PR DESCRIPTION
This PR fixes the rounding mechanism to be thread-safe. It removes CRlibm.jl as a dependency, and directly calls methods from CRlibm_jll, or from MPFR as suggested by @Joel-Dahne.

This PR also fixes rounding for intervals with rational bounds by returning a float interval for non exact operations.

To do: we should probably also fix our quadrant method for trigonometric functions which is not thread-safe due to https://github.com/JuliaLang/julia/issues/52862