### PR TITLE
Avoid `convert` in `^` for literal powers

### DIFF
--- a/src/intervals/arithmetic/power.jl
+++ b/src/intervals/arithmetic/power.jl
@@ -66,7 +66,8 @@ Base.:^(x::Rational, y::Interval) = ^(convert(Interval{typeof(x)}, x), y)
 Base.:^(x::Interval, y::Rational) = ^(x, convert(Interval{typeof(y)}, y))
 
 # overwrite behaviour for small integer powers from https://github.com/JuliaLang/julia/pull/24240
-Base.literal_pow(::typeof(^), x::Interval, ::Val{n}) where {n} = x^n
+# Base.literal_pow(::typeof(^), x::Interval, ::Val{n}) where {n} = x^n
+Base.literal_pow(::typeof(^), x::Interval, ::Val{n}) where {n} = _select_pown(power_mode(), x, n)
 
 # helper functions for power
 

--- a/test/interval_tests/power.jl
+++ b/test/interval_tests/power.jl
@@ -90,3 +90,14 @@ end
 #     @test real(b) == interval(-13.12878308146216, -13.128783081462153)
 #     @test imag(b) == interval(-15.200784463067956, -15.20078446306795)
 # end
+
+@testset "Literal powers" begin
+    x = interval(-1,1)
+    n = 2
+    @test isguaranteed(x ^ 2)
+    @test !isguaranteed(x ^ n)
+    @test_broken isguaranteed(x ^ 2.0)
+    @test_broken isguaranteed(x ^ 2305843009213693952)
+    @test isequal_interval(x^2, interval(0,1))
+    @test isequal_interval(x^3, x)
+end


### PR DESCRIPTION
Fix #618 