### PR TITLE
Ensure thread-safety for trigonometric functions

### DIFF
--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -12,10 +12,10 @@ function _quadrant(x::AbstractFloat)
     r = rem2pi(x, RoundNearest)
     r2 = 2r # should be exact for floats
     r2 ≤ -PI_HI && return 2 # [-π, -π/2)
-    r2 < -PI_LO && return throw(ArgumentError("could not determine if $x is lesser or greater than -π/2"))
+    r2 < -PI_LO && return throw(ArgumentError("could not determine the quadrant, the remainder $r of the division of $x by 2π is lesser or greater than -π/2"))
     r2 <  0     && return 3 # [-π/2, 0)
     r2 ≤  PI_LO && return 0 # [0, π/2)
-    r2 <  PI_HI && return throw(ArgumentError("could not determine if $x is lesser or greater than π/2"))
+    r2 <  PI_HI && return throw(ArgumentError("could not determine the quadrant, the remainder $r of the division of $x by 2π is lesser or greater than π/2"))
     return 1 # [π/2, π]
 end
 

--- a/src/intervals/arithmetic/trigonometric.jl
+++ b/src/intervals/arithmetic/trigonometric.jl
@@ -5,31 +5,22 @@
 # helper functions
 
 function _quadrant(x::AbstractFloat)
+    # NOTE: this algorithm may be flawed as it relies on `rem2pi(x, RoundNearest)`
+    # to yield a very tight result. This is not guaranteed by Julia, see e.g.
+    # https://github.com/JuliaLang/julia/blob/9669eecc99bc4553e28d94d7dd3dc9fd40b3bf3f/base/mpfr.jl#L845-L846
     PI_LO, PI_HI = bounds(bareinterval(typeof(x), π))
-
-    rlo = rem2pi(x, RoundDown) # [0, 2π]
-    qlo =        2rlo ≥ 3PI_HI ? 3 :
-        3PI_LO ≥ 2rlo ≥ 2PI_HI ? 2 :
-        2PI_LO ≥ 2rlo ≥  PI_HI ? 1 :
-         PI_LO ≥ 2rlo          ? 0 :
-        return throw(ArgumentError("could not determine a specific quadrant, got $qlo"))
-    rlo == x && return qlo
-
-    rhi = rem2pi(x, RoundUp) # [-2π, 0]
-    qhi =        -2rhi ≥ 3PI_HI ? 0 :
-        3PI_LO ≥ -2rhi ≥ 2PI_HI ? 1 :
-        2PI_LO ≥ -2rhi ≥  PI_HI ? 2 :
-         PI_LO ≥ -2rhi          ? 3 :
-        return throw(ArgumentError("could not determine a specific quadrant, got $qhi"))
-    rhi == x && return qhi
-
-    qlo == qhi && return qlo
-
-    return throw(ArgumentError("could not determine a specific quadrant, got $qlo and $qhi"))
+    r = rem2pi(x, RoundNearest)
+    r2 = 2r # should be exact for floats
+    r2 ≤ -PI_HI && return 2 # [-π, -π/2)
+    r2 < -PI_LO && return throw(ArgumentError("could not determine if $x is lesser or greater than -π/2"))
+    r2 <  0     && return 3 # [-π/2, 0)
+    r2 ≤  PI_LO && return 0 # [0, π/2)
+    r2 <  PI_HI && return throw(ArgumentError("could not determine if $x is lesser or greater than π/2"))
+    return 1 # [π/2, π]
 end
 
 function _quadrantpi(x::AbstractFloat) # used in `sinpi` and `cospi`
-    r = rem(x, 2) # [-2, 2] (should be exact for floats)
+    r = rem(x, 2) # [-2, 2], should be exact for floats
     2r < -3 && return 0 # [-2π, -3π/2)
     r  < -1 && return 1 # [-3π/2, -π)
     2r < -1 && return 2 # [-π, -π/2)


### PR DESCRIPTION
Closes #620

This PR makes sure we no longer rely on Julia default code to compare with `π` due to https://github.com/JuliaLang/julia/issues/52862.
This should ensure that trigonometric functions are thread-safe.

The PR also reworks the inner function `_quadrant`.

Now I consistently get the same precision before and after calling `sin` on multiple threads (see also #612):

```Julia
julia> x = interval(BigFloat, 1)
[1.0, 1.0]₂₅₆_com

julia> y = sin(x)
[0.84147, 0.841472]₂₅₆_com

julia> Threads.@threads for _ in 1:1000
           z = sin(x)
           @assert isequal_interval(y, z)
       end

julia> precision(BigFloat)
256
```

The implementation is based on @Joel-Dahne, @lbenet and @dpsanders suggestions.

Hopefully everything is in order! 🙂 