### PR TITLE
Extend boolean functions for intervals to numbers

### DIFF
--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -367,7 +367,7 @@ end
 
 isthin(x::Complex) = isthin(real(x)) & isthin(imag(x))
 
-isthin(x::Number) = isthin(interval(x)) # NOTE: isthin(pi) returns false
+isthin(x::Number) = isthin(interval(x))
 
 """
     isthin(x, y)
@@ -388,7 +388,7 @@ isthin(x::Number, y::Complex) = isthin(real(x), real(y)) & iszero(imag(y))
 
 isthin(x::BareInterval, y::Interval) = throw(MethodError(isthin, (x, y)))
 
-isthin(x::Number, y::Number) = isthin(interval(x), y) # NOTE: isthin(Inf, Inf) returns false
+isthin(x::Number, y::Number) = isthin(interval(x), y)
 
 """
     isthinzero(x)

--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -132,18 +132,18 @@ See also: [`isthin`](@ref).
 function Base.:(==)(x::Union{BareInterval,Interval}, y::Union{BareInterval,Interval}) # also returned when calling `≤`, `≥`, `isequal`
     isthin(y) || return throw(ArgumentError("`==` is only supported for thin intervals. See instead `isequal_interval`"))
     # `y` is not empty, nor an NaI
-    return x == inf(y)
+    return x == sup(y)
 end
 function Base.:(==)(x::Union{BareInterval,Interval}, y::Number)
     isthin(x) || return throw(ArgumentError("`==` is only supported between thin intervals and numbers. See instead `isequal_interval`"))
     # `x` is not empty, nor an NaI
-    return inf(x) == y
+    return sup(x) == y
 end
 Base.:(==)(x::Number, y::Union{BareInterval,Interval}) = y == x
 function Base.:(==)(x::Union{BareInterval,Interval}, y::Complex)
     isthin(x) || return throw(ArgumentError("`==` is only supported between thin intervals and numbers. See instead `isequal_interval`"))
     # `x` is not empty, nor an NaI
-    return inf(x) == y
+    return sup(x) == y
 end
 Base.:(==)(x::Complex, y::Union{BareInterval,Interval}) = y == x
 
@@ -171,17 +171,17 @@ See also: [`strictprecedes`](@ref).
 function Base.:<(x::Union{BareInterval,Interval}, y::Union{BareInterval,Interval}) # also returned when calling `isless`, `>`
     isthin(y) || return throw(ArgumentError("`<` is only supported for thin intervals. See instead `isstrictless`, `strictprecedes`"))
     # `y` is not empty, nor an NaI
-    return x < inf(y)
+    return x < sup(y)
 end
 function Base.:<(x::Union{BareInterval,Interval}, y::Real)
     isthin(x) || return throw(ArgumentError("`<` is only supported between thin intervals and numbers. See instead `isequal_interval`"))
     # `x` is not empty, nor an NaI
-    return inf(x) < y
+    return sup(x) < y
 end
 function Base.:<(x::Real, y::Union{BareInterval,Interval})
     isthin(y) || return throw(ArgumentError("`<` is only supported between thin intervals and numbers. See instead `isequal_interval`"))
     # `y` is not empty, nor an NaI
-    return x < inf(y)
+    return x < sup(y)
 end
 
 Base.:<(x::BareInterval, y::Interval) = throw(MethodError(<, (x, y)))
@@ -213,7 +213,7 @@ See also: [`isbounded`](@ref).
 function Base.isfinite(x::Union{BareInterval,Interval}) # also returned when calling `isinf`
     isthin(x) || return throw(ArgumentError("`isfinite` is only supported for thin intervals. See instead `isbounded`"))
     # `x` is not empty, nor an NaI
-    return isfinite(inf(x))
+    return isfinite(sup(x))
 end
 
 """
@@ -228,7 +228,7 @@ See also: [`isthinzero`](@ref).
 function Base.iszero(x::Union{BareInterval,Interval})
     isthin(x) || return throw(ArgumentError("`iszero` is only supported for thin intervals. See instead `isthinzero`"))
     # `x` is not empty, nor an NaI
-    return iszero(inf(x))
+    return iszero(sup(x))
 end
 
 """
@@ -243,7 +243,7 @@ See also: [`isthinone`](@ref).
 function Base.isone(x::Union{BareInterval,Interval})
     isthin(x) || return throw(ArgumentError("`isone` is only supported for thin intervals. See instead `isthinone`"))
     # `x` is not empty, nor an NaI
-    return isone(inf(x))
+    return isone(sup(x))
 end
 
 """
@@ -258,5 +258,5 @@ See also: [`isthininteger`](@ref).
 function Base.isinteger(x::Union{BareInterval,Interval})
     isthin(x) || return throw(ArgumentError("`isinteger` is only supported for thin intervals. See instead `isthininteger`"))
     # `x` is not empty, nor an NaI
-    return isinteger(inf(x))
+    return isinteger(sup(x))
 end

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -344,24 +344,24 @@
         @test x != y
         @test x < y
         @test isfinite(x)
-        @test isnan(x)
+        @test !isnan(x)
         @test isinteger(x)
         @test x == 1
         @test isone(x)
         @test !iszero(x)
 
-        @test_throws ArgumentError isdisjoint(x, y)
-        @test_throws ArgumentError issubset(x, y)
-        @test_throws ArgumentError issetequal(x, y)
-        @test_throws ArgumentError x ∈ y
-        @test_throws ArgumentError isempty(x)
+        @test_throws ArgumentError !isdisjoint(x, y)
+        @test_throws ArgumentError !issubset(x, y)
+        @test_throws ArgumentError !issetequal(x, y)
+        @test_throws ArgumentError !(x ∈ y)
+        @test_throws ArgumentError !isempty(x)
 
         x, y = interval(2, 3), interval(1)
 
         @test_throws ArgumentError x != y
         @test_throws ArgumentError x < y
         @test_throws ArgumentError isfinite(x)
-        @test_throws ArgumentError isnan(x)
+        @test_throws ArgumentError !isnan(x)
         @test_throws ArgumentError isinteger(x)
         @test_throws ArgumentError x == 1
         @test_throws ArgumentError isone(x)

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -340,19 +340,32 @@
 
     @testset "Disallowed `Real` functionalities" begin
         x, y = interval(1), interval(2)
-        @test_throws ArgumentError x == y
-        @test_throws ArgumentError x < y
+
+        @test x != y
+        @test x < y
+        @test isfinite(x)
+        @test isnan(x)
+        @test isinteger(x)
+        @test x == 1
+        @test isone(x)
+        @test !iszero(x)
+
         @test_throws ArgumentError isdisjoint(x, y)
         @test_throws ArgumentError issubset(x, y)
         @test_throws ArgumentError issetequal(x, y)
         @test_throws ArgumentError x ∈ y
         @test_throws ArgumentError isempty(x)
+
+        x, y = interval(2, 3), interval(1)
+
+        @test_throws ArgumentError x != y
+        @test_throws ArgumentError x < y
         @test_throws ArgumentError isfinite(x)
         @test_throws ArgumentError isnan(x)
-        @test isinteger(x)
-        @test x == 1
-        @test isone(x)
-        @test !iszero(x)
+        @test_throws ArgumentError isinteger(x)
+        @test_throws ArgumentError x == 1
+        @test_throws ArgumentError isone(x)
+        @test_throws ArgumentError !iszero(x)
     end
 
 end


### PR DESCRIPTION
This PR improves compatibility between `Number` and `Interval` by permitting most boolean functions to take numbers as an argument.

The general idea is that a boolean function defined for intervals, say `foo(x::Interval) = ...`, is extended to numbers by simply `foo(x::Number) = foo(interval(x))`.

This leads to some corner cases, eg `isthin(Inf, Inf)` and `isthin(pi)` return false.
Not sure if that should be the behaviour. The other possibility is of course to fall back to default Base functionalities: `isthinzero(x::Number) = iszero(x)` instead of `isthinzero(x::Number) = isthinzero(interval(x))`, etc.

@lbenet do you think this can help with https://github.com/JuliaDiff/TaylorSeries.jl/pull/345? Perhaps then you won't have to define your own `_isthinzero` function.