### PR TITLE
ForwardDiff extension for power

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.22.7"
+version = "0.22.8"
 
 [deps]
 CRlibm_jll = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"

--- a/Project.toml
+++ b/Project.toml
@@ -9,15 +9,18 @@ RoundingEmulator = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
 
 [weakdeps]
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [extensions]
 IntervalArithmeticDiffRulesExt = "DiffRules"
+IntervalArithmeticForwardDiffExt = "ForwardDiff"
 IntervalArithmeticRecipesBaseExt = "RecipesBase"
 
 [compat]
 CRlibm_jll = "1"
 DiffRules = "1"
+ForwardDiff = "0.10"
 RecipesBase = "1"
 RoundingEmulator = "0.2"
 julia = "1.9"

--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -1,0 +1,36 @@
+module IntervalArithmeticForwardDiffExt
+
+using IntervalArithmetic, ForwardDiff
+using ForwardDiff: Dual, ≺, value, partials
+
+function Base.:(^)(x::Dual{Txy, <:Interval}, y::Dual{Txy, <:Interval}) where Txy
+    vx, vy = value(x), value(y)
+    primal = vx^vy
+    powval = vy * vx^(vy - interval(1))
+    logval = primal * log(vx)
+    new_partials = _mul_partials(partials(x), partials(y), powval, logval)
+    return Dual{Txy}(primal, new_partials)
+end
+
+function Base.:(^)(x::Dual{Tx, <:Interval}, y::Dual{Ty, <:Interval}) where {Tx, Ty}
+    if Ty ≺ Tx 
+        return x^value(y)
+    else
+        return value(x)^y
+    end
+end
+
+function Base.:(^)(x::Dual{Tx, <:Interval}, y::Interval) where Tx
+    v = value(x)
+    new_partials = partials(x) * y * v^(y - interval(1))
+    return Dual{Tx}(v^y, new_partials)
+end
+
+function Base.:(^)(x::Interval, y::Dual{Ty, <:Interval}) where Ty
+    v = value(y)
+    primal = x^v
+    deriv = primal*log(x)
+    return Dual{Ty}(primal, deriv * partials(y))
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using Test
+
+using ForwardDiff
 using IntervalArithmetic
 using InteractiveUtils
 


### PR DESCRIPTION
This PR overlead ForwardDiff default behavior, so that it works with intervals.

It is necessary for updating IntervalRootFinding.jl because many tests there rely on polynomials.