### PR TITLE
Allow `==` if one of the operand is a thin interval

### DIFF
--- a/src/intervals/real_interface.jl
+++ b/src/intervals/real_interface.jl
@@ -80,8 +80,11 @@ Base.hash(x::Interval, h::UInt) = hash(sup(x), hash(inf(x), hash(Interval, h)))
 
 for T ∈ (:BareInterval, :Interval)
     @eval begin
-        Base.:(==)(::$T, ::$T) = # also returned when calling `≤`, `≥`, `isequal`
-            throw(ArgumentError("`==` is purposely not supported for intervals. See instead `isequal_interval`"))
+        function Base.:(==)(x::$T, y::$T) # also returned when calling `≤`, `≥`, `isequal`
+            isthin(x) && return sup(x) == y
+            isthin(y) && return x == sup(y)
+            return throw(ArgumentError("`==` is purposely not supported for intervals. See instead `isequal_interval`"))
+        end
 
         Base.:<(::$T, ::$T) = # also returned when calling `isless`, `>`
             throw(ArgumentError("`<` is purposely not supported for intervals. See instead `isstrictless`, `strictprecedes`"))

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -340,7 +340,9 @@
 
     @testset "Disallowed `Real` functionalities" begin
         x, y = interval(1), interval(2)
-        @test_throws ArgumentError x == y
+        @test x != y
+        @test (interval(1, 2) != y) & (y != interval(1, 2))
+        @test_throws ArgumentError interval(1, 2) == interval(1, 2)
         @test_throws ArgumentError x < y
         @test_throws ArgumentError isdisjoint(x, y)
         @test_throws ArgumentError issubset(x, y)


### PR DESCRIPTION
Closes #628.