### PR TITLE
Use rem2pi and rem with BigFloats in _quadrant

### DIFF
--- a/test/interval_tests/trigonometric.jl
+++ b/test/interval_tests/trigonometric.jl
@@ -307,4 +307,16 @@ end
     @test isequal_interval(sin(x), interval(-1, 1))
     @test isequal_interval(cos(x), interval(-1, 1))
     @test isequal_interval(tan(x), interval(-Inf, Inf))
+
+    setprecision(100) do
+        y = 6381956970095103 * 2.0^797 # worst case for C = pi/2 for Float64
+        yb = 6381956970095103 * big(2.0)^797
+        @test_throws AssertionError IntervalArithmetic._quadrant(y) == IntervalArithmetic._quadrant(yb)
+    end
+    setprecision(1000) do
+        y = 6381956970095103 * 2.0^797 # worst case for C = pi/2 for Float64
+        yb = 6381956970095103 * big(2.0)^797
+        @test IntervalArithmetic._quadrant(y) == IntervalArithmetic._quadrant(yb)
+    end
+
 end


### PR DESCRIPTION
This PR proposes to use `rem2pi` and `rem` with `BigFloat`s, instead of the same methods for the specific `AbsrtracFloat`s. The reason is that, in order to guarantee the precision one needs more "guard digits" than the actual precision; see J-M Muller, "Elementary Functions: Algorithms and implementations", Birkhäuser, 3rd ed (2005), chap. 11. While the solution to use `BigFloat`s should have a performance impact, it seems to be at least safe, without implementing more elaborate range reduction methods.

The following illustrates such a case:
```julia
julia> x = 6381956970095103 * 2.0^797 # worst case for C = pi/2 for Float64
5.319372648326541e255

julia> xb = big(x) 5.319372648326541416707296656673541083813475031793921822105998164685326343987747e+255

julia> rem2pi(x, RoundNearest)
1.5707963267948966

julia> rem2pi(xb, RoundNearest)
-2.545982325227109106133284489709240971297101919468998568916440481134254101023789
```

As far as I have checked, or the tests show, there haven't been any issues with this change.

This approach could be adapted for the `mod` (or should it be `rem`?) function; cf #129, #145 and #178).