### PR TITLE
Small fixes for ExactReal

### DIFF
--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -48,4 +48,12 @@ function Base.:(^)(x::Interval, y::Dual{Ty, <:Interval}) where Ty
     return Dual{Ty}(expv, deriv * partials(y))
 end
 
+function Base.:(^)(x::Dual{<:Any, I}, y::ExactReal) where I<:Interval
+    return x^convert(I, y)
+end
+
+function Base.:(^)(x::ExactReal, y::Dual{<:Any, I}) where I<:Interval
+    return convert(I, x)^y
+end
+
 end

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -54,6 +54,7 @@ struct ExactReal{T<:Real} <: Real
 end
 
 _value(x::ExactReal) = x.value # hook for interval constructor
+Base.to_index(i::ExactReal{<:Integer}) = i.value  # allow to index with ExactReal
 
 # conversion and promotion
 


### PR DESCRIPTION
This contains two small fixes that are useful for the update of IntervalRootFinding. 

1. Allow to use `ExactReal{<:Integer}` to index an array.
2. Fix derivative of `^` when mixing `ExactReal` and `Interval` in the ForwardDiff extension.

The first one in particular may be handy for everyone, when working with vectors of interval for example. With this PR, indexing work as intuitively expected with `@exact`
```julia
julia> @exact f(x) = x[1] + x[2] + 1.2
f (generic function with 1 method)

julia> X = [interval(-1, 1), interval(-0.1, 3)]
2-element Vector{Interval{Float64}}:
 [-1.0, 1.0]_com
 [-0.100001, 3.0]_com

julia> f(X)
[0.0999999, 5.20001]_com
```