### PR TITLE
Extend `ExactReal` to work with `BareInterval`

### DIFF
--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -72,7 +72,7 @@ Base.convert(::Type{BareInterval{T}}, x::ExactReal) where {T<:NumTypes} = barein
 
 Base.promote_rule(::Type{BareInterval{T}}, ::Type{ExactReal{S}}) where {T<:NumTypes,S<:Real} =
     BareInterval{promote_numtype(T, S)}
-Base.promote_rule(::Type{BareInterval{T}}, ::Type{Interval{S}}) where {T<:Real,S<:NumTypes} =
+Base.promote_rule(::Type{ExactReal{T}}, ::Type{BareInterval{S}}) where {T<:Real,S<:NumTypes} =
     BareInterval{promote_numtype(T, S)}
 
 # to Interval

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -126,6 +126,13 @@ Base.:-(x::ExactReal) = ExactReal(-x.value)
 
 Base.:^(x::ExactReal, p::Integer) = ^(promote(x, p)...)
 
+# basic operations with `BareInterval` and `ExactReal`
+
+for f ∈ (:+, :-, :*, :/, :\, :^)
+    @eval Base.$f(x::BareInterval, y::ExactReal) = $f(promote(x, y)...)
+    @eval Base.$f(x::ExactReal, y::BareInterval) = $f(promote(x, y)...)
+end
+
 """
     has_exact_display(x::Real)
 

--- a/test/interval_tests/exact_literals.jl
+++ b/test/interval_tests/exact_literals.jl
@@ -1,19 +1,4 @@
 @testset "Exact literals" begin
-    x = @exact 0.5
-    @test (2 * x) isa Float64
-    Y = interval(2) * x
-    @test isguaranteed(Y)
-    @test in_interval(1, Y)
-
-    @exact function f(x)
-       return x^2 - 2x + 1
-    end
-
-    Z = f(interval(1))
-    @test f(1.22) isa Real
-    @test isguaranteed(Z)
-    @test in_interval(0, Z)
-
     @test_throws MethodError convert(ExactReal{Float64}, 2)
 
     @test has_exact_display(0.5)
@@ -22,4 +7,40 @@
     @test (@exact 2im) isa Complex{<:ExactReal}
     @test (@exact 1.2 + 3.4im) isa Complex{<:ExactReal}
     @test_throws ArgumentError (@exact 1.2 + 3im)
+
+    #
+
+    x = @exact 0.5
+
+    @test (2 * x) isa Float64
+    @test isone(2 * x)
+
+    @test (bareinterval(2) * x) isa BareInterval
+    @test isthinone(bareinterval(2) * x)
+
+    @test (interval(2) * x) isa Interval
+    @test isthinone(interval(2) * x)
+    @test isguaranteed(interval(2) * x)
+
+    #
+
+    @exact function f(x)
+       return x^2 - 2x + 1
+    end
+
+    @test f(1.0) isa Real
+    @test iszero(f(1.22))
+
+    @test f(bareinterval(1)) isa BareInterval
+    @test isthinzero(f(bareinterval(1)))
+
+    @test f(bareinterval(1)) isa Interval
+    @test isthinzero(f(interval(1)))
+    @test isguaranteed(f(interval(1)))
+
+    #
+
+    @test isequal_interval(promote(bareinterval(1, 2), ExactReal(3))[2], bareinterval(3))
+
+    @test isequal_interval(promote(interval(1, 2), ExactReal(3))[2], interval(3))
 end

--- a/test/interval_tests/exact_literals.jl
+++ b/test/interval_tests/exact_literals.jl
@@ -29,12 +29,12 @@
     end
 
     @test f(1.0) isa Real
-    @test iszero(f(1.22))
+    @test iszero(f(1.0))
 
     @test f(bareinterval(1)) isa BareInterval
     @test isthinzero(f(bareinterval(1)))
 
-    @test f(bareinterval(1)) isa Interval
+    @test f(interval(1)) isa Interval
     @test isthinzero(f(interval(1)))
     @test isguaranteed(f(interval(1)))
 


### PR DESCRIPTION
This PR allows `@exact` to work with `BareInterval`, eg

```Julia
julia> @exact bareinterval(3, 4) ^ 2
BareInterval{Float64}(9.0, 16.0)
```

I think this PR also addresses the concerns raised in #646.

Closes #646.