### PR TITLE
Add unicode alias for `hull` and `intersect_interval`

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -93,6 +93,22 @@ Unicode alias of [`isinterior`](@ref).
 ⪽(x, y) = isinterior(x, y)
 
 """
+    ⊔(x, y)
+    x ⊔ y
+
+Unicode alias of [`hull`](@ref).
+"""
+⊔(x, y) = hull(x, y)
+
+"""
+    ⊓(x, y)
+    x ⊓ y
+
+Unicode alias of [`intersect_interval`](@ref).
+"""
+⊓(x, y) = intersect_interval(x, y)
+
+"""
     ∅
 
 Unicode alias of `emptyinterval()` representing an empty interval of default


### PR DESCRIPTION
This PR adds `⊔` (`\sqcup`), `⊓` (`\sqcap`) as unicode alias for `hull` and `intersect_interval` respectively.
An other option could be `⊍` (`\cupdot`), `⩀` (`\capdot`)

Closes #650