### PR TITLE
Fix ExactReal with power in ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IntervalArithmetic"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 repo = "https://github.com/JuliaIntervals/IntervalArithmetic.jl.git"
-version = "0.22.12"
+version = "0.22.13"
 
 [deps]
 CRlibm_jll = "4e9b3aee-d8a1-5a3d-ad8b-7d824db253f0"

--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -56,4 +56,22 @@ function Base.:(^)(x::ExactReal, y::Dual{<:Any, I}) where I<:Interval
     return convert(I, x)^y
 end
 
+function Base.:(^)(x::Dual{<:Tx}, y::ExactReal) where Tx
+    v = value(x)
+    expv = v^y
+    if iszero(y) || all(iszero.(values(partials(x))))
+        new_partials = zero(partials(x))
+    else
+        new_partials = partials(x) * y * v^(y - 1)
+    end
+    return Dual{Tx}(expv, new_partials)
+end
+
+function Base.:(^)(x::ExactReal, y::Dual{<:Ty}) where Ty
+    v = value(y)
+    expv = x^v
+    deriv = (iszero(x) && inf(v) > 0) ? zero(expv) : expv*log(x)
+    return Dual{Ty}(expv, deriv * partials(y))
+end
+
 end

--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -59,7 +59,7 @@ end
 function Base.:(^)(x::Dual{<:Tx}, y::ExactReal) where Tx
     v = value(x)
     expv = v^y
-    if iszero(y) || all(iszero.(values(partials(x))))
+    if iszero(y.value) || all(iszero.(values(partials(x))))
         new_partials = zero(partials(x))
     else
         new_partials = partials(x) * y * v^(y - 1)

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -53,8 +53,6 @@ struct ExactReal{T<:Real} <: Real
     ExactReal(value::T) where {T<:Real} = new{T}(value)
 end
 
-Base.iszero(x::ExactReal) = iszero(x.value)
-
 _value(x::ExactReal) = x.value # hook for interval constructor
 
 # allow to index with ExactReal

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -53,6 +53,8 @@ struct ExactReal{T<:Real} <: Real
     ExactReal(value::T) where {T<:Real} = new{T}(value)
 end
 
+Base.iszero(x::ExactReal) = iszero(x.value)
+
 _value(x::ExactReal) = x.value # hook for interval constructor
 
 # allow to index with ExactReal

--- a/test/interval_tests/forwarddiff.jl
+++ b/test/interval_tests/forwarddiff.jl
@@ -96,4 +96,12 @@ end
             end
         end
     end
+
+    @testset "ExactReal" begin
+        @exact f(x) = x^2 - 2
+        @test isguaranteed(ForwardDiff.derivative(f, interval(1)))
+
+        @exact g(x) = 2^x + 6sin(x^3) - 33
+        @test isguaranteed(ForwardDiff.derivative(f, interval(1)))
+    end
 end


### PR DESCRIPTION
The fixes the support for derivatives of powers containing ExactReal.

This *should* be the last missing piece before IntervalRootFinding can be upgraded to IA v0.22.