### PR TITLE
Export \sqcap and \sqcup

### DIFF
--- a/src/symbols.jl
+++ b/src/symbols.jl
@@ -1,7 +1,7 @@
 module Symbols
 
     using IntervalArithmetic
-    export .., ±, ≛, ≺, ⪽, ∅, ℝ
+    export .., ±, ≛, ≺, ⪽, ∅, ℝ, ⊓, ⊔
 
 """
     ..(a, b)


### PR DESCRIPTION
These were added to `IntervalArithmetic.Symbols` but weren't exported.