### PR TITLE
Remove inner constructor for ExactReal

### DIFF
--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -49,8 +49,6 @@ See also: [`@exact`](@ref).
 """
 struct ExactReal{T<:Real} <: Real
     value :: T
-
-    ExactReal(value::T) where {T<:Real} = new{T}(value)
 end
 
 _value(x::ExactReal) = x.value # hook for interval constructor

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -49,6 +49,9 @@ See also: [`@exact`](@ref).
 """
 struct ExactReal{T<:Real} <: Real
     value :: T
+
+    ExactReal{T}(value::T) where {T<:Real} = new{T}(value)
+    ExactReal(value::T) where {T<:Real} = new{T}(value)
 end
 
 _value(x::ExactReal) = x.value # hook for interval constructor

--- a/test/interval_tests/exact_literals.jl
+++ b/test/interval_tests/exact_literals.jl
@@ -8,6 +8,9 @@
     @test (@exact 1.2 + 3.4im) isa Complex{<:ExactReal}
     @test_throws ArgumentError (@exact 1.2 + 3im)
 
+    @test ExactReal{Int64}(3).value == 3
+    @test_throws MethodError ExactReal{Float64}(1//3)
+
     #
 
     x = @exact 0.5

--- a/test/interval_tests/exact_literals.jl
+++ b/test/interval_tests/exact_literals.jl
@@ -8,7 +8,7 @@
     @test (@exact 1.2 + 3.4im) isa Complex{<:ExactReal}
     @test_throws ArgumentError (@exact 1.2 + 3im)
 
-    @test ExactReal{Int64}(3).value == 3
+    @test ExactReal{Int}(3).value == 3
     @test_throws MethodError ExactReal{Float64}(1//3)
 
     #


### PR DESCRIPTION
This was preventing

```
ExactReal{Int64}(3)
```
which should be allowed.