### PR TITLE
Return explicitly an NaI for `intersect_interval` and `hull`

### DIFF
--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -61,7 +61,7 @@ not normalize the infimum of the interval.
 See also: [`inf`](@ref), [`sup`](@ref), [`mid`](@ref), [`diam`](@ref),
 [`radius`](@ref) and [`midradius`](@ref).
 """
-bounds(x::BareInterval{T}) where {T<:AbstractFloat} = (ifelse(isnan(x.lo), typemax(T), x.lo), x.hi)
+bounds(x::BareInterval{T}) where {T<:AbstractFloat} = (ifelse(isnan(x.lo), typemax(T), x.lo), sup(x))
 bounds(x::BareInterval{<:Rational}) = (inf(x), sup(x))
 
 function bounds(x::Interval{T}) where {T<:AbstractFloat}

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -16,7 +16,6 @@ Implement the `intersection` function of the IEEE Standard 1788-2015 (Section 9.
 function intersect_interval(x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes}
     lo = max(inf(x), inf(y))
     hi = min(sup(x), sup(y))
-
     if lo > hi
         return emptyinterval(BareInterval{T})
     else
@@ -25,9 +24,10 @@ function intersect_interval(x::BareInterval{T}, y::BareInterval{T}) where {T<:Nu
 end
 intersect_interval(x::BareInterval, y::BareInterval) = intersect_interval(promote(x, y)...)
 
-function intersect_interval(x::Interval, y::Interval)
+function intersect_interval(x::Interval{T}, y::Interval{S}) where {T<:NumTypes,S<:NumTypes}
+    isnai(x) | isnai(y) && return nai(promote_type(T, S))
     r = intersect_interval(bareinterval(x), bareinterval(y))
-    d = min(decoration(x), decoration(y), decoration(r), trv)
+    d = min(decoration(x), decoration(y), trv)
     t = isguaranteed(x) & isguaranteed(y)
     return _unsafe_interval(r, d, t)
 end
@@ -54,9 +54,10 @@ function hull(x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes}
 end
 hull(x::BareInterval, y::BareInterval) = hull(promote(x, y)...)
 
-function hull(x::Interval, y::Interval)
+function hull(x::Interval{T}, y::Interval{S}) where {T<:NumTypes,S<:NumTypes}
+    isnai(x) | isnai(y) && return nai(promote_type(T, S))
     r = hull(bareinterval(x), bareinterval(y))
-    d = min(decoration(x), decoration(y), decoration(r), trv)
+    d = min(decoration(x), decoration(y), trv)
     t = isguaranteed(x) & isguaranteed(y)
     return _unsafe_interval(r, d, t)
 end


### PR DESCRIPTION
This PR explicitly returns an NaI by calling `nai` whenever one of the argument is an NaI.
As pointed out in #662, before this PR we would obtain for `hull` a non trivial interval with `ill` decoration which could lead to errors down the line if one accesses the bounds of the interval through `getproperty`.

Closes #662

Also, this PR should supersede #663.