### PR TITLE
Base utilities for exact reals

### DIFF
--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -240,3 +240,6 @@ end
 Base.hash(x::ExactReal, h::UInt) = hash(x.value, h)
 
 Base.isfinite(x::ExactReal) = isfinite(x.value)
+
+Base.zero(x::ExactReal{T}) where {T} = ExactReal(zero(T))
+Base.one(x::ExactReal{T}) where {T} = ExactReal(one(T))

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -235,3 +235,8 @@ macro exact(expr)
 
     return esc(exact_expr)
 end
+
+
+Base.hash(x::ExactReal, h::UInt) = hash(x.value, h)
+
+Base.isfinite(x::ExactReal) = isfinite(x.value)


### PR DESCRIPTION
Defines `Base.hash` and `Base.isfinite` for `ExactReal`s.

This is necessary so that they work with Symbolics.jl.