### PR TITLE
Improve alignment display

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -111,181 +111,201 @@ Base.show(io::IO, ::MIME"text/plain", a::Union{BareInterval,Interval,Complex{<:I
 function _str_repr(a::BareInterval{T}, format::Symbol) where {T<:NumTypes}
     # `format` is either `:infsup`, `:midpoint` or `:full`
     str_interval = _str_basic_repr(a, format)
-    format === :full && return string("BareInterval{", T, "}(", str_interval, ')')
-    return str_interval
-end
-
-function _str_repr(a::BareInterval{BigFloat}, format::Symbol)
-    # `format` is either `:infsup`, `:midpoint` or `:full`
-    str_interval = _str_basic_repr(a, format)
-    format === :full && return string("BareInterval{BigFloat}(", str_interval, ')')
-    if format === :midpoint && str_interval != "∅"
-        str_interval = string('(', str_interval, ')')
-    end
-    return string(str_interval, _str_precision(a))
+    ((format === :full) & (str_interval != "∅")) && return string("BareInterval{", T, "}(", str_interval, ')')
+    return _str_precision(str_interval, a, format)
 end
 
 function _str_repr(a::Interval{T}, format::Symbol) where {T<:NumTypes}
     # `format` is either `:infsup`, `:midpoint` or `:full`
     str_interval = _str_basic_repr(a.bareinterval, format) # use `a.bareinterval` to not print a warning if `a` is an NaI
-    if isguaranteed(a) || !display_options.ng_flag
-        format === :full && return string("Interval{", T, "}(", str_interval, ", ", decoration(a), ')')
-        display_options.decorations || return str_interval
-        if format === :midpoint && str_interval != "∅"
-            str_interval = string('(', str_interval, ')')
-        end
-        return string(str_interval, '_', decoration(a))
+    if format === :full && str_interval != "∅"
+        str_interval = string("Interval{", T, "}(", str_interval, ", ", decoration(a), ')')
     else
-        format === :full && return string("Interval{", T, "}(", str_interval, ", ", decoration(a), ", NG)")
-        if format === :midpoint && str_interval != "∅"
+        str_interval = _str_precision(str_interval, a, format)
+        if format === :midpoint && str_interval != "∅" && T !== BigFloat && (display_options.decorations | (display_options.ng_flag & !isguaranteed(a)))
             str_interval = string('(', str_interval, ')')
         end
-        display_options.decorations || return string(str_interval, "_NG")
-        return string(str_interval, '_', decoration(a), "_NG")
+        str_interval = ifelse(display_options.decorations, string(str_interval, '_', decoration(a)), str_interval)
     end
+    return ifelse(display_options.ng_flag & !isguaranteed(a), string(str_interval, "_NG"), str_interval)
 end
 
-function _str_repr(a::Interval{BigFloat}, format::Symbol)
+function _str_repr(x::Complex{Interval{T}}, format::Symbol) where {T<:NumTypes}
     # `format` is either `:infsup`, `:midpoint` or `:full`
-    str_interval = _str_basic_repr(a.bareinterval, format) # use `a.bareinterval` to not print a warning if `a` is an NaI
-    if isguaranteed(a) || !display_options.ng_flag
-        format === :full && return string("Interval{BigFloat}(", str_interval, ", ", decoration(a), ')')
-        if format === :midpoint && str_interval != "∅"
-            str_interval = string('(', str_interval, ')')
-        end
-        display_options.decorations || return string(str_interval, _str_precision(a))
-        return string(str_interval, _str_precision(a), '_', decoration(a))
-    else
-        format === :full && return string("Interval{", BigFloat, "}(", str_interval, ", ", decoration(a), ", NG)")
-        if format === :midpoint && str_interval != "∅"
-            str_interval = string('(', str_interval, ')')
-        end
-        display_options.decorations || return string(str_interval, _str_precision(a), "_NG")
-        return string(str_interval, _str_precision(a), '_', decoration(a), "_NG")
-    end
-end
-
-function _str_repr(x::Complex{<:Interval}, format::Symbol)
-    # `format` is either `:infsup`, `:midpoint` or `:full`
+    str_imag = _str_repr(imag(x), format)
     if format === :full
-        return string(_str_repr(real(x), format), " + ", _str_repr(imag(x), format), "im")
-    elseif format === :infsup
-        ((!isguaranteed(x) & display_options.ng_flag) | display_options.decorations) && return string(_str_repr(real(x), format), " + (", _str_repr(imag(x), format), ")im")
-        return string(_str_repr(real(x), format), " + ", _str_repr(imag(x), format), "im")
+        if occursin("}(-", str_imag) && occursin(", -", str_imag)
+            c1, c2 = split(str_imag, ", "; limit = 2)
+            l = findfirst('-', c1)
+            ll = ifelse(occursin(',', c2), findfirst(',', c2), findfirst(')', c2))
+            return string(_str_repr(real(x), format), " - im*", view(c1, 1:l-1), view(c2, 2:ll-1), ", ", view(c1, l+1:lastindex(c1)), view(c2, ll:lastindex(c2)))
+        else
+            return string(_str_repr(real(x), format), " + im*", str_imag)
+        end
+    elseif format === :midpoint
+        str_real = _str_repr(real(x), format)
+        if !startswith(str_real, '(')
+            str_real = string('(', str_real, ')')
+        end
+        if !startswith(str_imag, '(')
+            str_imag = string('(', str_imag, ')')
+        end
+        startswith(str_imag, "(-") && return string(str_real, " - im*(", view(str_imag, 3:lastindex(str_imag)))
+        return string(str_real, " + im*", str_imag)
     else
-        ((!isguaranteed(x) & display_options.ng_flag) | display_options.decorations) && return string(_str_repr(real(x), format), " + (", _str_repr(imag(x), format), ")im")
-        return string('(', _str_repr(real(x), format), ") + (", _str_repr(imag(x), format), ")im")
+        if str_imag[2] == '-' && occursin(", -", str_imag)
+            c1, c2 = split(str_imag, ", ")
+            l = findfirst(t -> (t == ']') | (t == ')'), c2)
+            return string(_str_repr(real(x), format), " - im*", _flipl(c2[l]), view(c2, 2:l-1), ", ", view(c1, 3:lastindex(c1)), _flipr(c1[1]), view(c2, l+1:lastindex(c2)))
+        else
+            return string(_str_repr(real(x), format), " + im*", str_imag)
+        end
     end
 end
 
-function _str_repr(x::Complex{Interval{BigFloat}}, format::Symbol)
-    # `format` is either `:infsup`, `:midpoint` or `:full`
-    ((!isguaranteed(x) & display_options.ng_flag) | display_options.decorations) && return string(_str_repr(real(x), format), " + (", _str_repr(imag(x), format), ")im")
-    return string(_str_repr(real(x), format), " + ", _str_repr(imag(x), format), "im")
-end
+_flipl(char) = ifelse(char == ']', '[', '(')
+_flipr(char) = ifelse(char == '[', ']', ')')
 
 #
 
-function _str_precision(x)
+_str_precision(str_interval, x, format) = str_interval
+
+function _str_precision(str_interval, x::Union{BareInterval{BigFloat},Interval{BigFloat}}, format)
     plo = precision(inf(x))
     phi = precision(sup(x))
     pstr = _subscriptify(plo)
-    plo == phi && return pstr
-    return string(pstr, "_", _subscriptify(phi))
+    if format === :midpoint && str_interval != "∅"
+        str_interval = string('(', str_interval, ')')
+    end
+    str_interval = string(str_interval, pstr)
+    return ifelse(plo == phi, str_interval, string(str_interval, '_', _subscriptify(phi)))
 end
 
 #
 
 function _str_basic_repr(a::BareInterval{<:AbstractFloat}, format::Symbol)
     # `format` is either `:infsup`, `:midpoint` or `:full`
-    # do not use `inf(a)` to avoid `-0.0`
     isempty_interval(a) && return "∅"
+    lo, hi = bounds(a) # do not use `inf(a)` to avoid `-0.0`
     sigdigits = display_options.sigdigits
     if format === :full
-        return string(a.lo, ", ", sup(a))
+        str_lo = string(lo)
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = string(hi)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        return string(str_lo, ", ", str_hi)
     elseif format === :midpoint
-        m = _round_string(mid(a), sigdigits, RoundNearest)
-        r = _round_string(radius(a), sigdigits, RoundUp)
-        output = string(m, " ± ", r)
+        m = mid(a)
+        str_m = _round_string(m, sigdigits, RoundNearest)
+        # str_m = ifelse(m ≥ 0, string('+', str_m), str_m)
+        output = string(str_m, " ± ", _round_string(radius(a), sigdigits, RoundUp))
         return replace(output, "Inf" => '∞')
     else
-        lo = _round_string(a.lo, sigdigits, RoundDown)
-        hi = _round_string(sup(a), sigdigits, RoundUp)
-        output = string('[', lo, ", ", hi, ']')
+        str_lo = _round_string(lo, sigdigits, RoundDown)
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = _round_string(hi, sigdigits, RoundUp)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        output = string('[', str_lo, ", ", str_hi, ']')
         return replace(output, "Inf]" => "∞)", "[-Inf" => "(-∞")
     end
 end
 
 function _str_basic_repr(a::BareInterval{Float32}, format::Symbol)
     # `format` is either `:infsup`, `:midpoint` or `:full`
-    # do not use `inf(a)` to avoid `-0.0`
     isempty_interval(a) && return "∅"
+    lo, hi = bounds(a) # do not use `inf(a)` to avoid `-0.0`
     sigdigits = display_options.sigdigits
     if format === :full
-        lo = replace(string(a.lo, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
-        if contains(lo, 'e')
-            lo = replace(lo, 'e' => 'f', "f0" => "")
+        str_lo = string(lo)
+        str_lo = replace(string(str_lo, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
+        if contains(str_lo, 'e')
+            str_lo = replace(str_lo, 'e' => 'f', "f0" => "")
         end
-        hi = replace(string(sup(a), "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
-        if contains(hi, 'e')
-            hi = replace(hi, 'e' => 'f', "f0" => "")
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = string(hi)
+        str_hi = replace(string(str_hi, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
+        if contains(str_hi, 'e')
+            str_hi = replace(str_hi, 'e' => 'f', "f0" => "")
         end
-        return string(lo, ", ", hi)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        return string(str_lo, ", ", str_hi)
     elseif format === :midpoint
-        m = _round_string(mid(a), sigdigits, RoundNearest)
-        m = replace(string(m, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
-        if contains(m, 'e')
-            m = replace(m, 'e' => 'f', "f0" => "")
+        m = mid(a)
+        str_m = _round_string(m, sigdigits, RoundNearest)
+        str_m = replace(string(str_m, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
+        if contains(str_m, 'e')
+            str_m = replace(str_m, 'e' => 'f', "f0" => "")
         end
-        r = _round_string(radius(a), sigdigits, RoundUp)
-        r = replace(string(r, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
-        if contains(r, 'e')
-            r = replace(r, 'e' => 'f', "f0" => "")
+        # str_m = ifelse(m ≥ 0, string('+', str_m), str_m)
+        str_r = _round_string(radius(a), sigdigits, RoundUp)
+        str_r = replace(string(str_r, "f0"), "NaNf0" => "NaN32", "Inff0" => "Inf32")
+        if contains(str_r, 'e')
+            str_r = replace(str_r, 'e' => 'f', "f0" => "")
         end
-        return string(m, " ± ", r)
+        return string(str_m, " ± ", str_r)
     else
-        lo = _round_string(a.lo, sigdigits, RoundDown)
-        lo = replace(string('[', lo, "f0"), "NaNf0" => "NaN32", "[-Inff0" => "(-∞")
-        if contains(lo, 'e')
-            lo = replace(lo, 'e' => 'f', "f0" => "")
+        str_lo = _round_string(lo, sigdigits, RoundDown)
+        str_lo = replace(string('[', str_lo, "f0"), "NaNf0" => "NaN32", "[-Inff0" => "(-∞")
+        if contains(str_lo, 'e')
+            str_lo = replace(str_lo, 'e' => 'f', "f0" => "")
         end
-        hi = _round_string(sup(a), sigdigits, RoundUp)
-        hi = replace(string(hi, "f0]"), "NaNf0" => "NaN32", "Inff0]" => "∞)")
-        if contains(hi, 'e')
-            hi = replace(hi, 'e' => 'f', "f0" => "")
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = _round_string(hi, sigdigits, RoundUp)
+        str_hi = replace(string(str_hi, "f0]"), "NaNf0" => "NaN32", "Inff0]" => "∞)")
+        if contains(str_hi, 'e')
+            str_hi = replace(str_hi, 'e' => 'f', "f0" => "")
         end
-        return string(lo, ", ", hi)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        return string(str_lo, ", ", str_hi)
     end
 end
 
 function _str_basic_repr(a::BareInterval{Float16}, format::Symbol)
     # `format` is either `:infsup`, `:midpoint` or `:full`
-    # do not use `inf(a)` to avoid `-0.0`
     isempty_interval(a) && return "∅"
+    lo, hi = bounds(a) # do not use `inf(a)` to avoid `-0.0`
     sigdigits = display_options.sigdigits
     if format === :full
-        output = string("Float16(", a.lo, "), Float16(", sup(a), ')')
+        str_lo = string(lo)
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = string(hi)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        output = string("Float16(", str_lo, "), Float16(", str_hi, ')')
         return replace(output, "Float16(NaN)" => "NaN16", "Float16(-Inf)" => "-Inf16", "Float16(Inf)" => "Inf16")
     elseif format === :midpoint
-        m = _round_string(mid(a), sigdigits, RoundNearest)
-        r = _round_string(radius(a), sigdigits, RoundUp)
-        output = string("Float16(", m, ") ± Float16(", r, ')')
+        m = mid(a)
+        str_m = _round_string(mid(a), sigdigits, RoundNearest)
+        # str_m = ifelse(m ≥ 0, string('+', str_m), str_m)
+        output = string("Float16(", str_m, ") ± Float16(", _round_string(radius(a), sigdigits, RoundUp), ')')
         return replace(output, "Float16(NaN)" => "NaN16", "Float16(Inf)" => '∞')
     else
-        lo = _round_string(a.lo, sigdigits, RoundDown)
-        hi = _round_string(sup(a), sigdigits, RoundUp)
-        output = string("[Float16(", lo, "), Float16(", hi, ")]")
+        str_lo = _round_string(lo, sigdigits, RoundDown)
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = _round_string(sup(a), sigdigits, RoundUp)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        output = string("[Float16(", str_lo, "), Float16(", str_hi, ")]")
         return replace(output, "Float16(NaN)" => "NaN16", "[Float16(-Inf)" => "(-∞", "Float16(Inf)]" => "∞)")
     end
 end
 
 function _str_basic_repr(a::BareInterval{<:Rational}, format::Symbol)
     # `format` is either `:infsup`, `:midpoint` or `:full`
-    # do not use `inf(a)` to avoid `-0.0`
     isempty_interval(a) && return "∅"
-    format === :full && return string(a.lo, ", ", sup(a))
-    format === :midpoint && return string(mid(a), " ± ", radius(a))
-    return string('[', a.lo, ", ", sup(a), ']')
+    if format === :midpoint
+        m = mid(a)
+        str_m = string(m)
+        # str_m = ifelse(m ≥ 0, string('+', str_m), str_m)
+        return string(str_m, " ± ", radius(a))
+    else
+        lo, hi = bounds(a) # do not use `inf(a)` to avoid `-0.0`
+        str_lo = string(lo)
+        # str_lo = ifelse(lo ≥ 0, string('+', str_lo), str_lo)
+        str_hi = string(hi)
+        # str_hi = ifelse(hi ≥ 0, string('+', str_hi), str_hi)
+        output = string(str_lo, ", ", str_hi)
+        output = ifelse(format === :full, output, string('[', output, ']'))
+        return output
+    end
 end
 
 # round to the prescribed significant digits

--- a/test/interval_tests/display.jl
+++ b/test/interval_tests/display.jl
@@ -32,7 +32,7 @@ setprecision(BigFloat, 256) do
             # `sigdigits` is not taken into account for format `:full`
             setdisplay(:full; sigdigits = 100, decorations = true)
 
-            @test sprint(show, MIME("text/plain"), emptyinterval(BareInterval{Float64})) == "BareInterval{Float64}(∅)"
+            @test sprint(show, MIME("text/plain"), emptyinterval(BareInterval{Float64})) == "∅"
 
             @test sprint(show, MIME("text/plain"), a) == "BareInterval{Float64}(-2.2250738585072014e-308, 1.3)"
             @test sprint(show, MIME("text/plain"), large_expo) ==
@@ -73,13 +73,13 @@ setprecision(BigFloat, 256) do
                     @test sprint(show, MIME("text/plain"), emptyinterval()) == "∅_trv"
                     @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "∅_trv_NG"
 
-                    @test sprint(show, MIME("text/plain"), a)   == "[1.0, 2.0]_com"
-                    @test sprint(show, MIME("text/plain"), a_NG)   == "[1.0, 2.0]_com_NG"
-                    @test sprint(show, MIME("text/plain"), b)   == "[-2.22508e-308, 1.30001]_com"
-                    @test sprint(show, MIME("text/plain"), b32) == "[-1.1755f-38, 1.30001f0]_com"
-                    @test sprint(show, MIME("text/plain"), b16) == "[Float16(-6.104e-5), Float16(1.29981)]_com"
-                    @test sprint(show, MIME("text/plain"), br)  == "[-11//10, 13//10]_com"
-                    @test sprint(show, MIME("text/plain"), c)   == "[-1.0, ∞)_dac"
+                    @test sprint(show, MIME("text/plain"), a)    == "[1.0, 2.0]_com"
+                    @test sprint(show, MIME("text/plain"), a_NG) == "[1.0, 2.0]_com_NG"
+                    @test sprint(show, MIME("text/plain"), b)    == "[-2.22508e-308, 1.30001]_com"
+                    @test sprint(show, MIME("text/plain"), b32)  == "[-1.1755f-38, 1.30001f0]_com"
+                    @test sprint(show, MIME("text/plain"), b16)  == "[Float16(-6.104e-5), Float16(1.29981)]_com"
+                    @test sprint(show, MIME("text/plain"), br)   == "[-11//10, 13//10]_com"
+                    @test sprint(show, MIME("text/plain"), c)    == "[-1.0, ∞)_dac"
                     @test sprint(show, MIME("text/plain"), large_expo) ==
                         "[0.0, 1.00001e+123456789]₂₅₆_com"
                 end
@@ -90,13 +90,13 @@ setprecision(BigFloat, 256) do
                     @test sprint(show, MIME("text/plain"), emptyinterval()) == "∅"
                     @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "∅_NG"
 
-                    @test sprint(show, MIME("text/plain"), a)   == "[1.0, 2.0]"
-                    @test sprint(show, MIME("text/plain"), a_NG)   == "[1.0, 2.0]_NG"
-                    @test sprint(show, MIME("text/plain"), b)   == "[-2.22508e-308, 1.30001]"
-                    @test sprint(show, MIME("text/plain"), b32) == "[-1.1755f-38, 1.30001f0]"
-                    @test sprint(show, MIME("text/plain"), b16) == "[Float16(-6.104e-5), Float16(1.29981)]"
-                    @test sprint(show, MIME("text/plain"), br)  == "[-11//10, 13//10]"
-                    @test sprint(show, MIME("text/plain"), c)   == "[-1.0, ∞)"
+                    @test sprint(show, MIME("text/plain"), a)    == "[1.0, 2.0]"
+                    @test sprint(show, MIME("text/plain"), a_NG) == "[1.0, 2.0]_NG"
+                    @test sprint(show, MIME("text/plain"), b)    == "[-2.22508e-308, 1.30001]"
+                    @test sprint(show, MIME("text/plain"), b32)  == "[-1.1755f-38, 1.30001f0]"
+                    @test sprint(show, MIME("text/plain"), b16)  == "[Float16(-6.104e-5), Float16(1.29981)]"
+                    @test sprint(show, MIME("text/plain"), br)   == "[-11//10, 13//10]"
+                    @test sprint(show, MIME("text/plain"), c)    == "[-1.0, ∞)"
                     @test sprint(show, MIME("text/plain"), large_expo) ==
                         "[0.0, 1.00001e+123456789]₂₅₆"
                 end
@@ -105,13 +105,13 @@ setprecision(BigFloat, 256) do
             @testset "20 significant digits" begin
                 setdisplay(; sigdigits = 20, decorations = true)
 
-                @test sprint(show, MIME("text/plain"), a)   == "[1.0, 2.0]_com"
-                @test sprint(show, MIME("text/plain"), a_NG)   == "[1.0, 2.0]_com_NG"
-                @test sprint(show, MIME("text/plain"), b)   == "[-2.2250738585072014e-308, 1.3000000000000000445]_com"
-                @test sprint(show, MIME("text/plain"), b32) == "[-1.1754944f-38, 1.2999999523162841797f0]_com"
-                @test sprint(show, MIME("text/plain"), b16) == "[Float16(-6.104e-5), Float16(1.2998046875000000001)]_com"
-                @test sprint(show, MIME("text/plain"), br)  == "[-11//10, 13//10]_com"
-                @test sprint(show, MIME("text/plain"), c)   == "[-1.0, ∞)_dac"
+                @test sprint(show, MIME("text/plain"), a)    == "[1.0, 2.0]_com"
+                @test sprint(show, MIME("text/plain"), a_NG) == "[1.0, 2.0]_com_NG"
+                @test sprint(show, MIME("text/plain"), b)    == "[-2.2250738585072014e-308, 1.3000000000000000445]_com"
+                @test sprint(show, MIME("text/plain"), b32)  == "[-1.1754944f-38, 1.2999999523162841797f0]_com"
+                @test sprint(show, MIME("text/plain"), b16)  == "[Float16(-6.104e-5), Float16(1.2998046875000000001)]_com"
+                @test sprint(show, MIME("text/plain"), br)   == "[-11//10, 13//10]_com"
+                @test sprint(show, MIME("text/plain"), c)    == "[-1.0, ∞)_dac"
                 @test sprint(show, MIME("text/plain"), large_expo) ==
                     "[0.0, 1.0000000000000000001e+123456789]₂₅₆_com"
             end
@@ -121,16 +121,16 @@ setprecision(BigFloat, 256) do
             # `sigdigits` and `decorations` keywords are not taken into account for format `:full`
             setdisplay(:full; sigdigits = 100, decorations = false)
 
-            @test sprint(show, MIME("text/plain"), emptyinterval()) == "Interval{Float64}(∅, trv)"
-            @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "Interval{Float64}(∅, trv, NG)"
+            @test sprint(show, MIME("text/plain"), emptyinterval()) == "∅"
+            @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "∅_NG"
 
-            @test sprint(show, MIME("text/plain"), a)   == "Interval{Float64}(1.0, 2.0, com)"
-            @test sprint(show, MIME("text/plain"), a_NG)   == "Interval{Float64}(1.0, 2.0, com, NG)"
-            @test sprint(show, MIME("text/plain"), b)   == "Interval{Float64}(-2.2250738585072014e-308, 1.3, com)"
-            @test sprint(show, MIME("text/plain"), b32) == "Interval{Float32}(-1.1754944f-38, 1.3f0, com)"
-            @test sprint(show, MIME("text/plain"), b16) == "Interval{Float16}(Float16(-6.104e-5), Float16(1.3), com)"
-            @test sprint(show, MIME("text/plain"), br)  == "Interval{Rational{Int64}}(-11//10, 13//10, com)"
-            @test sprint(show, MIME("text/plain"), c)   == "Interval{Float64}(-1.0, Inf, dac)"
+            @test sprint(show, MIME("text/plain"), a)    == "Interval{Float64}(1.0, 2.0, com)"
+            @test sprint(show, MIME("text/plain"), a_NG) == "Interval{Float64}(1.0, 2.0, com)_NG"
+            @test sprint(show, MIME("text/plain"), b)    == "Interval{Float64}(-2.2250738585072014e-308, 1.3, com)"
+            @test sprint(show, MIME("text/plain"), b32)  == "Interval{Float32}(-1.1754944f-38, 1.3f0, com)"
+            @test sprint(show, MIME("text/plain"), b16)  == "Interval{Float16}(Float16(-6.104e-5), Float16(1.3), com)"
+            @test sprint(show, MIME("text/plain"), br)   == "Interval{Rational{Int64}}(-11//10, 13//10, com)"
+            @test sprint(show, MIME("text/plain"), c)    == "Interval{Float64}(-1.0, Inf, dac)"
             @test sprint(show, MIME("text/plain"), large_expo) ==
                 "Interval{BigFloat}(0.0, 1.000000000000000000000000000000000000000000000000000000000000000000000000000004e+123456789, com)"
         end
@@ -144,13 +144,13 @@ setprecision(BigFloat, 256) do
                 @test sprint(show, MIME("text/plain"), emptyinterval()) == "∅_trv"
                 @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "∅_trv_NG"
 
-                @test sprint(show, MIME("text/plain"), a)   == "(1.5 ± 0.5)_com"
-                @test sprint(show, MIME("text/plain"), a_NG)   == "(1.5 ± 0.5)_com_NG"
-                @test sprint(show, MIME("text/plain"), b)   == "(0.65 ± 0.650001)_com"
-                @test sprint(show, MIME("text/plain"), b32) == "(0.65f0 ± 0.650001f0)_com"
-                @test sprint(show, MIME("text/plain"), b16) == "(Float16(0.649902) ± Float16(0.649903))_com"
-                @test sprint(show, MIME("text/plain"), br)  == "(1//10 ± 6//5)_com"
-                @test sprint(show, MIME("text/plain"), c)   == "(1.79769e+308 ± ∞)_dac"
+                @test sprint(show, MIME("text/plain"), a)    == "(1.5 ± 0.5)_com"
+                @test sprint(show, MIME("text/plain"), a_NG) == "(1.5 ± 0.5)_com_NG"
+                @test sprint(show, MIME("text/plain"), b)    == "(0.65 ± 0.650001)_com"
+                @test sprint(show, MIME("text/plain"), b32)  == "(0.65f0 ± 0.650001f0)_com"
+                @test sprint(show, MIME("text/plain"), b16)  == "(Float16(0.649902) ± Float16(0.649903))_com"
+                @test sprint(show, MIME("text/plain"), br)   == "(1//10 ± 6//5)_com"
+                @test sprint(show, MIME("text/plain"), c)    == "(1.79769e+308 ± ∞)_dac"
                 @test sprint(show, MIME("text/plain"), large_expo) ==
                     "(5.0e+123456788 ± 5.00001e+123456788)₂₅₆_com"
             end
@@ -161,13 +161,13 @@ setprecision(BigFloat, 256) do
                 @test sprint(show, MIME("text/plain"), emptyinterval()) == "∅"
                 @test sprint(show, MIME("text/plain"), emptyinterval()/1) == "∅_NG"
 
-                @test sprint(show, MIME("text/plain"), a)   == "1.5 ± 0.5"
-                @test sprint(show, MIME("text/plain"), a_NG)   == "(1.5 ± 0.5)_NG"
-                @test sprint(show, MIME("text/plain"), b)   == "0.65 ± 0.650001"
-                @test sprint(show, MIME("text/plain"), b32) == "0.65f0 ± 0.650001f0"
-                @test sprint(show, MIME("text/plain"), b16) == "Float16(0.649902) ± Float16(0.649903)"
-                @test sprint(show, MIME("text/plain"), br)  == "1//10 ± 6//5"
-                @test sprint(show, MIME("text/plain"), c)   == "1.79769e+308 ± ∞"
+                @test sprint(show, MIME("text/plain"), a)    == "1.5 ± 0.5"
+                @test sprint(show, MIME("text/plain"), a_NG) == "(1.5 ± 0.5)_NG"
+                @test sprint(show, MIME("text/plain"), b)    == "0.65 ± 0.650001"
+                @test sprint(show, MIME("text/plain"), b32)  == "0.65f0 ± 0.650001f0"
+                @test sprint(show, MIME("text/plain"), b16)  == "Float16(0.649902) ± Float16(0.649903)"
+                @test sprint(show, MIME("text/plain"), br)   == "1//10 ± 6//5"
+                @test sprint(show, MIME("text/plain"), c)    == "1.79769e+308 ± ∞"
                 @test sprint(show, MIME("text/plain"), large_expo) ==
                     "(5.0e+123456788 ± 5.00001e+123456788)₂₅₆"
             end
@@ -176,7 +176,8 @@ setprecision(BigFloat, 256) do
 
     @testset "Complex{<:Interval}" begin
         a = complex(interval(0, 2), interval(1))
-
+        b = complex(interval(0, 2), interval(-1))
+        c = complex(interval(0, 1e-70), interval(-1e-70))
 
         @testset "Standard format" begin
             setdisplay(:infsup)
@@ -187,13 +188,17 @@ setprecision(BigFloat, 256) do
                 @testset "Decorations" begin
                     setdisplay(; decorations = true)
 
-                    @test sprint(show, MIME("text/plain"), a) == "[0.0, 2.0]_com + ([1.0, 1.0]_com)im"
+                    @test sprint(show, MIME("text/plain"), a) == "[0.0, 2.0]_com + im*[1.0, 1.0]_com"
+                    @test sprint(show, MIME("text/plain"), b) == "[0.0, 2.0]_com - im*[1.0, 1.0]_com"
+                    @test sprint(show, MIME("text/plain"), c) == "[0.0, 1.00001e-70]_com - im*[0.999999e-70, 1.00001e-70]_com"
                 end
 
                 @testset "No decorations" begin
                     setdisplay(; decorations = false)
 
-                    @test sprint(show, MIME("text/plain"), a) == "[0.0, 2.0] + [1.0, 1.0]im"
+                    @test sprint(show, MIME("text/plain"), a) == "[0.0, 2.0] + im*[1.0, 1.0]"
+                    @test sprint(show, MIME("text/plain"), b) == "[0.0, 2.0] - im*[1.0, 1.0]"
+                    @test sprint(show, MIME("text/plain"), c) == "[0.0, 1.00001e-70] - im*[0.999999e-70, 1.00001e-70]"
                 end
             end
         end
@@ -202,7 +207,9 @@ setprecision(BigFloat, 256) do
             # `sigdigits` and `decorations` keywords are not taken into account for format `:full`
             setdisplay(:full; sigdigits = 100, decorations = false)
 
-            @test sprint(show, MIME("text/plain"), a) == "Interval{Float64}(0.0, 2.0, com) + Interval{Float64}(1.0, 1.0, com)im"
+            @test sprint(show, MIME("text/plain"), a) == "Interval{Float64}(0.0, 2.0, com) + im*Interval{Float64}(1.0, 1.0, com)"
+            @test sprint(show, MIME("text/plain"), b) == "Interval{Float64}(0.0, 2.0, com) - im*Interval{Float64}(1.0, 1.0, com)"
+            # @test sprint(show, MIME("text/plain"), c) == "Interval{Float64}(0.0, 2.0, com) + im*Interval{Float64}(1.0, 1.0, com)"
         end
 
         @testset "Midpoint format" begin
@@ -211,13 +218,17 @@ setprecision(BigFloat, 256) do
             @testset "Decorations" begin
                 setdisplay(; decorations = true)
 
-                @test sprint(show, MIME("text/plain"), a) == "(1.0 ± 1.0)_com + ((1.0 ± 0.0)_com)im"
+                @test sprint(show, MIME("text/plain"), a) == "(1.0 ± 1.0)_com + im*(1.0 ± 0.0)_com"
+                @test sprint(show, MIME("text/plain"), b) == "(1.0 ± 1.0)_com - im*(1.0 ± 0.0)_com"
+                @test sprint(show, MIME("text/plain"), c) == "(5.0e-71 ± 5.00001e-71)_com - im*(1.0e-70 ± 0.0)_com"
             end
 
             @testset "No decorations" begin
                 setdisplay(; decorations = false)
 
-                @test sprint(show, MIME("text/plain"), a) == "(1.0 ± 1.0) + (1.0 ± 0.0)im"
+                @test sprint(show, MIME("text/plain"), a) == "(1.0 ± 1.0) + im*(1.0 ± 0.0)"
+                @test sprint(show, MIME("text/plain"), b) == "(1.0 ± 1.0) - im*(1.0 ± 0.0)"
+                @test sprint(show, MIME("text/plain"), c) == "(5.0e-71 ± 5.00001e-71) - im*(1.0e-70 ± 0.0)"
             end
         end
     end


### PR DESCRIPTION
This PR improves the alignment display when working with arrays of `Complex{<:Interval}`.
Somehow when the imaginary part contains a negative sign, the alignment is off.
To fix it when the imaginary part is an interval only containing negative values, the sign can be taken outside of the displayed interval.

E.g. before this PR:

```Julia
julia> [1.2 - im * interval(1e-77, 1e-75) ; interval(0.1) ; interval(-0.1) ; 1.2 + im*interval(1e-77, 1e-75)]
4-element Vector{Complex{Interval{Float64}}}:
 [1.19999, 1.20001]_com_NG + ([-1.00001e-75, -0.999999e-77]_com_NG)im
                   [0.0999999, 0.100001]_com + ([0.0, 0.0]_com)im
                 [-0.100001, -0.0999999]_com + ([0.0, 0.0]_com)im
                   [1.19999, 1.20001]_com_NG + ([0.999999e-77, 1.00001e-75]_com_NG)im
```

after this PR:

```Julia
4-element Vector{Complex{Interval{Float64}}}:
   [1.19999, 1.20001]_com_NG - im*[0.999999e-77, 1.00001e-75]_com_NG
   [0.0999999, 0.100001]_com + im*[0.0, 0.0]_com
 [-0.100001, -0.0999999]_com + im*[0.0, 0.0]_com
   [1.19999, 1.20001]_com_NG + im*[0.999999e-77, 1.00001e-75]_com_NG
```

The issue remains if the imaginary part is an interval containing both positive and negative values.