### PR TITLE
Extend conversion

### DIFF
--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -1,7 +1,7 @@
 module IntervalArithmeticForwardDiffExt
 
 using IntervalArithmetic, ForwardDiff
-using ForwardDiff: Dual, ≺, value, partials
+using ForwardDiff: Dual, Partials, ≺, value, partials
 
 #
 
@@ -69,5 +69,9 @@ function Base.:(^)(x::ExactReal, y::Dual{<:Ty}) where {Ty}
         return Dual{Ty}(expv, expv * log(x) * partials(y))
     end
 end
+
+# resolve ambiguity
+
+Base.convert(::Type{Dual{T,V,N}}, x::ExactReal) where {T,V,N} = Dual{T}(V(x), zero(Partials{N,V}))
 
 end

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -368,8 +368,8 @@ isguaranteed(x::Complex{<:Interval}) = isguaranteed(real(x)) & isguaranteed(imag
 isguaranteed(::Number) = false
 
 Interval{T}(x::Interval) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve method ambiguity
-# Interval{T}(x) where {T<:NumTypes} = convert(Interval{T}, x)
-# Interval{T}(x::Interval{T}) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve method ambiguity
+Interval{T}(x::Real) where {T<:NumTypes} = convert(Interval{T}, x)
+Interval(x::Real) = convert(Interval{promote_numtype(typeof(x), typeof(x))}, x)
 
 #
 

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -369,7 +369,7 @@ isguaranteed(::Number) = false
 
 Interval{T}(x::Interval) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve method ambiguity
 Interval{T}(x::Real) where {T<:NumTypes} = convert(Interval{T}, x)
-Interval(x::Real) = convert(Interval{promote_numtype(typeof(x), typeof(x))}, x)
+Interval(x::Real) = Interval{promote_numtype(typeof(x), typeof(x))}(x)
 
 #
 

--- a/src/intervals/construction.jl
+++ b/src/intervals/construction.jl
@@ -367,10 +367,6 @@ isguaranteed(x::Complex{<:Interval}) = isguaranteed(real(x)) & isguaranteed(imag
 
 isguaranteed(::Number) = false
 
-Interval{T}(x::Interval) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve method ambiguity
-Interval{T}(x::Real) where {T<:NumTypes} = convert(Interval{T}, x)
-Interval(x::Real) = Interval{promote_numtype(typeof(x), typeof(x))}(x)
-
 #
 
 """
@@ -562,6 +558,10 @@ Base.promote_rule(::Type{T}, ::Type{Interval{S}}) where {T<:AbstractIrrational,S
     Interval{promote_numtype(T, S)}
 
 # conversion
+
+Interval{T}(x::Real) where {T<:NumTypes} = convert(Interval{T}, x)
+Interval(x::Real) = Interval{promote_numtype(numtype(x), numtype(x))}(x)
+Interval{T}(x::Interval) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve method ambiguity
 
 Base.convert(::Type{Interval{T}}, x::Interval) where {T<:NumTypes} = interval(T, x)
 

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -105,9 +105,6 @@ Base.promote_rule(::Type{ExactReal{T}}, ::Type{Interval{S}}) where {T<:Real,S<:N
 
 # to Real
 
-# allows Interval{<:NumTypes}(::ExactReal)
-(::Type{T})(x::ExactReal) where {T<:Real} = convert(T, x)
-
 Base.convert(::Type{T}, x::ExactReal) where {T<:Real} = convert(T, x.value)
 
 Base.promote_rule(::Type{T}, ::Type{ExactReal{S}}) where {T<:Real,S<:Real} =

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -105,6 +105,10 @@ Base.promote_rule(::Type{ExactReal{T}}, ::Type{Interval{S}}) where {T<:Real,S<:N
 
 # to Real
 
+(::Type{T})(x::ExactReal) where {T<:Real} = convert(T, x)
+Interval{T}(x::ExactReal) where {T<:NumTypes} = convert(Interval{T}, x) # to resolve ambiguity
+Interval(x::ExactReal) = Interval{promote_numtype(typeof(x.value), typeof(x.value))}(x) # to resolve ambiguity
+
 Base.convert(::Type{T}, x::ExactReal) where {T<:Real} = convert(T, x.value)
 
 Base.promote_rule(::Type{T}, ::Type{ExactReal{S}}) where {T<:Real,S<:Real} =

--- a/src/intervals/exact_literals.jl
+++ b/src/intervals/exact_literals.jl
@@ -87,6 +87,9 @@ Base.promote_rule(::Type{ExactReal{T}}, ::Type{ExactReal{S}}) where {T<:Real,S<:
 
 # to BareInterval
 
+BareInterval{T}(x::ExactReal) where {T<:NumTypes} = convert(BareInterval{T}, x)
+BareInterval(x::ExactReal) = BareInterval{promote_numtype(numtype(x.value), numtype(x.value))}(x)
+
 Base.convert(::Type{BareInterval{T}}, x::ExactReal) where {T<:NumTypes} = bareinterval(T, x.value)
 
 Base.promote_rule(::Type{BareInterval{T}}, ::Type{ExactReal{S}}) where {T<:NumTypes,S<:Real} =
@@ -106,8 +109,8 @@ Base.promote_rule(::Type{ExactReal{T}}, ::Type{Interval{S}}) where {T<:Real,S<:N
 # to Real
 
 (::Type{T})(x::ExactReal) where {T<:Real} = convert(T, x)
-Interval{T}(x::ExactReal) where {T<:NumTypes} = convert(Interval{T}, x) # to resolve ambiguity
-Interval(x::ExactReal) = Interval{promote_numtype(typeof(x.value), typeof(x.value))}(x) # to resolve ambiguity
+Interval{T}(x::ExactReal) where {T<:NumTypes} = convert(Interval{T}, x) # needed to resolve ambiguity
+Interval(x::ExactReal) = Interval{promote_numtype(numtype(x.value), numtype(x.value))}(x) # needed to resolve ambiguity
 
 Base.convert(::Type{T}, x::ExactReal) where {T<:Real} = convert(T, x.value)
 

--- a/test/interval_tests/construction.jl
+++ b/test/interval_tests/construction.jl
@@ -43,8 +43,8 @@ end
     @test_throws MethodError BareInterval(1, 2)
     @test_throws MethodError BareInterval{Float64}(1, 2)
 
-    @test_throws MethodError Interval(1)
-    @test_throws MethodError Interval{Float64}(1)
+    @test !isguaranteed(Interval(1))
+    @test !isguaranteed(Interval{Float64}(1))
     @test_throws MethodError Interval(1, 2)
     @test_throws MethodError Interval{Float64}(1, 2)
 
@@ -163,7 +163,7 @@ end
     i = interval(IS.Interval(0.1, 2))
     @test isequal_interval(i, interval(0.1, 2.)) && !isguaranteed(i)
     @test interval(Float64, IS.Interval(0.1, 2)) === i
-    
+
     i = interval(IS.iv"[0.1, Inf)")
     @test isequal_interval(i, interval(0.1, Inf)) && !isguaranteed(i)
     @test interval(IS.iv"[0.1, Inf]") === nai(Float64)

--- a/test/interval_tests/forwarddiff.jl
+++ b/test/interval_tests/forwarddiff.jl
@@ -46,9 +46,9 @@ end
         dψ(t)   = ForwardDiff.derivative(ψ, t)
         ddψ(t)  = ForwardDiff.derivative(dψ, t)
         dddψ(t) = ForwardDiff.derivative(ddψ, t)
-        @test        ψ′(0)   === dψ(0)   && !isguaranteed(ψ′(0))
-        @test_broken ψ′′(0)  === ddψ(0)  && !isguaranteed(ψ′′(0)) # rely on `Interval{T}(::Real)` being defined
-        @test_broken ψ′′′(0) === dddψ(0) && !isguaranteed(ψ′′′(0)) # rely on `Interval{T}(::Real)` being defined
+        @test ψ′(0)   === dψ(0)   && !isguaranteed(ψ′(0))
+        @test ψ′′(0)  === ddψ(0)  && !isguaranteed(ψ′′(0))
+        @test ψ′′′(0) === dddψ(0) && !isguaranteed(ψ′′′(0))
         t₀ = interval(0)
         @test ψ′(t₀)   === dψ(t₀)   && isguaranteed(ψ′(t₀))
         @test ψ′′(t₀)  === ddψ(t₀)  && isguaranteed(ψ′′(t₀))
@@ -73,14 +73,14 @@ end
                 @test isguaranteed(dfdy)
                 @test isguaranteed(grad[1])
                 @test isguaranteed(grad[2])
-                
+
                 if iszero(x) && y < 0
                     @test decoration(dfdx) == trv
                 else
                     @test in_interval(ForwardDiff.derivative(fx, x), dfdx)
                 end
 
-                if iszero(x) && y <= 0 
+                if iszero(x) && y <= 0
                     @test decoration(dfdy) == trv
                 else
                     @test in_interval(ForwardDiff.derivative(fy, y), dfdy)


### PR DESCRIPTION
This PR re-introduce `Interval(::Real)` and `Interval{T}(::Real)`, marking the output with the "NG flag".

It also adds a conversion in the ForwardDiff extension between `ExactReal` and `Dual`.

Closes #685 