### PR TITLE
Return [-1,1] for the derivative of `abs` at 0

### DIFF
--- a/ext/IntervalArithmeticDiffRulesExt.jl
+++ b/ext/IntervalArithmeticDiffRulesExt.jl
@@ -1,9 +1,10 @@
 module IntervalArithmeticDiffRulesExt
 
-using IntervalArithmetic, DiffRules
+using IntervalArithmetic
+import DiffRules
 
-function DiffRules._abs_deriv(x::Interval)
-    r = sign(bareinterval(x))
+function DiffRules._abs_deriv(x::Interval{T}) where {T<:IntervalArithmetic.NumTypes}
+    r = ifelse(isthinzero(x), bareinterval(-one(T), one(T)), sign(bareinterval(x)))
     d = decoration(x)
     d = min(d, ifelse(in_interval(0, x), trv, d)) # if `x` contains 0, then `trv` decoration
     return IntervalArithmetic._unsafe_interval(r, d, isguaranteed(x))

--- a/ext/IntervalArithmeticForwardDiffExt.jl
+++ b/ext/IntervalArithmeticForwardDiffExt.jl
@@ -101,14 +101,14 @@ end
 function (piecewise::Piecewise)(dual::Dual{T, <:Interval}) where {T}
     X = value(dual)
     input_domain = Domain(X)
-    if !overlap_domain(input_domain, piecewise) 
+    if !overlap_domain(input_domain, piecewise)
         return Dual{T}(emptyinterval(X), emptyinterval(X) .* partials(dual))
     end
 
     if !in_domain(input_domain, piecewise)
         dec = trv
     elseif any(x -> in_domain(x, input_domain), discontinuities(piecewise, 1))
-        dec = def 
+        dec = def
     else
         dec = com
     end
@@ -135,5 +135,7 @@ function (piecewise::Piecewise)(dual::Dual{T, <:Interval}) where {T}
     return Dual{T}(primal, tuple(partial...))
 end
 
+ForwardDiff.DiffRules._abs_deriv(x::Dual{T,<:Interval}) where {T} =
+    Dual{T}(ForwardDiff.DiffRules._abs_deriv(value(x)), zero(partials(x)))
 
 end

--- a/test/interval_tests/forwarddiff.jl
+++ b/test/interval_tests/forwarddiff.jl
@@ -10,7 +10,7 @@ end
     @testset "abs" begin
         @test ForwardDiff.derivative(abs, interval(-2, -1)) === interval(-1, -1, com)
         @test ForwardDiff.derivative(abs, interval( 1,  2)) === interval( 1,  1, com)
-        @test ForwardDiff.derivative(abs, interval(   0  )) === interval(   0  , trv)
+        @test ForwardDiff.derivative(abs, interval(   0  )) === interval(-1,  1, trv)
         @test ForwardDiff.derivative(abs, interval(-1,  0)) === interval(-1,  0, trv)
         @test ForwardDiff.derivative(abs, interval( 0,  1)) === interval( 0,  1, trv)
         @test ForwardDiff.derivative(abs, interval(-2,  2)) === interval(-1,  1, trv)
@@ -21,7 +21,7 @@ end
         g(x) = abs(x)^2
         @test     ForwardDiff.derivative(g,             interval(-1, 1) )  ===  interval(convert(Interval{Float64}, -2), convert(Interval{Float64}, 2), trv)
         @test all(ForwardDiff.gradient(  v -> g(v[1]), [interval(-1, 1)]) .=== [interval(convert(Interval{Float64}, -2), convert(Interval{Float64}, 2), trv)])
-        @test_broken all(ForwardDiff.hessian(   v -> g(v[1]), [interval(  0  )]) .=== [interval(convert(Interval{Float64}, -2), convert(Interval{Float64}, 2), trv)])
+        @test all(ForwardDiff.hessian(   v -> g(v[1]), [interval(  0  )]) .=== [interval(convert(Interval{Float64}, -2), convert(Interval{Float64}, 2), trv)])
     end
 
     @testset "sin" begin


### PR DESCRIPTION
As pointed out by @dpsanders, it is much more consistent to return $[-1, 1]$ for the derivative of `abs`. It also resolves a broken test for second-order derivatives with [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl).