### PR TITLE
Add `rand(::Interval)`

### DIFF
--- a/ext/IntervalArithmeticRandomExt.jl
+++ b/ext/IntervalArithmeticRandomExt.jl
@@ -3,9 +3,15 @@ module IntervalArithmeticRandomExt
 using IntervalArithmetic
 import Random
 
-Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} = interval(rand(rng, T))
+Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} =
+    interval(rand(rng, T))
 
-Random.rand(rng::Random.AbstractRNG, x::Random.SamplerTrivial{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} =
-    max(inf(x), floatmin(T)) + rand(rng, T) * (min(sup(x), floatmax(T)) - max(inf(x), floatmin(T)))
+function Random.rand(rng::Random.AbstractRNG, x::Random.SamplerTrivial{Interval{T}}) where {T<:AbstractFloat}
+    lo, hi = bounds(x[])
+    val = max(lo, floatmin(T)) + rand(rng, T) * (min(hi, floatmax(T)) - max(lo, floatmin(T)))
+    val = ifelse(val < lo, lo, val)
+    val = ifelse(val > hi, hi, val)
+    return val
+end
 
 end

--- a/ext/IntervalArithmeticRandomExt.jl
+++ b/ext/IntervalArithmeticRandomExt.jl
@@ -5,4 +5,6 @@ import Random
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} = interval(rand(rng, T))
 
+Random.rand(rng::Random.AbstractRNG, x::Random.SamplerTrivial{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} = mid(x[], rand(rng, T))
+
 end

--- a/ext/IntervalArithmeticRandomExt.jl
+++ b/ext/IntervalArithmeticRandomExt.jl
@@ -5,6 +5,7 @@ import Random
 
 Random.rand(rng::Random.AbstractRNG, ::Random.SamplerType{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} = interval(rand(rng, T))
 
-Random.rand(rng::Random.AbstractRNG, x::Random.SamplerTrivial{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} = mid(x[], rand(rng, T))
+Random.rand(rng::Random.AbstractRNG, x::Random.SamplerTrivial{Interval{T}}) where {T<:IntervalArithmetic.NumTypes} =
+    max(inf(x), floatmin(T)) + rand(rng, T) * (min(sup(x), floatmax(T)) - max(inf(x), floatmin(T)))
 
 end

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -100,8 +100,10 @@ function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
         hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
         β = convert(T, α)
         midpoint = β * (hi + lo * (1/β - 1)) # exactly 0.5 * (hi + lo) for β = 0.5
-        isfinite(midpoint) && return _normalisezero(midpoint)
-        return _normalisezero((1 - β) * lo + β * hi)
+        midpoint = ifelse(isfinite(midpoint), midpoint, (1 - β) * lo + β * hi)
+        midpoint = ifelse(midpoint < lo, lo, midpoint)
+        midpoint = ifelse(midpoint > hi, hi, midpoint)
+        return _normalisezero(midpoint)
     end
 end
 function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -118,11 +118,7 @@ function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
         lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
         hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
         β = convert(T, α)
-        midpoint = β * (hi - lo) + lo
-        midpoint = ifelse(isfinite(midpoint), midpoint, (1 - β) * lo + β * hi)
-        midpoint = ifelse(midpoint < lo, lo, midpoint)
-        midpoint = ifelse(midpoint > hi, hi, midpoint)
-        return _normalisezero(midpoint)
+        return _normalisezero((1 - β) * lo + β * hi)
     end
 end
 

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -119,8 +119,10 @@ function mid(x::BareInterval{T}, α = 1//2) where {T<:Rational}
         hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
         β = convert(T, α)
         midpoint = β * (hi - lo) + lo
-        isfinite(midpoint) && return _normalisezero(midpoint)
-        return _normalisezero((1 - β) * lo + β * hi)
+        midpoint = ifelse(isfinite(midpoint), midpoint, (1 - β) * lo + β * hi)
+        midpoint = ifelse(midpoint < lo, lo, midpoint)
+        midpoint = ifelse(midpoint > hi, hi, midpoint)
+        return _normalisezero(midpoint)
     end
 end
 

--- a/test/interval_tests/consistency.jl
+++ b/test/interval_tests/consistency.jl
@@ -181,6 +181,7 @@
 
     @testset "mid" begin
         @test mid(interval(Rational{Int}, 1//2)) == 1//2
+        @test mid(interval(2), 0.4969816845401611) == 2
         @test mid(interval(1, 2)) == 1.5
         @test mid(interval(0.1, 0.3)) == 0.2
         @test mid(interval(-10, 5)) == -2.5


### PR DESCRIPTION
This properly addresses #709. Closes #709.

This also contains a fix for a bug with `mid(x, t)` and $t \ne 1/2$, where floating point errors could result in a midpoint value outside the prescribed interval.

cc @lbenet @dpsanders 