### PR TITLE
Add extension for Arblib.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RoundingEmulator = "5eaf0fd0-dfba-4ccb-bf02-d820a40db705"
 
 [weakdeps]
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
@@ -19,6 +20,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extensions]
+IntervalArithmeticArblibExt = "Arblib"
 IntervalArithmeticDiffRulesExt = "DiffRules"
 IntervalArithmeticForwardDiffExt = "ForwardDiff"
 IntervalArithmeticIntervalSetsExt = "IntervalSets"
@@ -27,6 +29,7 @@ IntervalArithmeticRecipesBaseExt = "RecipesBase"
 IntervalArithmeticSparseArraysExt = "SparseArrays"
 
 [compat]
+Arblib = "1.3.0"
 CRlibm = "1.0.2"
 DiffRules = "1"
 ForwardDiff = "0.10, 1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,6 +22,9 @@ makedocs(;
         "Manual" => [
             "Constructing intervals" => "manual/construction.md",
             "Usage" => "manual/usage.md",
+            "Interfaces" => [
+              "Arblib.jl" => "manual/interfaces/Arblib.md"
+            ],
             "API" => "manual/api.md"
         ],
         "Examples" => ["Rigorous computation of ``\\pi``" => "examples/pi.md"],

--- a/docs/src/manual/interfaces/Arblib.md
+++ b/docs/src/manual/interfaces/Arblib.md
@@ -1,0 +1,116 @@
+# Interfacing with Arblib.jl
+
+[Arblib.jl](https://github.com/kalmarek/Arblib.jl/) is a Julia package
+for rigorous numerics based on ball arithmetic. It provides a thin and
+efficient wrapper around the parts of the C library
+[FLINT](https://flintlib.org/) that are concerned with real and
+complex numbers.
+
+The purpose of this interface is to make conversions between the types
+used by IntervalArithmetic.jl and Arblib.jl straightforward. This
+allows for easy switching between doing different parts of
+computations in different packages, depending on which package suits
+that particular part of the computation best.
+
+Some of the things that Arblib.jl excels at are:
+1. Fast high precision computations, including linear algebra routines.
+2. A large library of special functions.
+3. [Support for mutable arithmetic](https://kalmarek.github.io/Arblib.jl/stable/interface-mutable/).
+4. [Taylor series expansions](https://kalmarek.github.io/Arblib.jl/stable/interface-series/).
+
+Some things that IntervalArithmetic.jl excels at:
+1. Fast computations at `Float32` and `Float64` precision.
+2. Computations with wide intervals (FLINT is in general not optimized
+   for this, though the situation is improving).
+3. Built-in safety features, such as decorations and the `NG` flag.
+   Arblib.jl provides fewer built-in safeguards, requiring more
+   careful handling.
+
+## Conversion between `Interval` and Arblib.jl types
+The fundamental types in Arblib.jl are `Arb` and `Acb`, corresponding
+to real and complex balls respectively. Conversion between `Interval`
+and `Arb` as well as between `Complex{Interval}` and `Acb` is done
+through the standard constructors. If no type is specified it defaults
+to `Interval{BigFloat}` for `Arb` and `Complex{Interval{BigFloat}}`
+for `Acb`.
+
+``` @repl 1
+using Arblib
+
+x = interval(π)
+Arb(x)
+
+y = Arb(π)
+interval(y) # Defaults to BigFloat
+interval(Float64, y) # Other type can be explicitly specified
+
+z = complex(interval(2), interval(1 // 3))
+Acb(z)
+
+w = Acb(2, 1 // 3)
+interval(w)
+interval(Float64, w)
+```
+
+## Linear algebra
+To use the optimized linear algebra routines in FLINT the matrices
+should be converted to `ArbMatrix` or `AcbMatrix` (depending on
+whether they are real or complex). Basic methods can then be used
+directly:
+
+``` @repl
+using Arblib, LinearAlgebra
+
+A = interval.(BigFloat, [1 2; 3 4])
+
+B = ArbMatrix(A)
+
+B * B
+
+inv(B)
+
+B \ B
+
+eigvals(AcbMatrix(B)) # Eigenvalues are only supported for AcbMatrix
+```
+
+Full documentation about supported methods can be found in the FLINT
+documentation for [arb_mat](https://flintlib.org/doc/arb_mat.html) and
+[acb_mat](https://flintlib.org/doc/acb_mat.html). Note that many of
+these methods are not wrapped in Arblib.jl, but most of them can be
+used through the [low level
+wrapper](https://kalmarek.github.io/Arblib.jl/stable/wrapper-methods/).
+
+## Special functions
+Arblib.jl wraps a large number of the special functions in
+[SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl).
+
+``` @repl
+using Arblib, SpecialFunctions
+
+x = interval(BigFloat, 2)
+
+interval(besselj0(Arb(x))) # Convert to Arb and then back
+
+interval(gamma(Arb(x)))
+
+interval(zeta(Arb(x)))
+```
+
+Note that FLINT implements several special functions that are not in
+SpecialFunctions.jl, such as the [confluent hypergeometric
+functions](https://flintlib.org/doc/acb_hypgeom.html#confluent-hypergeometric-functions)
+and the [Lerch
+transcendent](https://flintlib.org/doc/acb_dirichlet.html#lerch-transcendent);
+they can be used through the [low-level
+wrapper](https://kalmarek.github.io/Arblib.jl/stable/wrapper-methods/):
+
+``` @repl
+using Arblib
+
+z = interval(BigFloat, 2 + 3im)
+s = interval(BigFloat, 2)
+a = interval(BigFloat, 4)
+
+interval(Arblib.dirichlet_lerch_phi!(Acb(), Acb(z), Acb(s), Acb(a)))
+```

--- a/ext/IntervalArithmeticArblibExt.jl
+++ b/ext/IntervalArithmeticArblibExt.jl
@@ -1,0 +1,153 @@
+module IntervalArithmeticArblibExt
+
+import IntervalArithmetic as IA
+import Arblib
+
+# Promotion rules
+
+# These are needed for ambiguity reasons
+Base.promote_rule(
+    ::Type{IA.Interval{T}},
+    ::Type{S},
+) where {T<:IA.NumTypes,S<:Arblib.ArfOrRef} = IA.Interval{promote_type(T, S)}
+Base.promote_rule(
+    ::Type{T},
+    ::Type{IA.Interval{S}},
+) where {T<:Arblib.ArfOrRef,S<:IA.NumTypes} = IA.Interval{promote_type(T, S)}
+
+Base.promote_rule(
+    ::Type{IA.Interval{T}},
+    ::Type{S},
+) where {T<:IA.NumTypes,S<:Arblib.ArbOrRef} =
+    throw(ArgumentError("promotion between Interval and Arb is purposely not supported"))
+Base.promote_rule(
+    ::Type{T},
+    ::Type{IA.Interval{S}},
+) where {T<:Arblib.ArbOrRef,S<:IA.NumTypes} =
+    throw(ArgumentError("promotion between Interval and Arb is purposely not supported"))
+
+# Construction of Arb from Interval
+# Note that this automatically gives support for construction of Acb.
+
+Arblib._precision(x::Union{IA.Interval,IA.BareInterval}) =
+    Arblib._precision(IA.inf(x), IA.sup(x))
+
+function Arblib.set!(
+    res::Arblib.ArbLike,
+    x::Union{IA.Interval,IA.BareInterval};
+    prec::Integer = precision(res),
+)
+    if IA.isempty_interval(x)
+        Arblib.indeterminate!(res)
+    else
+        Arblib.set!(res, (IA.inf(x), IA.sup(x)); prec)
+    end
+    return res
+end
+
+# Construction of Interval from Arb
+
+# We essentially treat Arb as Interval{BigFloat} for the purposes of
+# constructing Intervals. This means that we only have to change the
+# behavior of _inf and _sup since these are called early on in the
+# construction process to handle endpoints which are Intervals.
+
+IA._inf(x::Arblib.ArbOrRef) = BigFloat(Arblib.lbound(x))
+IA._sup(x::Arblib.ArbOrRef) = BigFloat(Arblib.ubound(x))
+
+# Make promote_numtype for Arb behave like promotion with BigFloat
+IA.promote_numtype(::Type{<:Arblib.ArbOrRef}, ::Type{<:Arblib.ArbOrRef}) = BigFloat
+IA.promote_numtype(::Type{<:Arblib.ArbOrRef}, ::Type{S}) where {S} =
+    IA.promote_numtype(BigFloat, S)
+IA.promote_numtype(::Type{<:Arblib.ArbOrRef}, ::Type{S}) where {S<:IA.NumTypes} =
+    IA.promote_numtype(BigFloat, S)
+IA.promote_numtype(::Type{T}, ::Type{<:Arblib.ArbOrRef}) where {T} =
+    IA.promote_numtype(T, BigFloat)
+IA.promote_numtype(::Type{T}, ::Type{<:Arblib.ArbOrRef}) where {T<:IA.NumTypes} =
+    IA.promote_numtype(T, BigFloat)
+
+# Construction of Complex{Interval} from Acb
+IA.numtype(::Type{<:Arblib.AcbOrRef}) = Arblib.Arb
+
+# Handle Acb in the same way as Complex.
+IA._interval_infsup(
+    ::Type{T},
+    a::Arblib.AcbOrRef,
+    b::Arblib.AcbOrRef,
+    d::IA.Decoration,
+) where {T<:IA.NumTypes} = complex(
+    IA._interval_infsup(T, real(a), real(b), d),
+    IA._interval_infsup(T, imag(a), imag(b), d),
+)
+IA._interval_infsup(
+    ::Type{T},
+    a::Arblib.AcbOrRef,
+    b,
+    d::IA.Decoration,
+) where {T<:IA.NumTypes} = complex(
+    IA._interval_infsup(T, real(a), real(b), d),
+    IA._interval_infsup(T, imag(a), imag(b), d),
+)
+IA._interval_infsup(
+    ::Type{T},
+    a,
+    b::Arblib.AcbOrRef,
+    d::IA.Decoration,
+) where {T<:IA.NumTypes} = complex(
+    IA._interval_infsup(T, real(a), real(b), d),
+    IA._interval_infsup(T, imag(a), imag(b), d),
+)
+
+# Handle ambiguities
+for S in [Union{IA.BareInterval,IA.Interval}, Complex]
+    @eval IA._interval_infsup(
+        ::Type{T},
+        a::Arblib.AcbOrRef,
+        b::$S,
+        d::IA.Decoration,
+    ) where {T<:IA.NumTypes} = complex(
+        IA._interval_infsup(T, real(a), real(b), d),
+        IA._interval_infsup(T, imag(a), imag(b), d),
+    )
+    @eval IA._interval_infsup(
+        ::Type{T},
+        a::$S,
+        b::Arblib.AcbOrRef,
+        d::IA.Decoration,
+    ) where {T<:IA.NumTypes} = complex(
+        IA._interval_infsup(T, real(a), real(b), d),
+        IA._interval_infsup(T, imag(a), imag(b), d),
+    )
+end
+
+# Make it so that implicit conversion from Arb to Interval doesn't set
+# the NG flag.
+
+Base.convert(::Type{IA.Interval{T}}, x::Arblib.ArbOrRef) where {T<:IA.NumTypes} =
+    IA.interval(T, x)
+
+function Base.convert(::Type{IA.Interval{T}}, x::Arblib.AcbOrRef) where {T<:IA.NumTypes}
+    isreal(x) || return throw(DomainError(x, "imaginary part must be zero"))
+    return convert(IA.Interval{T}, real(x))
+end
+
+Base.convert(::Type{Complex{IA.Interval{T}}}, x::Arblib.ArbOrRef) where {T<:IA.NumTypes} =
+    complex(IA.interval(T, x))
+
+# Handle ambiguities related to ExactReal
+
+Arblib.Mag(x::IA.ExactReal) = convert(Arblib.Mag, x)
+Arblib.Arf(x::IA.ExactReal) = convert(Arblib.Arf, x)
+Arblib.Arb(x::IA.ExactReal) = convert(Arblib.Arb, x)
+
+Base.promote_rule(::Type{T}, ::Type{IA.ExactReal{S}}) where {T<:Arblib.ArfOrRef,S<:Real} =
+    promote_type(T, S)
+Base.promote_rule(::Type{IA.ExactReal{T}}, ::Type{S}) where {T<:Real,S<:Arblib.ArfOrRef} =
+    promote_type(T, S)
+
+Base.promote_rule(::Type{T}, ::Type{IA.ExactReal{S}}) where {T<:Arblib.ArbOrRef,S<:Real} =
+    promote_type(T, S)
+Base.promote_rule(::Type{IA.ExactReal{T}}, ::Type{S}) where {T<:Real,S<:Arblib.ArbOrRef} =
+    promote_type(T, S)
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Arblib = "fb37089c-8514-4489-9461-98f9c8763369"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"

--- a/test/interval_tests/IntervalArithmeticArblibExt.jl
+++ b/test/interval_tests/IntervalArithmeticArblibExt.jl
@@ -1,0 +1,344 @@
+@testset "IntervalArithmeticArblibExt" begin
+    Arf = Arblib.Arf
+    ArfRef = Arblib.ArfRef
+    Arb = Arblib.Arb
+    ArbRef = Arblib.ArbRef
+    Acb = Arblib.Acb
+    setball = Arblib.setball
+
+    # There is a bug in Flint before version 3.3.0 that gives NaN for
+    # getinterval on balls with infinite midpoint and radius. Check if
+    # we are using such a version to mark tests as broken.
+    broken_getinterval = isnan(Arblib.getinterval(setball(Arb, -Inf, Inf))[2])
+
+    @testset "Promotion rules" begin
+        # Arf behaves like normal promotion with Interval
+        @test promote_type(Arf, Interval{Float64}) == Interval{Arf}
+        @test promote_type(Arf, Interval{BigFloat}) == Interval{Arf}
+        @test promote_type(Arf, Interval{Rational{Int}}) == Interval{Arf}
+        @test promote_type(ArfRef, Interval{Float64}) == Interval{Arf}
+        @test promote_type(ArfRef, Interval{BigFloat}) == Interval{Arf}
+        @test promote_type(ArfRef, Interval{Rational{Int}}) == Interval{Arf}
+        @test promote_type(Interval{Float64}, Arf) == Interval{Arf}
+        @test promote_type(Interval{BigFloat}, Arf) == Interval{Arf}
+        @test promote_type(Interval{Rational{Int}}, Arf) == Interval{Arf}
+        @test promote_type(Interval{Float64}, ArfRef) == Interval{Arf}
+        @test promote_type(Interval{BigFloat}, ArfRef) == Interval{Arf}
+        @test promote_type(Interval{Rational{Int}}, ArfRef) == Interval{Arf}
+
+
+
+        # Promotion between Arb and Interval is not allowed
+        @test_throws ArgumentError promote_type(Arb, Interval{Float64})
+        @test_throws ArgumentError promote_type(Arb, Interval{BigFloat})
+        @test_throws ArgumentError promote_type(Arb, Interval{Arf})
+        @test_throws ArgumentError promote_type(Arb, Interval{Arb})
+        @test_throws ArgumentError promote_type(ArbRef, Interval{Float64})
+        @test_throws ArgumentError promote_type(ArbRef, Interval{BigFloat})
+        @test_throws ArgumentError promote_type(ArbRef, Interval{Arf})
+        @test_throws ArgumentError promote_type(ArbRef, Interval{Arb})
+        @test_throws ArgumentError promote_type(Interval{Float64}, Arb)
+        @test_throws ArgumentError promote_type(Interval{BigFloat}, Arb)
+        @test_throws ArgumentError promote_type(Interval{Arf}, Arb)
+        @test_throws ArgumentError promote_type(Interval{Arb}, Arb)
+        @test_throws ArgumentError promote_type(Interval{Float64}, ArbRef)
+        @test_throws ArgumentError promote_type(Interval{BigFloat}, ArbRef)
+        @test_throws ArgumentError promote_type(Interval{Arf}, ArbRef)
+        @test_throws ArgumentError promote_type(Interval{Arb}, ArbRef)
+    end
+
+    @testset "Interval from Arb" begin
+        @testset "promote_numtype" begin
+            @test IntervalArithmetic.promote_numtype(Arb, Arb) == BigFloat
+            @test IntervalArithmetic.promote_numtype(Arb, ArbRef) == BigFloat
+            @test IntervalArithmetic.promote_numtype(ArbRef, Arb) == BigFloat
+            @test IntervalArithmetic.promote_numtype(ArbRef, ArbRef) == BigFloat
+
+            @test IntervalArithmetic.promote_numtype(Arb, Float64) == BigFloat
+            @test IntervalArithmetic.promote_numtype(ArbRef, Float64) == BigFloat
+            @test IntervalArithmetic.promote_numtype(Arb, Rational{Int}) == BigFloat
+            @test IntervalArithmetic.promote_numtype(ArbRef, Rational{Int}) == BigFloat
+
+            @test IntervalArithmetic.promote_numtype(Arb, Arf) == Arf
+            @test IntervalArithmetic.promote_numtype(ArbRef, Arf) == Arf
+            @test IntervalArithmetic.promote_numtype(Arb, ArfRef) == Arf
+            @test IntervalArithmetic.promote_numtype(ArbRef, ArfRef) == Arf
+        end
+
+        @testset "Single argument constructor" begin
+            # Valid intervals
+            xs = Arb[
+                0,
+                1,
+                π,
+                ℯ,
+                1//3,
+                Arb((1, 2)),
+                Arb((-Inf, Inf)),
+                setball(Arb, 5, Inf),
+                #setball(Arb, -Inf, Inf),
+                #setball(Arb, Inf, Inf),
+            ]
+
+            for x in xs
+                @test interval(x) isa Interval{BigFloat}
+
+                for T in [BigFloat, Arf, Float64, Float32]
+                    y = interval(T, x)
+                    @test y isa Interval{T}
+                    @test !isnai(y)
+                    @test isbounded(y) == isfinite(x)
+                    @test Arblib.contains(Arb(y), x)
+                end
+            end
+
+            # These are bugs in Flint
+            @test isequal_interval(interval(setball(Arb, -Inf, Inf)), interval(-Inf, Inf)) broken =
+                broken_getinterval
+            @test isequal_interval(interval(setball(Arb, Inf, Inf)), interval(-Inf, Inf)) broken =
+                broken_getinterval
+
+            # Invalid intervals
+            @test isnai(interval(Arb(-Inf)))
+            @test isnai(interval(Arb(Inf)))
+            @test isnai(interval(Arb(NaN)))
+        end
+
+        @testset "Two argument constructor" begin
+            # Valid infs and sups
+            # All <=3
+            as1 = Real[0, 1, ℯ, 1//3, 0.1, BigFloat(1.1), BigInt(3)]
+            # All >=3
+            bs1 = Real[3, π, 7//2, BigFloat(4.1), BigInt(4)]
+
+            for a in as1
+                for b in bs1
+                    a_Arb = Arb(a)
+                    b_Arb = Arb(b)
+
+                    y1 = interval(a, b_Arb)
+                    y2 = interval(a_Arb, b)
+                    y3 = interval(a_Arb, b_Arb)
+
+                    @test y1 isa Interval{BigFloat}
+                    @test y2 isa Interval{BigFloat}
+                    @test y3 isa Interval{BigFloat}
+
+                    @test Arblib.overlaps(Arb(y1), a_Arb)
+                    @test Arblib.overlaps(Arb(y1), b_Arb)
+                    @test Arblib.overlaps(Arb(y2), a_Arb)
+                    @test Arblib.overlaps(Arb(y2), b_Arb)
+                    @test Arblib.overlaps(Arb(y3), a_Arb)
+                    @test Arblib.overlaps(Arb(y3), b_Arb)
+
+                    # TODO: Doesn't work for Arf because it doesn't support nextfloat
+                    for T in [BigFloat, Float64, Float32]
+                        y1 = interval(T, a, b_Arb)
+                        y2 = interval(T, a_Arb, b)
+                        y3 = interval(T, a_Arb, b_Arb)
+
+                        @test y1 isa Interval{T}
+                        @test y2 isa Interval{T}
+                        @test y3 isa Interval{T}
+
+                        @test Arblib.overlaps(Arb(y1), a_Arb)
+                        @test Arblib.overlaps(Arb(y1), b_Arb)
+                        @test Arblib.overlaps(Arb(y2), a_Arb)
+                        @test Arblib.overlaps(Arb(y2), b_Arb)
+                        @test Arblib.overlaps(Arb(y3), a_Arb)
+                        @test Arblib.overlaps(Arb(y3), b_Arb)
+                    end
+                end
+            end
+
+            # Overlapping intervals
+            @test isequal_interval(
+                interval(interval(1, 3), interval(2, 4)),
+                interval(setball(Arb, 2, 1), setball(Arb, 3, 1)),
+            )
+            @test isequal_interval(
+                interval(interval(1, 3), interval(0, 4)),
+                interval(setball(Arb, 2, 1), setball(Arb, 2, 2)),
+            )
+            @test isequal_interval(
+                interval(interval(1, 5), interval(2, 4)),
+                interval(setball(Arb, 3, 2), setball(Arb, 3, 1)),
+            )
+
+            # Infinite, but valid, intervals
+            as2 = [
+                Arb(-Inf),
+                setball(Arb, -Inf, 1),
+                Arb((-Inf, Inf)),
+                setball(Arb, -Inf, Inf),
+                setball(Arb, 0, Inf),
+                setball(Arb, Inf, Inf),
+            ]
+
+            bs2 = [
+                Arb(Inf),
+                setball(Arb, Inf, 1),
+                Arb((-Inf, Inf)),
+                setball(Arb, -Inf, Inf),
+                setball(Arb, 0, Inf),
+                setball(Arb, Inf, Inf),
+            ]
+
+            for a in as2
+                for b in bs2
+                    # This is a bug in Flint
+                    broken =
+                        broken_getinterval && (
+                            isequal(a, setball(Arb, Inf, Inf)) ||
+                            isequal(b, setball(Arb, -Inf, Inf))
+                        )
+                    @test isequal_interval(interval(a, b), interval(-Inf, Inf)) broken =
+                        broken
+                end
+            end
+
+            for a in as2
+                # This is a bug in Flint
+                broken = broken_getinterval && isequal(a, setball(Arb, Inf, Inf))
+                @test isequal_interval(interval(a, Inf), interval(-Inf, Inf)) broken =
+                    broken
+            end
+
+            for b in bs2
+                # This is a bug in Flint
+                broken = broken_getinterval && isequal(b, setball(Arb, -Inf, Inf))
+                @test isequal_interval(interval(-Inf, b), interval(-Inf, Inf)) broken =
+                    broken
+            end
+
+            # Invalid intervals
+
+            # [-Inf, -Inf] or [Inf, Inf]
+            @test isnai(interval(Arb(-Inf), Arb(-Inf)))
+            @test isnai(interval(-Inf, Arb(-Inf)))
+            @test isnai(interval(Arb(-Inf), -Inf))
+            @test isnai(interval(setball(Arb, -Inf, 1), Arb(-Inf)))
+            @test isnai(interval(Arb(-Inf), setball(Arb, -Inf, 1)))
+            @test isnai(interval(Arb(Inf), Arb(Inf)))
+            @test isnai(interval(Inf, Arb(Inf)))
+            @test isnai(interval(Arb(Inf), Inf))
+            @test isnai(interval(setball(Arb, Inf, 1), Arb(Inf)))
+            @test isnai(interval(Arb(Inf), setball(Arb, Inf, 1)))
+
+            # With NaN
+            @test isnai(interval(Arb(NaN), 0))
+            @test isnai(interval(setball(Arb, NaN, Inf), 0))
+            @test isnai(interval(Arb(NaN), -Inf))
+            @test isnai(interval(Arb(NaN), Inf))
+            @test isnai(interval(0, Arb(NaN)))
+            @test isnai(interval(0, setball(Arb, NaN, Inf)))
+            @test isnai(interval(-Inf, Arb(NaN)))
+            @test isnai(interval(Inf, Arb(NaN)))
+
+            # A few tests to check that :midpoint constructor seems ok
+            @test isequal_interval(
+                interval(setball(Arb, 0, 1), format = :midpoint),
+                interval(-1, 1),
+            )
+            @test isequal_interval(
+                interval(setball(Arb, 0, 1), setball(Arb, 4, 1), format = :midpoint),
+                interval(-6, 6),
+            )
+            @test_throws DomainError interval(0, Arb((-1, 1)), format = :midpoint)
+        end
+
+        @testset "Complex intervals" begin
+            @test isequal_interval(
+                interval(1 + 2im, 3 + 4im),
+                interval(Acb(setball(Arb, 2, 1), setball(Arb, 3, 1))),
+            )
+            @test isequal_interval(
+                interval(Float64, 1 + 2im, 3 + 4im),
+                interval(Acb(setball(Arb, 2, 1), setball(Arb, 3, 1))),
+            )
+
+            @test isequal_interval(
+                interval(1 + 2im, 3 + 4im),
+                interval(Acb(1, 2), Acb(3, 4)),
+            )
+
+            @test isequal_interval(interval(1 + 2im, 3 + 4im), interval(Acb(1, 2), 3 + 4im))
+            @test isequal_interval(interval(1 - 2im, 3), interval(Acb(1, -2), 3))
+            @test isequal_interval(
+                interval(1 - 2im, 3),
+                interval(Acb(1, -2), interval(3, 3)),
+            )
+
+            @test isequal_interval(interval(1 + 2im, 3 + 4im), interval(1 + 2im, Acb(3, 4)))
+            @test isequal_interval(interval(1, 3 + 2im), interval(1, Acb(3, 2)))
+            @test isequal_interval(interval(1, 3 + 2im), interval(interval(1), Acb(3, 2)))
+        end
+
+        @testset "convert" begin
+            @test isguaranteed(convert(Interval{Float64}, Arb(1)))
+            @test isguaranteed(convert(Interval{Float64}, Acb(1)))
+            @test_throws DomainError convert(Interval{Float64}, Acb(1, 1))
+
+            @test isguaranteed(convert(Complex{Interval{Float64}}, Arb(1)))
+            @test isguaranteed(convert(Complex{Interval{Float64}}, Acb(1)))
+            @test isguaranteed(convert(Complex{Interval{Float64}}, Acb(1, 1)))
+        end
+    end
+
+    @testset "Arb from Interval" begin
+        # Check constructor
+        @test isequal(Arb((0, 1)), Arb(interval(0, 1)))
+        @test isequal(setball(Arb, NaN, Inf), Arb(nai(Float64)))
+        @test Arblib.overlaps(Arb(π), Arb(interval(π)))
+        @test Arblib.overlaps(Arb(π), Arb(interval(BigFloat, π)))
+        @test isequal(Arblib.indeterminate!(Arb()), Arb(emptyinterval()))
+        @test isequal(Acb(1, 2), Acb(interval(1 + 2im)))
+
+        # Check Arblib.set!
+        @test isequal(Arb((0, 1)), Arblib.set!(Arb(), interval(0, 1)))
+        @test isequal(setball(Arb, NaN, Inf), Arblib.set!(Arb(), nai(Float64)))
+        @test isequal(Arb(interval(π)), Arblib.set!(Arb(), interval(π)))
+        @test isequal(Arb(interval(BigFloat, π)), Arblib.set!(Arb(), interval(BigFloat, π)))
+        @test isequal(Arblib.indeterminate!(Arb()), Arblib.set!(Arb(), emptyinterval()))
+        @test isequal(Acb(1, 2), Arblib.set!(Acb(), interval(1 + 2im)))
+        # Check that prec argument works
+        @test Arblib.contains_interior(
+            Arblib.set!(Arb(), interval(BigFloat, π), prec = 64),
+            Arb(interval(BigFloat, π)),
+        )
+
+        # Check _precision
+        # One argument
+        @test Arblib._precision(interval(1, 2)) == precision(Arb)
+        @test Arblib._precision(interval(BigFloat, BigFloat(1, precision = 80))) == 80
+        @test Arblib._precision(
+            interval(BigFloat, BigFloat(1, precision = 80), BigFloat(1, precision = 64)),
+        ) == 80
+        @test Arblib._precision(
+            interval(BigFloat, BigFloat(1, precision = 64), BigFloat(1, precision = 80)),
+        ) == 80
+
+        # Check that precision is preserved
+        @test precision(
+            Arb(interval(BigFloat(1, precision = 80), BigFloat(2, precision = 64))),
+        ) == 80
+        @test precision(Arb(interval(Arf(0, prec = 64), Arf(1, prec = 80)))) == 80
+    end
+
+    # Check that the ambiguity related changes actually work
+    @testset "ExactReal" begin
+        @test Arblib.Mag(ExactReal(5)) == Arblib.Mag(5)
+        @test Arf(ExactReal(5)) == Arf(5)
+        @test Arb(ExactReal(5)) == Arb(5)
+
+        @test promote_type(Arf, ExactReal{Float64}) == Arf
+        @test promote_type(ArfRef, ExactReal{Float64}) == Arf
+        @test promote_type(ExactReal{Float64}, Arf) == Arf
+        @test promote_type(ExactReal{Float64}, ArfRef) == Arf
+
+        @test promote_type(Arb, ExactReal{Float64}) == Arb
+        @test promote_type(ArbRef, ExactReal{Float64}) == Arb
+        @test promote_type(ExactReal{Float64}, Arb) == Arb
+        @test promote_type(ExactReal{Float64}, ArbRef) == Arb
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using ForwardDiff
 using IntervalArithmetic
 using InteractiveUtils
+import Arblib
 import IntervalSets as IS
 
 include("generate_ITF1788.jl")


### PR DESCRIPTION
As discussed in #721, it would be nice to make the Arblib.jl and IntervalArithmetic.jl packages talk to each other. This is an attempt at making basic conversion between `Interval` and `Arb` work.

```julia
julia> using Arblib, IntervalArithmetic

julia> x = interval(BigFloat, π)
[3.14159, 3.1416]₂₅₆_com

julia> y = Arb(x)
[3.1415926535897932384626433832795028841971693993751058209749445923078164062862 +/- 5.38e-77]

julia> cos(x)
[-1.0, -0.999999]₂₅₆_com

julia> cos(y)
[-1.000000000000000000000000000000000000000000000000000000000000000000000000000 +/- 1.78e-77]
```

It is also possible to construct matrices and do basic linear algebra

```julia
julia> A = interval.(rand(BigFloat, 2, 2))
2×2 Matrix{Interval{BigFloat}}:
 [0.15383, 0.153831]₂₅₆_com  [0.655025, 0.655026]₂₅₆_com
 [0.165259, 0.16526]₂₅₆_com  [0.828643, 0.828644]₂₅₆_com

julia> B = ArbMatrix(A)
2×2 ArbMatrix:
 [0.15{…73 digits…}85 ± 3.64e-78]  [0.65{…73 digits…}67 ± 4.69e-78]
 [0.16{…73 digits…}30 ± 4.82e-78]  [0.82{…73 digits…}91 ± 1.48e-78]

julia> Arblib.overlaps(B * B, ArbMatrix(A * A))
true
```

# Implementation
Construction of `Arb` from `Interval` is straightforward. It only requires overloading `Arblib.set!` to handle inputs of type `Interval`. To make some of the internal precision handling correct, I also updated `Arblib._precision` to be aware of the `Interval` type.

I realized my first attempt at the construction of `Interval` from `Arb` was incorrect. The second attempt was super complicated and used a lot of internals of IntervalArithmetic. The final attempt ended up being fairly simple. For construction, we basically want to treat `Arb` as equivalent to `Interval{BigFloat}`. For this, we define

```julia
IA._inf(x::Arblib.ArbOrRef) = BigFloat(Arblib.lbound(x))
IA._sup(x::Arblib.ArbOrRef) = BigFloat(Arblib.ubound(x))
```

and make sure that `IntervalArithmetic.promote_numtype` handles promotion with `Arb` in the way we want. Note that this generates quite a lot of allocation, to compute `_inf(x)` it first computes the lower bound as and `Arf`, then converts it to a `BigFloat` and then further converts it to whatever type the interval should be. I could however note figure out a better way to do it at this point.

I also made the following updates:
- Made `Base.promote_rule` explicitly throw an error for promotion between `Arb` and `Interval`.
- Handle some ambiguities related to `ExactReal` as well as `Arf`.

I added **a lot** of tests. This was partially because my first few attempts of implementing the constructor were fairly complicated and I wanted to make sure that I checked all edge cases. The final implementation is a lot simpler and maybe doesn't warrant quite as many tests. But testing more never hurts!

Note that a few of the implemented tests are marked as broken. While doing the implementation, I noticed some issues with the `Arblib.getinterval` function for infinite intervals with infinite endpoints. This is due to an issue in Flint that I [reported](https://github.com/flintlib/flint/issues/2329).
