### PR TITLE
Eigenbox

### DIFF
--- a/docs/src/manual/usage.md
+++ b/docs/src/manual/usage.md
@@ -152,6 +152,28 @@ and deal properly with the decorations of intervals.
 
 
 
+### Linear algebra
+
+Interval matrices support standard linear algebra operations from the `LinearAlgebra`
+standard library. The eigendecomposition (`eigen`, `eigvals`) uses several algorithms
+that can be selected via the `alg` keyword argument:
+
+- [`IntervalEigen`](@ref IntervalArithmetic.IntervalEigen) (default): tries the contraction mapping theorem first, falls back to the Rohn enclosure.
+- [`IntervalEigenContraction`](@ref IntervalArithmetic.IntervalEigenContraction): contraction mapping only.
+- [`IntervalEigenRohn`](@ref IntervalArithmetic.IntervalEigenRohn): Rohn eigenvalue enclosure.
+- [`IntervalEigenHertz`](@ref IntervalArithmetic.IntervalEigenHertz): Hertz exact hull (exponential complexity).
+
+All algorithms are subtypes of [`AbstractIntervalEigenAlg`](@ref IntervalArithmetic.AbstractIntervalEigenAlg).
+
+```@repl usage
+using LinearAlgebra
+A = interval.([1.0 0.5; 0.5 2.0])
+eigen(A)
+eigen(A; alg = IntervalEigenRohn())
+```
+
+
+
 ### Custom interval bounds type
 
 A `BareInterval{T}` or `Interval{T}` have the restriction `T <: Union{Rational,AbstractFloat}` which is the parametric type for the bounds of the interval. Supposing one wishes to use their own numeric type `MyNumType <: Union{Rational,AbstractFloat}`, they must provide their own arithmetic operations (with correct rounding!).

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -62,9 +62,24 @@ end
 
 # matrix eigenvalues
 
-function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby, kwargs...)
+if isdefined(LinearAlgebra, :Algorithm)
+    struct IntervalEigen <: LinearAlgebra.Algorithm end
+else
+    struct IntervalEigen end
+end
+
+# Julia ≥ 1.12: override default_eigen_alg so that the Symmetric/Hermitian eigvals/eigen
+# paths pass IntervalEigen() instead of a LAPACK algorithm.
+if isdefined(LinearAlgebra, :default_eigen_alg)
+    LinearAlgebra.default_eigen_alg(::Union{
+        LinearAlgebra.Symmetric{<:RealIntervalType},
+        LinearAlgebra.Symmetric{<:Complex{<:RealIntervalType}},
+        LinearAlgebra.Hermitian{<:RealIntervalType},
+        LinearAlgebra.Hermitian{<:Complex{<:RealIntervalType}}}) = IntervalEigen()
+end
+
+function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; alg::IntervalEigen=IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
     # note: this function does not overwrite `A`
-    # kwargs absorbs e.g. `alg` passed by Symmetric eigvals in Julia ≥ 1.12
     λ = _eigvals(A, permute, scale, sortby)
     isreal(λ) && return real(λ)
     _fold_conjugate!(λ)
@@ -72,7 +87,7 @@ function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; permute::Bool=tru
     return λ
 end
 
-LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby, kwargs...) =
+LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; alg::IntervalEigen=IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
     # note: this function does not overwrite `A`
     _eigvals(A, permute, scale, sortby)
 

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -60,25 +60,12 @@ function LinearAlgebra.opnormInf(A::AbstractMatrix{T}) where {T<:RealOrComplexI}
     return convert(Tnorm, nrm)
 end
 
-# matrix eigenvalues
+# matrix eigenvalues – algorithm types
+# Types are defined in IntervalArithmetic; we use them here for dispatch.
 
-if isdefined(LinearAlgebra, :Algorithm)
-    struct IntervalEigen <: LinearAlgebra.Algorithm end
-else
-    struct IntervalEigen end
-end
+# Algorithm types (IntervalArithmetic.IntervalEigen etc.) are used with explicit prefix below.
 
-# Julia ≥ 1.12: override default_eigen_alg so that the Symmetric/Hermitian eigvals/eigen
-# paths pass IntervalEigen() instead of a LAPACK algorithm.
-if isdefined(LinearAlgebra, :default_eigen_alg)
-    LinearAlgebra.default_eigen_alg(::Union{
-        LinearAlgebra.Symmetric{<:RealIntervalType},
-        LinearAlgebra.Symmetric{<:Complex{<:RealIntervalType}},
-        LinearAlgebra.Hermitian{<:RealIntervalType},
-        LinearAlgebra.Hermitian{<:Complex{<:RealIntervalType}}}) = IntervalEigen()
-end
-
-function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; alg::IntervalEigen=IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
+function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
     # note: this function does not overwrite `A`
     λ = _eigvals(A, permute, scale, sortby)
     isreal(λ) && return real(λ)
@@ -87,9 +74,27 @@ function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; alg::IntervalEige
     return λ
 end
 
-LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; alg::IntervalEigen=IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
+LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
     # note: this function does not overwrite `A`
     _eigvals(A, permute, scale, sortby)
+
+# More specific methods for Symmetric/Hermitian wrappers to take priority over
+# LinearAlgebra's methods on Julia ≥ 1.12 (which require alg::Algorithm).
+const _SymHermInterval = Union{
+    LinearAlgebra.Symmetric{<:RealIntervalType},
+    LinearAlgebra.Symmetric{<:Complex{<:RealIntervalType}},
+    LinearAlgebra.Hermitian{<:RealIntervalType},
+    LinearAlgebra.Hermitian{<:Complex{<:RealIntervalType}}}
+
+function LinearAlgebra.eigvals(A::_SymHermInterval; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), sortby::Union{Function,Nothing}=nothing)
+    sb = sortby === nothing ? LinearAlgebra.eigsortby : sortby
+    return LinearAlgebra.eigvals!(Matrix(A); alg, permute=true, scale=true, sortby=sb)
+end
+
+function LinearAlgebra.eigvals!(A::_SymHermInterval; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), sortby::Union{Function,Nothing}=nothing)
+    sb = sortby === nothing ? LinearAlgebra.eigsortby : sortby
+    return LinearAlgebra.eigvals!(Matrix(A); alg, permute=true, scale=true, sortby=sb)
+end
 
 function _eigvals(A, permute, scale, sortby)
     # Gershgorin circle theorem
@@ -140,13 +145,45 @@ LinearAlgebra.det(A::AbstractMatrix{<:Interval}) = real(reduce(*, LinearAlgebra.
 LinearAlgebra.det(A::AbstractMatrix{<:Complex{<:Interval}}) = reduce(*, LinearAlgebra.eigvals(A))
 
 # matrix eigendecomposition
-# note: use the contraction mapping theorem, only works when the entries of A have small radii, and A has simple eigenvalues
 
-LinearAlgebra.eigen(A::AbstractMatrix{<:RealOrComplexI}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
-    LinearAlgebra.eigen!(A; permute, scale, sortby)
+LinearAlgebra.eigen(A::AbstractMatrix{<:RealOrComplexI}; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
+    LinearAlgebra.eigen!(A; alg, permute, scale, sortby)
 
-function LinearAlgebra.eigen!(A::AbstractMatrix{<:RealOrComplexI}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
+LinearAlgebra.eigen(A::_SymHermInterval; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
+    LinearAlgebra.eigen!(A; alg, permute, scale, sortby)
+
+function LinearAlgebra.eigen!(A::AbstractMatrix{<:RealOrComplexI}; alg::IntervalArithmetic.AbstractIntervalEigenAlg=IntervalArithmetic.IntervalEigen(), permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
     # note: this function does not overwrite `A`
+    true_λ, true_v = _eigen_dispatch(alg, A, permute, scale, sortby)
+    _ensure_ng_flag!(true_v, all(isguaranteed, A))
+    return LinearAlgebra.Eigen(true_λ, true_v)
+end
+
+# IntervalEigen (default): try contraction mapping, fall back to Rohn on failure
+function _eigen_dispatch(::IntervalArithmetic.IntervalEigen, A, permute, scale, sortby)
+    contraction_ok, true_λ, true_v = _eigen_contraction(A, permute, scale, sortby)
+    contraction_ok && return true_λ, true_v
+    return _eigen_eigbox(A, _eigbox_rohn)
+end
+
+# IntervalEigenContraction: contraction mapping only (nai if it fails)
+function _eigen_dispatch(::IntervalArithmetic.IntervalEigenContraction, A, permute, scale, sortby)
+    contraction_ok, true_λ, true_v = _eigen_contraction(A, permute, scale, sortby)
+    contraction_ok && return true_λ, true_v
+    n = LinearAlgebra.checksquare(A)
+    T = eltype(A)
+    return fill(nai(T), n), fill(nai(T), n, n)
+end
+
+# IntervalEigenRohn: Rohn eigenvalue enclosure
+_eigen_dispatch(::IntervalArithmetic.IntervalEigenRohn, A, permute, scale, sortby) = _eigen_eigbox(A, _eigbox_rohn)
+
+# IntervalEigenHertz: Hertz exact hull
+_eigen_dispatch(::IntervalArithmetic.IntervalEigenHertz, A, permute, scale, sortby) = _eigen_eigbox(A, _eigbox_hertz)
+
+# shared: contraction mapping theorem (tight bounds when radii are small and eigenvalues are simple)
+
+function _eigen_contraction(A, permute, scale, sortby)
     λ, v = LinearAlgebra.eigen!(mid.(A); permute, scale, sortby)
     n = length(λ)
     inds = [argmax(i -> abs(v[i,j]), 1:n) for j ∈ 1:n]
@@ -173,14 +210,21 @@ function LinearAlgebra.eigen!(A::AbstractMatrix{<:RealOrComplexI}; permute::Bool
         true_v = interval.(v, r; format = :midpoint)
         _fold_conjugate!(eltype(A), true_λ, true_v)
         foreach(j -> true_v[:,j] .*= interval(ref_scale[j]), 1:n)
+        return true, true_λ, true_v
     else
-        # contraction mapping failed; fall back to eigenvalue enclosure
-        box = _eigbox(A)
-        true_λ = fill(box, n)
-        true_v = fill(nai(eltype(v_bar)), n, n)
+        return false, nothing, nothing
     end
-    _ensure_ng_flag!(true_v, all(isguaranteed, A))
-    return LinearAlgebra.Eigen(true_λ, true_v)
+end
+
+# shared: eigenvalue enclosure via eigbox (returns single enclosing interval for all eigenvalues, nai eigenvectors)
+
+function _eigen_eigbox(A, eigbox_method)
+    n = LinearAlgebra.checksquare(A)
+    box = _eigbox(A, eigbox_method)
+    v_bar = interval(mid.(A))  # just need the element type
+    true_λ = fill(box, n)
+    true_v = fill(nai(eltype(v_bar)), n, n)
+    return true_λ, true_v
 end
 
 _fold_conjugate!(::Type{<:ComplexI}, λ, v) = (λ, v)
@@ -279,32 +323,32 @@ end
 
 # eigenvalue enclosure for general and complex interval matrices (reduced to symmetric case)
 
-function _eigbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}) where {T}
-    return _eigbox_rohn(A)
+function _eigbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}, method=_eigbox_rohn) where {T}
+    return method(A)
 end
 
-function _eigbox(A::AbstractMatrix{Interval{T}}) where {T}
-    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*(A + A'))))
+function _eigbox(A::AbstractMatrix{Interval{T}}, method=_eigbox_rohn) where {T}
+    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*(A + A'))), method)
 
     n = size(A, 1)
     S = 0.5*(A - A')
-    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, [zeros(Interval{T}, n, n) S'; S zeros(Interval{T}, n, n)])))
+    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, [zeros(Interval{T}, n, n) S'; S zeros(Interval{T}, n, n)])), method)
 
     return λ + μ*im
 end
 
-function _eigbox(M::AbstractMatrix{Complex{Interval{T}}}) where {T}
+function _eigbox(M::AbstractMatrix{Complex{Interval{T}}}, method=_eigbox_rohn) where {T}
     A = real.(M)
     B = imag.(M)
-    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[A+A' B'-B; B-B' A+A'])))
-    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[B+B' A-A'; A'-A B+B'])))
+    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[A+A' B'-B; B-B' A+A'])), method)
+    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[B+B' A-A'; A'-A B+B'])), method)
     return λ + μ*im
 end
 
-function _eigbox(M::LinearAlgebra.Hermitian{Complex{Interval{T}}, Matrix{Complex{Interval{T}}}}) where {T}
+function _eigbox(M::LinearAlgebra.Hermitian{Complex{Interval{T}}, Matrix{Complex{Interval{T}}}}, method=_eigbox_rohn) where {T}
     A = real(M)
     B = imag(M)
-    return _eigbox(LinearAlgebra.Symmetric([A B'; B A]))
+    return _eigbox(LinearAlgebra.Symmetric([A B'; B A]), method)
 end
 
 # matrix inversion

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -187,6 +187,12 @@ function _fold_conjugate!(::Type{<:Interval}, λ, v)
 end
 
 # eigenvalue enclosure (eigenbox)
+# The Orthants iterator, eigenbox (Rohn and Hertz methods), and the reduction of
+# general/complex/Hermitian matrices to the symmetric case are derived from
+# IntervalLinearAlgebra.jl (https://github.com/JuliaIntervals/IntervalLinearAlgebra.jl)
+# Copyright (c) 2021 Luca Ferranti, MIT License.
+# See: Hladík, Daney, Tsigaridas, "Bounds on real eigenvalues and singular values
+# of interval matrices", APNUM 2013 (https://doi.org/10.1016/j.apnum.2012.09.003).
 
 struct Orthants
     n::Int

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -62,8 +62,9 @@ end
 
 # matrix eigenvalues
 
-function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby)
+function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby, kwargs...)
     # note: this function does not overwrite `A`
+    # kwargs absorbs e.g. `alg` passed by Symmetric eigvals in Julia ≥ 1.12
     λ = _eigvals(A, permute, scale, sortby)
     isreal(λ) && return real(λ)
     _fold_conjugate!(λ)
@@ -71,7 +72,7 @@ function LinearAlgebra.eigvals!(A::AbstractMatrix{<:Interval}; permute::Bool=tru
     return λ
 end
 
-LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby) =
+LinearAlgebra.eigvals!(A::AbstractMatrix{<:Complex{<:Interval}}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=LinearAlgebra.eigsortby, kwargs...) =
     # note: this function does not overwrite `A`
     _eigvals(A, permute, scale, sortby)
 

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -158,7 +158,9 @@ function LinearAlgebra.eigen!(A::AbstractMatrix{<:RealOrComplexI}; permute::Bool
         _fold_conjugate!(eltype(A), true_λ, true_v)
         foreach(j -> true_v[:,j] .*= interval(ref_scale[j]), 1:n)
     else
-        true_λ = fill(nai(eltype(λ_bar)), n)
+        # contraction mapping failed; fall back to eigenbox for eigenvalue bounds
+        box = IntervalArithmetic.eigenbox(A)
+        true_λ = fill(box, n)
         true_v = fill(nai(eltype(v_bar)), n, n)
     end
     _ensure_ng_flag!(true_v, all(isguaranteed, A))
@@ -183,6 +185,109 @@ function _fold_conjugate!(::Type{<:Interval}, λ, v)
     end
     return λ, v
 end
+
+# eigenvalue enclosure (eigenbox)
+
+struct Orthants
+    n::Int
+end
+
+Base.eltype(::Type{Orthants}) = Vector{Int}
+Base.length(O::Orthants) = 2^(O.n)
+
+function Base.iterate(O::Orthants, state=1)
+    state > 2 ^ O.n && return nothing
+    vec = -2*digits(state-1, base=2, pad=O.n) .+ 1
+    return (vec, state+1)
+end
+
+function Base.getindex(O::Orthants, i::Int)
+    1 <= i <= length(O) || throw(BoundsError(O, i))
+    return -2*digits(i-1, base=2, pad=O.n) .+ 1
+end
+
+Base.firstindex(O::Orthants) = 1
+Base.lastindex(O::Orthants) = length(O)
+
+# rigorous eigmax/eigmin via interval eigvals
+
+function _interval_eigmax(A::LinearAlgebra.Symmetric{<:Real, <:AbstractMatrix{<:Real}})
+    λs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric(interval.(A)))
+    return sup(maximum(real.(λs)))
+end
+
+function _interval_eigmin(A::LinearAlgebra.Symmetric{<:Real, <:AbstractMatrix{<:Real}})
+    λs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric(interval.(A)))
+    return inf(minimum(real.(λs)))
+end
+
+function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}, ::IntervalArithmetic.Rohn) where {T}
+    AΔ = LinearAlgebra.Symmetric(IntervalArithmetic.radius.(A))
+    Ac = LinearAlgebra.Symmetric(mid.(A))
+
+    ρ = _interval_eigmax(AΔ)
+    λmax = _interval_eigmax(Ac)
+    λmin = _interval_eigmin(Ac)
+    return interval(λmin - ρ, λmax + ρ)
+end
+
+function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}, ::IntervalArithmetic.Hertz) where {T}
+    n = LinearAlgebra.checksquare(A)
+    Amax = Matrix{T}(undef, n, n)
+    Amin = Matrix{T}(undef, n, n)
+
+    λmin = T(Inf)
+    λmax = T(-Inf)
+    @inbounds for z in Orthants(n)
+        first(z) < 0 && continue
+        for j in 1:n
+            for i in 1:j
+                if z[i] == z[j]
+                    Amax[i, j] = sup(A[i, j])
+                    Amin[i, j] = inf(A[i, j])
+                else
+                    Amax[i, j] = inf(A[i, j])
+                    Amin[i, j] = sup(A[i, j])
+                end
+            end
+        end
+
+        candmax = _interval_eigmax(LinearAlgebra.Symmetric(Amax))
+        candmin = _interval_eigmin(LinearAlgebra.Symmetric(Amin))
+        λmin = min(λmin, candmin)
+        λmax = max(λmax, candmax)
+    end
+    return interval(λmin, λmax)
+end
+
+function IntervalArithmetic.eigenbox(A::AbstractMatrix{Interval{T}},
+                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
+    λ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*(A + A'))), method)
+
+    n = size(A, 1)
+    S = 0.5*(A - A')
+    μ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, [zeros(Interval{T}, n, n) S'; S zeros(Interval{T}, n, n)])), method)
+
+    return λ + μ*im
+end
+
+function IntervalArithmetic.eigenbox(M::AbstractMatrix{Complex{Interval{T}}},
+                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
+    A = real.(M)
+    B = imag.(M)
+    λ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[A+A' B'-B; B-B' A+A'])), method)
+    μ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[B+B' A-A'; A'-A B+B'])), method)
+    return λ + μ*im
+end
+
+function IntervalArithmetic.eigenbox(M::LinearAlgebra.Hermitian{Complex{Interval{T}}, Matrix{Complex{Interval{T}}}},
+                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
+    A = real(M)
+    B = imag(M)
+    return IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric([A B'; B A]), method)
+end
+
+IntervalArithmetic.eigenbox(A) = IntervalArithmetic.eigenbox(A, IntervalArithmetic.Rohn())
 
 # matrix inversion
 # note: use the contraction mapping theorem, only works when the entries of A have small radii

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -365,6 +365,19 @@ function LinearAlgebra.mul!(C::AbstractMatrix{<:RealOrComplexI}, A::AbstractVecO
     return _mul!(IntervalArithmetic.default_matmul(), C, A, B, α, β)
 end
 
+# disambiguate with LinearAlgebra methods for structured matrices. Needed only for Julia v1.10.
+const _StructuredMatrix = Union{LinearAlgebra.Bidiagonal, LinearAlgebra.Diagonal, LinearAlgebra.SymTridiagonal, LinearAlgebra.Tridiagonal}
+
+function LinearAlgebra.mul!(C::AbstractMatrix{<:RealOrComplexI}, A::AbstractMatrix, B::_StructuredMatrix, α::Number, β::Number)
+    size(A, 2) == size(B, 1) || return throw(DimensionMismatch("The number of columns of A must match the number of rows of B."))
+    return _mul!(IntervalArithmetic.default_matmul(), C, A, B, α, β)
+end
+
+function LinearAlgebra.mul!(C::AbstractMatrix{<:RealOrComplexI}, A::_StructuredMatrix, B::AbstractMatrix, α::Number, β::Number)
+    size(A, 2) == size(B, 1) || return throw(DimensionMismatch("The number of columns of A must match the number of rows of B."))
+    return _mul!(IntervalArithmetic.default_matmul(), C, A, B, α, β)
+end
+
 #
 
 LinearAlgebra.mul!(C::AbstractVecOrMat{<:RealOrComplexI}, A::AbstractMatrix{<:RealOrComplexI}, B::AbstractVecOrMat{<:RealOrComplexI}) =

--- a/ext/IntervalArithmeticLinearAlgebraExt.jl
+++ b/ext/IntervalArithmeticLinearAlgebraExt.jl
@@ -158,8 +158,8 @@ function LinearAlgebra.eigen!(A::AbstractMatrix{<:RealOrComplexI}; permute::Bool
         _fold_conjugate!(eltype(A), true_λ, true_v)
         foreach(j -> true_v[:,j] .*= interval(ref_scale[j]), 1:n)
     else
-        # contraction mapping failed; fall back to eigenbox for eigenvalue bounds
-        box = IntervalArithmetic.eigenbox(A)
+        # contraction mapping failed; fall back to eigenvalue enclosure
+        box = _eigbox(A)
         true_λ = fill(box, n)
         true_v = fill(nai(eltype(v_bar)), n, n)
     end
@@ -186,34 +186,25 @@ function _fold_conjugate!(::Type{<:Interval}, λ, v)
     return λ, v
 end
 
-# eigenvalue enclosure (eigenbox)
-# The Orthants iterator, eigenbox (Rohn and Hertz methods), and the reduction of
+# eigenvalue enclosure for the eigen fallback
+# The Rohn method, Hertz method, Orthants iterator, and the reduction of
 # general/complex/Hermitian matrices to the symmetric case are derived from
 # IntervalLinearAlgebra.jl (https://github.com/JuliaIntervals/IntervalLinearAlgebra.jl)
 # Copyright (c) 2021 Luca Ferranti, MIT License.
 # See: Hladík, Daney, Tsigaridas, "Bounds on real eigenvalues and singular values
 # of interval matrices", APNUM 2013 (https://doi.org/10.1016/j.apnum.2012.09.003).
 
-struct Orthants
+struct _Orthants
     n::Int
 end
 
-Base.eltype(::Type{Orthants}) = Vector{Int}
-Base.length(O::Orthants) = 2^(O.n)
+Base.length(O::_Orthants) = 2^(O.n)
 
-function Base.iterate(O::Orthants, state=1)
+function Base.iterate(O::_Orthants, state=1)
     state > 2 ^ O.n && return nothing
     vec = -2*digits(state-1, base=2, pad=O.n) .+ 1
     return (vec, state+1)
 end
-
-function Base.getindex(O::Orthants, i::Int)
-    1 <= i <= length(O) || throw(BoundsError(O, i))
-    return -2*digits(i-1, base=2, pad=O.n) .+ 1
-end
-
-Base.firstindex(O::Orthants) = 1
-Base.lastindex(O::Orthants) = length(O)
 
 # rigorous eigmax/eigmin via interval eigvals
 
@@ -227,7 +218,9 @@ function _interval_eigmin(A::LinearAlgebra.Symmetric{<:Real, <:AbstractMatrix{<:
     return inf(minimum(real.(λs)))
 end
 
-function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}, ::IntervalArithmetic.Rohn) where {T}
+# Rohn: fast eigenvalue enclosure for symmetric interval matrices
+
+function _eigbox_rohn(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}) where {T}
     AΔ = LinearAlgebra.Symmetric(IntervalArithmetic.radius.(A))
     Ac = LinearAlgebra.Symmetric(mid.(A))
 
@@ -237,14 +230,16 @@ function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Mat
     return interval(λmin - ρ, λmax + ρ)
 end
 
-function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}, ::IntervalArithmetic.Hertz) where {T}
+# Hertz: exact hull for symmetric interval matrices (exponential complexity)
+
+function _eigbox_hertz(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}) where {T}
     n = LinearAlgebra.checksquare(A)
     Amax = Matrix{T}(undef, n, n)
     Amin = Matrix{T}(undef, n, n)
 
     λmin = T(Inf)
     λmax = T(-Inf)
-    @inbounds for z in Orthants(n)
+    @inbounds for z in _Orthants(n)
         first(z) < 0 && continue
         for j in 1:n
             for i in 1:j
@@ -266,34 +261,35 @@ function IntervalArithmetic.eigenbox(A::LinearAlgebra.Symmetric{Interval{T}, Mat
     return interval(λmin, λmax)
 end
 
-function IntervalArithmetic.eigenbox(A::AbstractMatrix{Interval{T}},
-                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
-    λ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*(A + A'))), method)
+# eigenvalue enclosure for general and complex interval matrices (reduced to symmetric case)
+
+function _eigbox(A::LinearAlgebra.Symmetric{Interval{T}, Matrix{Interval{T}}}) where {T}
+    return _eigbox_rohn(A)
+end
+
+function _eigbox(A::AbstractMatrix{Interval{T}}) where {T}
+    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*(A + A'))))
 
     n = size(A, 1)
     S = 0.5*(A - A')
-    μ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, [zeros(Interval{T}, n, n) S'; S zeros(Interval{T}, n, n)])), method)
+    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, [zeros(Interval{T}, n, n) S'; S zeros(Interval{T}, n, n)])))
 
     return λ + μ*im
 end
 
-function IntervalArithmetic.eigenbox(M::AbstractMatrix{Complex{Interval{T}}},
-                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
+function _eigbox(M::AbstractMatrix{Complex{Interval{T}}}) where {T}
     A = real.(M)
     B = imag.(M)
-    λ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[A+A' B'-B; B-B' A+A'])), method)
-    μ = IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[B+B' A-A'; A'-A B+B'])), method)
+    λ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[A+A' B'-B; B-B' A+A'])))
+    μ = _eigbox(LinearAlgebra.Symmetric(interval.(T, 0.5*[B+B' A-A'; A'-A B+B'])))
     return λ + μ*im
 end
 
-function IntervalArithmetic.eigenbox(M::LinearAlgebra.Hermitian{Complex{Interval{T}}, Matrix{Complex{Interval{T}}}},
-                  method::IntervalArithmetic.AbstractIntervalEigenSolver) where {T}
+function _eigbox(M::LinearAlgebra.Hermitian{Complex{Interval{T}}, Matrix{Complex{Interval{T}}}}) where {T}
     A = real(M)
     B = imag(M)
-    return IntervalArithmetic.eigenbox(LinearAlgebra.Symmetric([A B'; B A]), method)
+    return _eigbox(LinearAlgebra.Symmetric([A B'; B A]))
 end
-
-IntervalArithmetic.eigenbox(A) = IntervalArithmetic.eigenbox(A, IntervalArithmetic.Rohn())
 
 # matrix inversion
 # note: use the contraction mapping theorem, only works when the entries of A have small radii

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -238,15 +238,4 @@ bareinterval(::Type{BigFloat}, a::AbstractIrrational) = _unsafe_bareinterval(Big
     return :($x) # set body of the function to return the precomputed result
 end
 
-# eigenvalue enclosure types and functions (implementations in LinearAlgebra extension)
-
-abstract type AbstractIntervalEigenSolver end
-
-struct Rohn <: AbstractIntervalEigenSolver end
-struct Hertz <: AbstractIntervalEigenSolver end
-
-function eigenbox end
-
-    export eigenbox, AbstractIntervalEigenSolver, Rohn, Hertz
-
 end

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -137,8 +137,8 @@ struct IntervalEigen <: AbstractIntervalEigenAlg end
 """
     IntervalEigenContraction
 
-Eigendecomposition via the contraction mapping theorem only. Returns `nai` if the
-contraction fails (e.g. when interval radii are too large).
+Eigendecomposition via the contraction mapping theorem only. Returns [`nai`](@ref)
+if the contraction fails (e.g. when interval radii are too large).
 """
 struct IntervalEigenContraction <: AbstractIntervalEigenAlg end
 
@@ -146,7 +146,7 @@ struct IntervalEigenContraction <: AbstractIntervalEigenAlg end
     IntervalEigenRohn
 
 Rohn eigenvalue enclosure (fast, O(n³)). Returns a single interval enclosing all
-eigenvalues and `nai` eigenvectors. Valid for any interval radius.
+eigenvalues and [`nai`](@ref) eigenvectors. Valid for any interval radius.
 """
 struct IntervalEigenRohn <: AbstractIntervalEigenAlg end
 
@@ -154,7 +154,7 @@ struct IntervalEigenRohn <: AbstractIntervalEigenAlg end
     IntervalEigenHertz
 
 Hertz exact hull of eigenvalues (exponential O(2ⁿ) complexity). Returns a single
-interval enclosing all eigenvalues and `nai` eigenvectors.
+interval enclosing all eigenvalues and [`nai`](@ref) eigenvectors.
 """
 struct IntervalEigenHertz <: AbstractIntervalEigenAlg end
 

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -113,7 +113,52 @@ function configure_power(power::Symbol)
     return power
 end
 
-# algorithms are defined in the package extension for LinearAlgebra
+# eigendecomposition algorithm types
+
+"""
+    AbstractIntervalEigenAlg
+
+Abstract supertype for interval eigendecomposition algorithms.
+
+See also: [`IntervalEigen`](@ref), [`IntervalEigenContraction`](@ref),
+[`IntervalEigenRohn`](@ref), [`IntervalEigenHertz`](@ref).
+"""
+abstract type AbstractIntervalEigenAlg end
+
+"""
+    IntervalEigen
+
+Default eigendecomposition algorithm for interval matrices. Tries the contraction
+mapping theorem first (tight bounds when radii are small and eigenvalues are simple),
+and falls back to the Rohn eigenvalue enclosure if it fails.
+"""
+struct IntervalEigen <: AbstractIntervalEigenAlg end
+
+"""
+    IntervalEigenContraction
+
+Eigendecomposition via the contraction mapping theorem only. Returns `nai` if the
+contraction fails (e.g. when interval radii are too large).
+"""
+struct IntervalEigenContraction <: AbstractIntervalEigenAlg end
+
+"""
+    IntervalEigenRohn
+
+Rohn eigenvalue enclosure (fast, O(n³)). Returns a single interval enclosing all
+eigenvalues and `nai` eigenvectors. Valid for any interval radius.
+"""
+struct IntervalEigenRohn <: AbstractIntervalEigenAlg end
+
+"""
+    IntervalEigenHertz
+
+Hertz exact hull of eigenvalues (exponential O(2ⁿ) complexity). Returns a single
+interval enclosing all eigenvalues and `nai` eigenvectors.
+"""
+struct IntervalEigenHertz <: AbstractIntervalEigenAlg end
+
+export AbstractIntervalEigenAlg, IntervalEigen, IntervalEigenContraction, IntervalEigenRohn, IntervalEigenHertz
 
 """
     MatMulMode{T}

--- a/src/IntervalArithmetic.jl
+++ b/src/IntervalArithmetic.jl
@@ -238,4 +238,15 @@ bareinterval(::Type{BigFloat}, a::AbstractIrrational) = _unsafe_bareinterval(Big
     return :($x) # set body of the function to return the precomputed result
 end
 
+# eigenvalue enclosure types and functions (implementations in LinearAlgebra extension)
+
+abstract type AbstractIntervalEigenSolver end
+
+struct Rohn <: AbstractIntervalEigenSolver end
+struct Hertz <: AbstractIntervalEigenSolver end
+
+function eigenbox end
+
+    export eigenbox, AbstractIntervalEigenSolver, Rohn, Hertz
+
 end

--- a/test/interval_tests/linearalgebra.jl
+++ b/test/interval_tests/linearalgebra.jl
@@ -8,70 +8,47 @@ import LinearAlgebra
     @test all(isnai, inv(B))
 end
 
-@testset "Eigenbox" begin
-    # Rohn: symmetric matrix with zero radius
-    A0 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0]))
+@testset "Eigendecomposition" begin
     exact_eigs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric([1.0 0.5; 0.5 2.0]))
-    box0 = eigenbox(A0)
-    @test in_interval(exact_eigs[1], box0)
-    @test in_interval(exact_eigs[2], box0)
 
-    # Rohn: symmetric matrix with nonzero radius
-    A1 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0], 0.1; format = :midpoint))
-    box1 = eigenbox(A1)
-    @test in_interval(exact_eigs[1], box1)
-    @test in_interval(exact_eigs[2], box1)
-
-    # Hertz gives tighter bounds than Rohn
-    box1h = eigenbox(A1, Hertz())
-    @test in_interval(exact_eigs[1], box1h)
-    @test in_interval(exact_eigs[2], box1h)
-    @test inf(box1) ≤ inf(box1h)
-    @test sup(box1h) ≤ sup(box1)
-
-    # wider intervals
-    A2 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0], 0.3; format = :midpoint))
-    box2 = eigenbox(A2)
-    box2h = eigenbox(A2, Hertz())
-    @test in_interval(exact_eigs[1], box2)
-    @test in_interval(exact_eigs[2], box2)
-    @test inf(box2) ≤ inf(box2h)
-    @test sup(box2h) ≤ sup(box2)
-
-    # general (non-symmetric) matrix
-    M = [0.0 -1.0; 2.0 -0.5]
-    A3 = interval.(M, 0.5; format = :midpoint)
-    box3 = eigenbox(A3)
-    mid_eigs = LinearAlgebra.eigvals(M)
-    for λ in mid_eigs
-        @test in_interval(real(λ), real(box3))
-        @test in_interval(imag(λ), imag(box3))
-    end
-
-    # 3×3 symmetric
-    S3 = LinearAlgebra.Symmetric(interval.([2.0 1.0 0.0; 1.0 3.0 1.0; 0.0 1.0 4.0], 0.1; format = :midpoint))
-    exact3 = LinearAlgebra.eigvals(LinearAlgebra.Symmetric(mid.(S3)))
-    box3s = eigenbox(S3)
-    for λ in exact3
-        @test in_interval(λ, box3s)
-    end
-end
-
-@testset "Eigen fallback to eigenbox" begin
     # small radius: contraction mapping succeeds, tight individual bounds
     A_small = interval.([1.0 0.5; 0.5 2.0])
     r_small = LinearAlgebra.eigen(A_small)
-    exact_eigs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric([1.0 0.5; 0.5 2.0]))
     @test in_interval(exact_eigs[1], real(r_small.values[1]))
     @test in_interval(exact_eigs[2], real(r_small.values[2]))
     @test !any(isnai, r_small.vectors)
 
-    # large radius: contraction mapping fails, eigenbox fallback
+    # moderate radius: contraction mapping may fail, fallback provides valid enclosure
+    A_mid = interval.([1.0 0.5; 0.5 2.0], 0.3; format = :midpoint)
+    r_mid = LinearAlgebra.eigen(A_mid)
+    @test in_interval(exact_eigs[1], real(r_mid.values[1]))
+    @test in_interval(exact_eigs[2], real(r_mid.values[2]))
+
+    # large radius: contraction mapping fails, eigenvalue enclosure fallback
     A_large = interval.([1.0 0.5; 0.5 2.0], 1.0; format = :midpoint)
     r_large = LinearAlgebra.eigen(A_large)
     @test in_interval(exact_eigs[1], real(r_large.values[1]))
     @test in_interval(exact_eigs[2], real(r_large.values[2]))
     @test all(isnai, r_large.vectors)
+
+    # general (non-symmetric) matrix with large radius
+    M = [0.0 -1.0; 2.0 -0.5]
+    mid_eigs = LinearAlgebra.eigvals(M)
+    A_gen = interval.(M, 0.5; format = :midpoint)
+    r_gen = LinearAlgebra.eigen(A_gen)
+    for λ in mid_eigs
+        @test in_interval(real(λ), real(r_gen.values[1]))
+        @test in_interval(imag(λ), imag(r_gen.values[1]))
+    end
+
+    # 3×3 symmetric with large radius
+    S3_mid = [2.0 1.0 0.0; 1.0 3.0 1.0; 0.0 1.0 4.0]
+    exact3 = LinearAlgebra.eigvals(LinearAlgebra.Symmetric(S3_mid))
+    A3 = interval.(S3_mid, 0.5; format = :midpoint)
+    r3 = LinearAlgebra.eigen(A3)
+    for λ in exact3
+        @test in_interval(λ, real(r3.values[1]))
+    end
 end
 
 @testset "Matrix multiplication" begin

--- a/test/interval_tests/linearalgebra.jl
+++ b/test/interval_tests/linearalgebra.jl
@@ -8,6 +8,72 @@ import LinearAlgebra
     @test all(isnai, inv(B))
 end
 
+@testset "Eigenbox" begin
+    # Rohn: symmetric matrix with zero radius
+    A0 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0]))
+    exact_eigs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric([1.0 0.5; 0.5 2.0]))
+    box0 = eigenbox(A0)
+    @test in_interval(exact_eigs[1], box0)
+    @test in_interval(exact_eigs[2], box0)
+
+    # Rohn: symmetric matrix with nonzero radius
+    A1 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0], 0.1; format = :midpoint))
+    box1 = eigenbox(A1)
+    @test in_interval(exact_eigs[1], box1)
+    @test in_interval(exact_eigs[2], box1)
+
+    # Hertz gives tighter bounds than Rohn
+    box1h = eigenbox(A1, Hertz())
+    @test in_interval(exact_eigs[1], box1h)
+    @test in_interval(exact_eigs[2], box1h)
+    @test inf(box1) ≤ inf(box1h)
+    @test sup(box1h) ≤ sup(box1)
+
+    # wider intervals
+    A2 = LinearAlgebra.Symmetric(interval.([1.0 0.5; 0.5 2.0], 0.3; format = :midpoint))
+    box2 = eigenbox(A2)
+    box2h = eigenbox(A2, Hertz())
+    @test in_interval(exact_eigs[1], box2)
+    @test in_interval(exact_eigs[2], box2)
+    @test inf(box2) ≤ inf(box2h)
+    @test sup(box2h) ≤ sup(box2)
+
+    # general (non-symmetric) matrix
+    M = [0.0 -1.0; 2.0 -0.5]
+    A3 = interval.(M, 0.5; format = :midpoint)
+    box3 = eigenbox(A3)
+    mid_eigs = LinearAlgebra.eigvals(M)
+    for λ in mid_eigs
+        @test in_interval(real(λ), real(box3))
+        @test in_interval(imag(λ), imag(box3))
+    end
+
+    # 3×3 symmetric
+    S3 = LinearAlgebra.Symmetric(interval.([2.0 1.0 0.0; 1.0 3.0 1.0; 0.0 1.0 4.0], 0.1; format = :midpoint))
+    exact3 = LinearAlgebra.eigvals(LinearAlgebra.Symmetric(mid.(S3)))
+    box3s = eigenbox(S3)
+    for λ in exact3
+        @test in_interval(λ, box3s)
+    end
+end
+
+@testset "Eigen fallback to eigenbox" begin
+    # small radius: contraction mapping succeeds, tight individual bounds
+    A_small = interval.([1.0 0.5; 0.5 2.0])
+    r_small = LinearAlgebra.eigen(A_small)
+    exact_eigs = LinearAlgebra.eigvals(LinearAlgebra.Symmetric([1.0 0.5; 0.5 2.0]))
+    @test in_interval(exact_eigs[1], real(r_small.values[1]))
+    @test in_interval(exact_eigs[2], real(r_small.values[2]))
+    @test !any(isnai, r_small.vectors)
+
+    # large radius: contraction mapping fails, eigenbox fallback
+    A_large = interval.([1.0 0.5; 0.5 2.0], 1.0; format = :midpoint)
+    r_large = LinearAlgebra.eigen(A_large)
+    @test in_interval(exact_eigs[1], real(r_large.values[1]))
+    @test in_interval(exact_eigs[2], real(r_large.values[2]))
+    @test all(isnai, r_large.vectors)
+end
+
 @testset "Matrix multiplication" begin
     IntervalArithmetic.configure(; matmul = :fast)
     A = [interval(2, 4) interval(-2, 1) ; interval(-1, 2) interval(2, 4)]

--- a/test/interval_tests/linearalgebra.jl
+++ b/test/interval_tests/linearalgebra.jl
@@ -49,6 +49,29 @@ end
     for λ in exact3
         @test in_interval(λ, real(r3.values[1]))
     end
+
+    # explicit algorithm selection: IntervalEigenContraction on small-radius matrix
+    r_contraction = LinearAlgebra.eigen(A_small; alg = IntervalEigenContraction())
+    @test in_interval(exact_eigs[1], real(r_contraction.values[1]))
+    @test in_interval(exact_eigs[2], real(r_contraction.values[2]))
+    @test !any(isnai, r_contraction.vectors)
+
+    # explicit algorithm selection: IntervalEigenContraction on large-radius matrix → nai
+    r_contraction_large = LinearAlgebra.eigen(A_large; alg = IntervalEigenContraction())
+    @test all(isnai, r_contraction_large.values)
+    @test all(isnai, r_contraction_large.vectors)
+
+    # explicit algorithm selection: IntervalEigenRohn
+    r_rohn = LinearAlgebra.eigen(A_large; alg = IntervalEigenRohn())
+    @test in_interval(exact_eigs[1], real(r_rohn.values[1]))
+    @test in_interval(exact_eigs[2], real(r_rohn.values[2]))
+    @test all(isnai, r_rohn.vectors)
+
+    # explicit algorithm selection: IntervalEigenHertz
+    r_hertz = LinearAlgebra.eigen(A_large; alg = IntervalEigenHertz())
+    @test in_interval(exact_eigs[1], real(r_hertz.values[1]))
+    @test in_interval(exact_eigs[2], real(r_hertz.values[2]))
+    @test all(isnai, r_hertz.vectors)
 end
 
 @testset "Matrix multiplication" begin


### PR DESCRIPTION
As discussed during the meeting, the current implementation in the LinearAlgebra extension is incorrect for large intervals while the implementation in IntervalLinearAlgebra works for large interval but is its computation of `eigvals` for the matrix of centers and radius is just using floating point computation. By combining both, we have a fully rigorous eigen function for matrices of intervals.

This was done by Claude Code, still need to read it carefully

- [x] Not sure why Claude named it eigenbox, should be renamed to eigen
- [x] Add tests
- [x] Allow the user to choose it with `alg`