### PR TITLE
fix: Handle empty and unbounded intervals in `mince`

### DIFF
--- a/src/intervals/interval_operations/bisect.jl
+++ b/src/intervals/interval_operations/bisect.jl
@@ -32,7 +32,8 @@ end
 """
     mince(x, n)
 
-Split an interval `x` in `n` intervals of the same diameter.
+Split an interval `x` in `n` intervals of the same diameter. An unbounded `x`
+has no such splitting and is rejected; use [`bisect`](@ref) instead.
 
 Split the `i`-th component of a vector `x` in `n[i]` intervals of the
 same diameter; `n` can be a tuple of integers, or a single integer in which case
@@ -46,12 +47,24 @@ mince(x::AbstractVector, n::NTuple{N,Integer}) where {N} = mince!(Vector{typeof(
 
 mince(x::AbstractVector, n::Integer) = mince(x, ntuple(_ -> n, length(x)))
 
+# an infinite diameter cannot be divided in equal parts: interpolating between
+# infinite bounds yields nodes that are not a number
+_check_minceable(x) = isbounded(x) ||
+    throw(DomainError(x, "cannot split an unbounded interval in intervals of the same diameter; see instead `bisect`"))
+
 """
     mince!(v, x, n)
 
 In-place version of [`mince`](@ref).
 """
 function mince!(v::AbstractVector{<:BareInterval}, x::BareInterval{T}, n::Integer) where {T<:NumTypes}
+    if isempty_interval(x) # an empty interval has no nodes to interpolate
+        for i ∈ 1:n
+            v[i] = emptyinterval(x)
+        end
+        return v
+    end
+    _check_minceable(x)
     nodes = LinRange(inf(x), sup(x), n+1)
     @inbounds for i ∈ 1:n
         v[i] = _unsafe_bareinterval(T, nodes[i], nodes[i+1])
@@ -60,6 +73,14 @@ function mince!(v::AbstractVector{<:BareInterval}, x::BareInterval{T}, n::Intege
 end
 
 function mince!(v::AbstractVector{<:Interval}, x::Interval{T}, n::Integer) where {T<:NumTypes}
+    if isnai(x) | isempty_interval(x) # neither has nodes to interpolate
+        y = isnai(x) ? nai(x) : emptyinterval(x)
+        for i ∈ 1:n
+            v[i] = y
+        end
+        return v
+    end
+    _check_minceable(x)
     nodes = LinRange(inf(x), sup(x), n+1)
     d = decoration(x)
     t = isguaranteed(x)

--- a/test/interval_tests/numeric.jl
+++ b/test/interval_tests/numeric.jl
@@ -324,6 +324,27 @@ end
     v = mince(II, 8)
     @test length(v) == 8
     @test isequal_interval(hull(v...), II)
+
+    # an empty interval and an NaI have no nodes to interpolate
+    @test all(isempty_interval, mince(emptyinterval(BareInterval{Float64}), 3))
+    @test all(isempty_interval, mince(emptyinterval(), 3))
+    @test all(isnai, mince(nai(Float64), 3))
+
+    # an infinite diameter cannot be divided in equal parts
+    @test_throws "cannot split an unbounded interval" mince(entireinterval(), 2)
+    @test_throws "cannot split an unbounded interval" mince(interval(0, Inf), 2)
+    @test_throws "cannot split an unbounded interval" mince(entireinterval(BareInterval{Float64}), 2)
+    @test_throws "cannot split an unbounded interval" mince([interval(0, 1), entireinterval()], 2)
+
+    # every piece is a valid interval and together they cover the input
+    for x ∈ (interval(-1, 1), interval(0, 1e300), interval(-1e300, 1e300), interval(3, 3))
+        for n ∈ (1, 2, 3, 7)
+            v = mince(x, n)
+            @test length(v) == n
+            @test isequal_interval(reduce(hull, v), x)
+            @test all(z -> !isnan(inf(z)) & !isnan(sup(z)), v)
+        end
+    end
 end
 
 @testset "rootn test" begin


### PR DESCRIPTION
The nodes of `mince` are interpolated between the bounds of the interval, which is not possible for a degenerate one: `LinRange` between infinite endpoints yields `NaN`. An empty interval and an NaI now produce `n` copies of themselves, while an unbounded interval is rejected, `bisect` being the operation that splits one.

Splitting an unbounded interval used to return pieces that do not cover it, e.g. `mince(interval(0, Inf), 2)` gave two copies of `[Inf, Inf]`.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>

This PR is ground-work for the empty interval representation proposed in https://github.com/JuliaIntervals/IntervalArithmetic.jl/issues/585#issuecomment-5102354395; I ran a "soundness check" for operations that could produce `NaN`, and this is the one thing that popped up. **Note**: it is a behavior change since it now throws for unbounded intervals.