### PR TITLE
fix: Correctness fixes in interval_operations

### DIFF
--- a/src/intervals/interval_operations/bisect.jl
+++ b/src/intervals/interval_operations/bisect.jl
@@ -58,6 +58,7 @@ _check_minceable(x) = isbounded(x) ||
 In-place version of [`mince`](@ref).
 """
 function mince!(v::AbstractVector{<:BareInterval}, x::BareInterval{T}, n::Integer) where {T<:NumTypes}
+    resize!(v, n)
     if isempty_interval(x) # an empty interval has no nodes to interpolate
         for i ∈ 1:n
             v[i] = emptyinterval(x)
@@ -66,13 +67,18 @@ function mince!(v::AbstractVector{<:BareInterval}, x::BareInterval{T}, n::Intege
     end
     _check_minceable(x)
     nodes = LinRange(inf(x), sup(x), n+1)
+    lo = inf(x)
     @inbounds for i ∈ 1:n
-        v[i] = _unsafe_bareinterval(T, nodes[i], nodes[i+1])
+        # `LinRange` may interpolate non-monotonically, clamp the nodes to keep every piece valid
+        hi = i == n ? sup(x) : min(max(nodes[i+1], lo), sup(x))
+        v[i] = _unsafe_bareinterval(T, lo, hi)
+        lo = hi
     end
     return v
 end
 
 function mince!(v::AbstractVector{<:Interval}, x::Interval{T}, n::Integer) where {T<:NumTypes}
+    resize!(v, n)
     if isnai(x) | isempty_interval(x) # neither has nodes to interpolate
         y = isnai(x) ? nai(x) : emptyinterval(x)
         for i ∈ 1:n
@@ -84,10 +90,14 @@ function mince!(v::AbstractVector{<:Interval}, x::Interval{T}, n::Integer) where
     nodes = LinRange(inf(x), sup(x), n+1)
     d = decoration(x)
     t = isguaranteed(x)
+    lo = inf(x)
     @inbounds for i ∈ 1:n
-        rᵢ = _unsafe_bareinterval(T, nodes[i], nodes[i+1])
+        # `LinRange` may interpolate non-monotonically, clamp the nodes to keep every piece valid
+        hi = i == n ? sup(x) : min(max(nodes[i+1], lo), sup(x))
+        rᵢ = _unsafe_bareinterval(T, lo, hi)
         dᵢ = min(d, decoration(rᵢ))
         v[i] = _unsafe_interval(rᵢ, dᵢ, t)
+        lo = hi
     end
     return v
 end

--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -164,8 +164,7 @@ _isdisjoint_interval(x, y, z, w...) = _isdisjoint_interval(x, y) && _isdisjoint_
 """
     isweakless(x, y)
 
-Test whether `inf(x) ≤ inf(y)` and `sup(x) ≤ sup(y)`, where `<` is replaced by
-`≤` for infinite values.
+Test whether `inf(x) ≤ inf(y)` and `sup(x) ≤ sup(y)`.
 
 Implement the `less` function of the IEEE Standard 1788-2015
 (Table 10.3, and Sections 10.5.10 and 12.12.9).
@@ -197,7 +196,7 @@ end
 """
     precedes(x, y)
 
-Test whether any element of `x` is lesser or equal to every elements of `y`.
+Test whether every element of `x` is lesser or equal to every element of `y`.
 
 Implement the `precedes` function of the IEEE Standard 1788-2015
 (Table 10.3, and Sections 10.5.10 and 12.12.9).
@@ -212,7 +211,7 @@ end
 """
     strictprecedes(x, y)
 
-Test whether any element of `x` is strictly lesser than every elements of `y`.
+Test whether every element of `x` is strictly lesser than every element of `y`.
 
 Implement the `strictPrecedes` function of the IEEE Standard 1788-2015
 (Table 10.3, and Sections 10.5.10 and 12.12.9).

--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -88,10 +88,9 @@ See also: [`issubset_interval`](@ref) and [`isinterior`](@ref).
 isstrictsubset(x::BareInterval, y::BareInterval) = issubset_interval(x, y) & !isequal_interval(x, y)
 
 isstrictsubset(x::Interval, y::Interval) = issubset_interval(x, y) & !isequal_interval(x, y)
-isstrictsubset(x::Complex{<:Interval}, y::Complex{<:Interval}) =
-    (isstrictsubset(real(x), real(y)) & issubset_interval(imag(x), imag(y))) | (issubset_interval(real(x), real(y)) & isstrictsubset(imag(x), imag(y)))
-isstrictsubset(x::Complex{<:Interval}, y::Interval) = isstrictsubset(real(x), y) & isthinzero(imag(x))
-isstrictsubset(x::Interval, y::Complex{<:Interval}) = isstrictsubset(x, real(y)) & in_interval(0, imag(y))
+isstrictsubset(x::Complex{<:Interval}, y::Complex{<:Interval}) = issubset_interval(x, y) & !isequal_interval(x, y)
+isstrictsubset(x::Complex{<:Interval}, y::Interval) = issubset_interval(x, y) & !isequal_interval(x, y)
+isstrictsubset(x::Interval, y::Complex{<:Interval}) = issubset_interval(x, y) & !isequal_interval(x, y)
 
 isstrictsubset(x::AbstractVector, y::AbstractVector) = issubset_interval(x, y) & any(t -> isstrictsubset(t[1], t[2]), zip(x, y))
 

--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -144,8 +144,14 @@ function isdisjoint_interval(x::Interval, y::Interval)
     return isdisjoint_interval(bareinterval(x), bareinterval(y))
 end
 isdisjoint_interval(x::Complex{<:Interval}, y::Complex{<:Interval}) = isdisjoint_interval(real(x), real(y)) | isdisjoint_interval(imag(x), imag(y))
-isdisjoint_interval(x::Complex{<:Interval}, y::Interval) = isdisjoint_interval(real(x), y) | !in_interval(0, imag(x))
-isdisjoint_interval(x::Interval, y::Complex{<:Interval}) = isdisjoint_interval(x, real(y)) | !in_interval(0, imag(y))
+function isdisjoint_interval(x::Complex{<:Interval}, y::Interval)
+    isnai(x) | isnai(y) && return false
+    return isdisjoint_interval(real(x), y) | !in_interval(0, imag(x))
+end
+function isdisjoint_interval(x::Interval, y::Complex{<:Interval})
+    isnai(x) | isnai(y) && return false
+    return isdisjoint_interval(x, real(y)) | !in_interval(0, imag(y))
+end
 
 function isdisjoint_interval(x::AbstractVector, y::AbstractVector)
     n = length(x)

--- a/src/intervals/interval_operations/boolean.jl
+++ b/src/intervals/interval_operations/boolean.jl
@@ -295,7 +295,7 @@ Implement the `isNaI` function of the IEEE Standard 1788-2015 (Section 12.12.9).
 isnai(::BareInterval) = false
 
 isnai(x::Interval) = decoration(x) == ill
-isnai(x::Complex{<:Interval}) = isnai(real(x)) & isnai(imag(x))
+isnai(x::Complex{<:Interval}) = isnai(real(x)) | isnai(imag(x))
 
 """
     isbounded(x)

--- a/src/intervals/interval_operations/cancellative.jl
+++ b/src/intervals/interval_operations/cancellative.jl
@@ -32,17 +32,21 @@ function cancelminus(x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes}
     z = _unsafe_bareinterval(T, z_lo, z_hi)
     isunbounded(z) && return z
 
-    # corner case 1 (page 62) involving finite precision for diam(x) and diam(y)
-    w_lo, w_hi = bounds(@round(T, inf(y) + z_lo, sup(y) + z_hi))
-    (diam(x) == diam(y)) & ((prevfloat(inf(x)) > w_lo) | (nextfloat(sup(x)) < w_hi)) && return entireinterval(BareInterval{T})
+    if T <: AbstractFloat # rational arithmetic is exact, so corner case 1 cannot occur
+        # corner case 1 (page 62) involving finite precision for diam(x) and diam(y)
+        w_lo, w_hi = bounds(@round(T, inf(y) + z_lo, sup(y) + z_hi))
+        (diam(x) == diam(y)) & ((prevfloat(inf(x)) > w_lo) | (nextfloat(sup(x)) < w_hi)) && return entireinterval(BareInterval{T})
+    end
 
     return z
 end
 cancelminus(x::BareInterval, y::BareInterval) = cancelminus(promote(x, y)...)
 
 function cancelminus(x::Interval, y::Interval; dec = :default)
-    r = cancelminus(bareinterval(x), bareinterval(y))
-    d = min(decoration(x), decoration(y), decoration(r))
+    d = min(decoration(x), decoration(y))
+    d == ill && return nai(promote_type(numtype(x), numtype(y))) # one of the inputs is an NaI
+    r = cancelminus(_bareinterval(x), _bareinterval(y))
+    d = min(d, decoration(r))
     t = isguaranteed(x) & isguaranteed(y)
     return _set_decoration(_unsafe_interval(r, d, t), dec)
 end

--- a/src/intervals/interval_operations/cancellative.jl
+++ b/src/intervals/interval_operations/cancellative.jl
@@ -7,11 +7,11 @@
 
 Compute the unique interval `z` such that `y + z == x`.
 
-The keywork `dec` argument controls the decoration of the result. It can be
+The keyword `dec` argument controls the decoration of the result. It can be
 either a specific decoration, or one of two following options:
     - `:default`: if at least one of the input intervals is `ill`,
         then the result is `ill`, otherwise it is `trv` (Section 11.7.1).
-    - `:auto`: the ouptut has the minimal decoration of the inputs.
+    - `:auto`: the output has the minimal decoration of the inputs.
 
 Implement the `cancelMinus` function of the IEEE Standard 1788-2015 (Section 9.2).
 """
@@ -50,14 +50,14 @@ end
 """
     cancelplus(x, y; dec = :default)
 
-Compute the unique interval `z` such that `y - z == x`; this is semantically
+Compute the unique interval `z` such that `z - y == x`; this is semantically
 equivalent to `cancelminus(x, -y)`.
 
-The keywork `dec` argument controls the decoration of the result. It can be
+The keyword `dec` argument controls the decoration of the result. It can be
 either a specific decoration, or one of two following options:
     - `:default`: if at least one of the input intervals is `ill`,
         then the result is `ill`, otherwise it is `trv` (Section 11.7.1).
-    - `:auto`: the ouptut has the minimal decoration of the inputs.
+    - `:auto`: the output has the minimal decoration of the inputs.
 
 Implement the `cancelPlus` function of the IEEE Standard 1788-2015 (Section 9.2).
 """

--- a/src/intervals/interval_operations/constants.jl
+++ b/src/intervals/interval_operations/constants.jl
@@ -5,7 +5,7 @@
     emptyinterval(T=[default_numtype()])
 
 Create an empty interval. This interval is an exception to the fact that the
-lower bound is larger than the upper one.
+lower bound is smaller than or equal to the upper one.
 
 Implement the `empty` function of the IEEE Standard 1788-2015 (Section 10.5.2).
 """

--- a/src/intervals/interval_operations/extended_div.jl
+++ b/src/intervals/interval_operations/extended_div.jl
@@ -23,6 +23,8 @@ function extended_div(x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes
     end
 end
 
+extended_div(x::BareInterval, y::BareInterval) = extended_div(promote(x, y)...)
+
 function extended_div(x::Interval, y::Interval)
     bx = bareinterval(x)
     by = bareinterval(y)

--- a/src/intervals/interval_operations/extended_div.jl
+++ b/src/intervals/interval_operations/extended_div.jl
@@ -7,6 +7,8 @@
 Two-output division.
 
 Implement the `mulRevToPair` function of the IEEE Standard 1788-2015 (Section 10.5.5).
+`extended_div(x, y)` corresponds to `mulRevToPair(y, x)` of the standard (the
+numerator comes first).
 """
 function extended_div(x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes}
     ylo, yhi = bounds(y)

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -215,7 +215,7 @@ See also: [`inf`](@ref), [`sup`](@ref), [`bounds`](@ref), [`mid`](@ref),
 """
 function midradius(x::BareInterval)
     m = mid(x)
-    return m, max(m - inf(x), sup(x) - m)
+    return m, max(_fround(-, m, inf(x), RoundUp), _fround(-, sup(x), m, RoundUp)) # cf. Section 12.12.8
 end
 function midradius(x::BareInterval{<:Rational}) # needed to avoid integer overflow error
     m = mid(x)

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -83,7 +83,10 @@ bounds(x::Real) = bounds(interval(x))
 
 Relative midpoint of `x`, for `α` between 0 and 1 such that `mid(x, 0)` is the
 lower bound of the interval, `mid(x, 1)` its upper bound, and `mid(x, 0.5)` its
-midpoint.
+midpoint. For an unbounded interval, the finite bound is returned whenever `α`
+selects its side, and the infinite bound is replaced by the largest finite
+value of the bound type otherwise (cf. Section 12.12.8 of the IEEE Standard
+1788-2015).
 
 Implement the `mid` function of the IEEE Standard 1788-2015 (Table 9.2).
 
@@ -99,8 +102,14 @@ function mid(x::BareInterval{T}, α = 0.5) where {T<:AbstractFloat}
         return nextfloat(typemin(T))
     else
         lo, hi = bounds(x)
-        lo == typemin(T) && return nextfloat(lo) # cf. Section 12.12.8
-        hi == typemax(T) && return prevfloat(hi) # cf. Section 12.12.8
+        if lo == typemin(T) # cf. Section 12.12.8
+            α > 0.5 && return _normalisezero(hi)
+            return nextfloat(lo)
+        end
+        if hi == typemax(T) # cf. Section 12.12.8
+            α < 0.5 && return _normalisezero(lo)
+            return prevfloat(hi)
+        end
         β = convert(T, α)
         midpoint = β * (hi + lo * (1/β - 1)) # exactly 0.5 * (hi + lo) for β = 0.5
         midpoint = ifelse(isfinite(midpoint), midpoint, (1 - β) * lo + β * hi)
@@ -118,8 +127,14 @@ function mid(x::BareInterval{Rational{T}}, α = 1//2) where {T<:Integer}
         return convert(Rational{T}, typemin(T))
     else
         lo, hi = bounds(x)
-        lo == typemin(Rational{T}) && return convert(Rational{T}, typemin(T)) # cf. Section 12.12.8
-        hi == typemax(Rational{T}) && return convert(Rational{T}, typemax(T)) # cf. Section 12.12.8
+        if lo == typemin(Rational{T}) # cf. Section 12.12.8
+            α > 0.5 && return _normalisezero(hi)
+            return convert(Rational{T}, typemin(T))
+        end
+        if hi == typemax(Rational{T}) # cf. Section 12.12.8
+            α < 0.5 && return _normalisezero(lo)
+            return convert(Rational{T}, typemax(T))
+        end
         β = convert(Rational{T}, α)
         return _normalisezero((1 - β) * lo + β * hi)
     end

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -78,6 +78,16 @@ end
 
 bounds(x::Real) = bounds(interval(x))
 
+# analogues of `nextfloat(typemin(T))` and `prevfloat(typemax(T))` for
+# `Rational` bounds (cf. Section 12.12.8); unbounded integer types such as
+# `BigInt` have no smallest or largest finite value
+_finitemin(::Type{Rational{T}}) where {T<:Integer} = convert(Rational{T}, typemin(T))
+_finitemax(::Type{Rational{T}}) where {T<:Integer} = convert(Rational{T}, typemax(T))
+_finitemin(::Type{Rational{BigInt}}) =
+    throw(ArgumentError("cannot compute the midpoint of unbounded intervals with `Rational{BigInt}` bounds; there is no smallest finite `Rational{BigInt}`"))
+_finitemax(::Type{Rational{BigInt}}) =
+    throw(ArgumentError("cannot compute the midpoint of unbounded intervals with `Rational{BigInt}` bounds; there is no largest finite `Rational{BigInt}`"))
+
 """
     mid(x, α = 0.5)
 
@@ -123,17 +133,17 @@ function mid(x::BareInterval{Rational{T}}, α = 1//2) where {T<:Integer}
     isempty_interval(x) && return throw(ArgumentError("cannot compute the midpoint of empty intervals; cannot return a `Rational` NaN"))
     if isentire_interval(x)
         α == 0.5 && return zero(Rational{T})
-        α > 0.5 && return convert(Rational{T}, typemax(T))
-        return convert(Rational{T}, typemin(T))
+        α > 0.5 && return _finitemax(Rational{T})
+        return _finitemin(Rational{T})
     else
         lo, hi = bounds(x)
         if lo == typemin(Rational{T}) # cf. Section 12.12.8
             α > 0.5 && return _normalisezero(hi)
-            return convert(Rational{T}, typemin(T))
+            return _finitemin(Rational{T})
         end
         if hi == typemax(Rational{T}) # cf. Section 12.12.8
             α < 0.5 && return _normalisezero(lo)
-            return convert(Rational{T}, typemax(T))
+            return _finitemax(Rational{T})
         end
         β = convert(Rational{T}, α)
         return _normalisezero((1 - β) * lo + β * hi)

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -300,15 +300,17 @@ mig(x::Complex) = inf(abs(interval(x)))
 """
     dist(x, y)
 
-Distance between `x` and `y`.
+Upper bound of the Hausdorff distance between `x` and `y`: the bound
+differences are rounded upward, and equal bounds, including infinite ones, are
+at distance zero.
 """
 function dist(x::BareInterval{T}, y::BareInterval{T}) where {T<:AbstractFloat}
     isempty_interval(x) | isempty_interval(y) && return convert(T, NaN)
-    return max(abs(inf(x) - inf(y)), abs(sup(x) - sup(y)))
+    return max(_dist(inf(x), inf(y)), _dist(sup(x), sup(y)))
 end
 function dist(x::BareInterval{T}, y::BareInterval{T}) where {T<:Rational}
     isempty_interval(x) | isempty_interval(y) && return throw(ArgumentError("cannot compute the distance of empty intervals; cannot return a `Rational` NaN"))
-    return max(abs(inf(x) - inf(y)), abs(sup(x) - sup(y)))
+    return max(_dist(inf(x), inf(y)), _dist(sup(x), sup(y)))
 end
 dist(x::BareInterval, y::BareInterval) = dist(promote(x, y)...)
 
@@ -321,3 +323,11 @@ function dist(x::Interval{T}, y::Interval{T}) where {T<:Rational}
     return dist(bareinterval(x), bareinterval(y))
 end
 dist(x::Interval, y::Interval) = dist(promote(x, y)...)
+
+# used internally, upper bound of `abs(a - b)` with equal, possibly infinite,
+# bounds at distance zero
+function _dist(a::T, b::T) where {T<:NumTypes}
+    a == b && return zero(T)
+    isinf(a) & isinf(b) && return typemax(T) # opposite infinities
+    return _fround(-, max(a, b), min(a, b), RoundUp)
+end

--- a/src/intervals/interval_operations/numeric.jl
+++ b/src/intervals/interval_operations/numeric.jl
@@ -263,7 +263,11 @@ function mag(x::Interval{<:Rational})
 end
 
 mag(x::Real) = mag(interval(x))
-mag(x::Complex) = sup(abs(interval(x)))
+function mag(x::Complex)
+    z = interval(x)
+    isempty_interval(z) && return mag(emptyinterval(real(z)))
+    return sup(abs(z))
+end
 
 """
     mig(x)
@@ -295,7 +299,11 @@ function mig(x::Interval{<:Rational})
 end
 
 mig(x::Real) = mig(interval(x))
-mig(x::Complex) = inf(abs(interval(x)))
+function mig(x::Complex)
+    z = interval(x)
+    isempty_interval(z) && return mig(emptyinterval(real(z)))
+    return inf(abs(z))
+end
 
 """
     dist(x, y)

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -257,15 +257,20 @@ end
 #
 
 function interval_diff(x::Interval{T}, y::Interval) where {T<:NumTypes}
-    isdisjoint_interval(x, y) && return [x]
+    d = min(decoration(x), decoration(y))
+    d == ill && return [nai(T)] # one of the inputs is an NaI
+    t = isguaranteed(x) & isguaranteed(y)
+    # the pieces are decorated `trv` (Section 11.7.1), including in the
+    # disjoint branch where `x` is returned with its decoration downgraded
+    isdisjoint_interval(x, y) && return [_unsafe_interval(_bareinterval(x), trv, t)]
     issubset_interval(x, y) && return Interval{T}[]
 
     intersection = intersect_interval(x, y)
-    inf(x) == inf(intersection) && return [interval(sup(intersection), sup(x))]
-    sup(x) == sup(intersection) && return [interval(inf(x), inf(intersection))]
+    inf(x) == inf(intersection) && return [_unsafe_interval(_unsafe_bareinterval(T, sup(intersection), sup(x)), trv, t)]
+    sup(x) == sup(intersection) && return [_unsafe_interval(_unsafe_bareinterval(T, inf(x), inf(intersection)), trv, t)]
 
     return [
-        interval(inf(x), inf(intersection)),
-        interval(sup(intersection), sup(x))
+        _unsafe_interval(_unsafe_bareinterval(T, inf(x), inf(intersection)), trv, t),
+        _unsafe_interval(_unsafe_bareinterval(T, sup(intersection), sup(x)), trv, t)
     ]
 end

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -143,11 +143,11 @@ const union_interval = hull
 Remove the interior of `y` from `x`. If `x` and `y` are vectors, then they are
 treated as multi-dimensional intervals.
 
-The keywork `dec` argument controls the decoration of the result. It can be
+The keyword `dec` argument controls the decoration of the result. It can be
 either a specific decoration, or one of two following options:
 - `:default`: if at least one of the input intervals is `ill`,
   then the result is `ill`, otherwise it is `trv` (Section 11.7.1).
-- `:auto`: the ouptut has the minimal decoration of the inputs.
+- `:auto`: the output has the minimal decoration of the inputs.
 """
 interiordiff(x::BareInterval, y::BareInterval) =
     interiordiff!(Vector{promote_type(typeof(x), typeof(y))}(undef, 0), x, y)
@@ -162,7 +162,7 @@ interiordiff(x::AbstractVector{<:Interval}, y::AbstractVector{<:Interval}; dec =
     interiordiff!(Vector{promote_type(typeof(x), typeof(y))}(undef, 0), x, y; dec = dec)
 
 """
-    interiordiff!(x, y; dec = :default)
+    interiordiff!(v, x, y; dec = :default)
 
 In-place version of [`interiordiff`](@ref).
 """

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -163,25 +163,10 @@ interiordiff(x::AbstractVector{<:Interval}, y::AbstractVector{<:Interval}; dec =
 In-place version of [`interiordiff`](@ref).
 """
 function interiordiff!(v::AbstractVector, x::BareInterval{T}, y::BareInterval{T}) where {T<:NumTypes}
-    if isinterior(x, y)
-        empty!(v)
-    elseif isdisjoint_interval(x, y)
-        resize!(v, 1)
-        @inbounds v[begin] = x
-    else
-        inter = intersect_interval(x, y)
-        if issubset_interval(y, x)
-            resize!(v, 2)
-            @inbounds v[begin] = _unsafe_bareinterval(T, inf(x), inf(inter))
-            @inbounds v[end] = _unsafe_bareinterval(T, sup(inter), sup(x))
-        elseif isweakless(x, inter)
-            resize!(v, 1)
-            @inbounds v[begin] = _unsafe_bareinterval(T, inf(x), inf(inter))
-        else
-            resize!(v, 1)
-            @inbounds v[begin] = _unsafe_bareinterval(T, sup(inter), sup(x))
-        end
-    end
+    h₁, h₂, _ = _interiordiff(x, y, nothing)
+    empty!(v)
+    isempty_interval(h₁) || push!(v, h₁)
+    isempty_interval(h₂) || push!(v, h₂)
     return v
 end
 interiordiff!(v::AbstractVector, x::BareInterval, y::BareInterval) = interiordiff!(v, promote(x, y)...)
@@ -189,31 +174,17 @@ interiordiff!(v::AbstractVector{<:AbstractVector}, x::AbstractVector{<:BareInter
     _interiordiff!(v, x, y, nothing)
 
 function interiordiff!(v::AbstractVector, x::Interval{T}, y::Interval{T}; dec = :default) where {T<:NumTypes}
-    if isinterior(x, y)
-        empty!(v)
-    elseif isdisjoint_interval(x, y)
+    d = min(decoration(x), decoration(y))
+    if d == ill # one of the inputs is an NaI
         resize!(v, 1)
-        @inbounds v[begin] = x
-    else
-        d = min(decoration(x), decoration(y))
-        t = isguaranteed(x) & isguaranteed(y)
-        inter = intersect_interval(x, y)
-        if issubset_interval(y, x)
-            resize!(v, 2)
-            r1 = _unsafe_bareinterval(T, inf(x), inf(inter))
-            @inbounds v[begin] = _set_decoration(_unsafe_interval(r1, d, t), dec)
-            r2 = _unsafe_bareinterval(T, sup(inter), sup(x))
-            @inbounds v[end] = _set_decoration(_unsafe_interval(r2, d, t), dec)
-        elseif isweakless(x, inter)
-            resize!(v, 1)
-            r1 = _unsafe_bareinterval(T, inf(x), inf(inter))
-            @inbounds v[begin] = _set_decoration(_unsafe_interval(r1, d, t), dec)
-        else
-            resize!(v, 1)
-            r2 = _unsafe_bareinterval(T, sup(inter), sup(x))
-            @inbounds v[begin] = _set_decoration(_unsafe_interval(r2, d, t), dec)
-        end
+        @inbounds v[begin] = nai(T)
+        return v
     end
+    t = isguaranteed(x) & isguaranteed(y)
+    h₁, h₂, _ = _interiordiff(_bareinterval(x), _bareinterval(y), nothing)
+    empty!(v)
+    isempty_interval(h₁) || push!(v, _set_decoration(_unsafe_interval(h₁, d, t), dec))
+    isempty_interval(h₂) || push!(v, _set_decoration(_unsafe_interval(h₂, d, t), dec))
     return v
 end
 interiordiff!(v::AbstractVector, x::Interval, y::Interval; dec = :default) = interiordiff!(v, promote(x, y)...; dec = dec)
@@ -228,8 +199,14 @@ function _interiordiff!(v::AbstractVector{<:AbstractVector}, x::AbstractVector, 
     N == len || return throw(DimensionMismatch("x has length $N, y has length $len"))
 
     if any(t -> isdisjoint_interval(t[1], t[2]), zip(x, y))
-        resize!(v, 1)
-        @inbounds v[begin] = copy(x)
+        # mirror the filter of the general case: an empty or NaI component
+        # means that `x` does not describe a box
+        if any(t -> isempty_interval(t) | isnai(t), x)
+            empty!(v)
+        else
+            resize!(v, 1)
+            @inbounds v[begin] = copy(x)
+        end
     else
         resize!(v, 2N)
 
@@ -257,16 +234,16 @@ function _interiordiff!(v::AbstractVector{<:AbstractVector}, x::AbstractVector, 
 end
 
 function _interiordiff(x::BareInterval{T}, y::BareInterval{T}, ::Nothing) where {T<:NumTypes}
-    isdisjoint_interval(x, y) && return (x, emptyinterval(BareInterval{T}), emptyinterval(BareInterval{T}))
-
     inter = intersect_interval(x, y)
+    isdisjoint_interval(x, y) && return (x, emptyinterval(BareInterval{T}), inter)
     isinterior(x, y) && return (emptyinterval(BareInterval{T}), emptyinterval(BareInterval{T}), inter)
-    isequal_interval(x, y) && return (_unsafe_bareinterval(T, inf(x), inf(x)), _unsafe_bareinterval(T, sup(x), sup(x)), inter)
 
-    inf(x) == inf(inter) && return (_unsafe_bareinterval(T, sup(inter), sup(x)), emptyinterval(BareInterval{T}), inter)
-    sup(x) == sup(inter) && return (_unsafe_bareinterval(T, inf(x), inf(inter)), emptyinterval(BareInterval{T}), inter)
-
-    return (_unsafe_bareinterval(T, inf(x), inf(y)), _unsafe_bareinterval(T, sup(y), sup(x)), inter)
+    # a piece of `x` survives on a given side only if the corresponding bound
+    # of `y` is finite, since an infinite bound means that the interior of `y`
+    # is unbounded on that side
+    h₁ = (inf(x) ≤ inf(y)) & (inf(y) != typemin(T)) ? _unsafe_bareinterval(T, inf(x), inf(y)) : emptyinterval(BareInterval{T})
+    h₂ = (sup(y) ≤ sup(x)) & (sup(y) != typemax(T)) ? _unsafe_bareinterval(T, sup(y), sup(x)) : emptyinterval(BareInterval{T})
+    return (h₁, h₂, inter)
 end
 _interiordiff(x::BareInterval, y::BareInterval, dec::Nothing) = _interiordiff(promote(x, y)..., dec)
 

--- a/src/intervals/interval_operations/set_operations.jl
+++ b/src/intervals/interval_operations/set_operations.jl
@@ -5,7 +5,7 @@
 _set_decoration(x::Interval, d::Decoration) = setdecoration(x, d)
 
 function _set_decoration(x::Interval, d::Symbol)
-    d === :auto    && return x
+    d === :auto    && return setdecoration(x, decoration(x))
     d === :default && return setdecoration(x, min(trv, decoration(x)))
     return throw(ArgumentError("decoration option must be `:default`, `:auto` or a specific decoration"))
 end
@@ -39,7 +39,6 @@ function intersect_interval(x::Interval{T}, y::Interval{S}; dec = :default) wher
     d == ill && return nai(promote_type(T, S)) # one of the inputs is an NaI
     r = intersect_interval(_bareinterval(x), _bareinterval(y))
     t = isguaranteed(x) & isguaranteed(y)
-    dec === :default && return _unsafe_interval(r, trv, t)
     return _set_decoration(_unsafe_interval(r, d, t), dec)
 end
 
@@ -60,7 +59,6 @@ function intersect_interval(x::Interval, y::Interval, z::Interval, w::Vararg{Int
     d = mapreduce(decoration, min, xs)
     d == ill && return nai(numtype(r)) # one of the inputs is an NaI
     t = mapreduce(isguaranteed, &, xs)
-    dec === :default && return _unsafe_interval(r, trv, t)
     return _set_decoration(_unsafe_interval(r, d, t), dec)
 end
 
@@ -98,7 +96,6 @@ function hull(x::Interval{T}, y::Interval{S}; dec = :default) where {T<:NumTypes
     d == ill && return nai(promote_type(T, S)) # one of the inputs is an NaI
     r = hull(_bareinterval(x), _bareinterval(y))
     t = isguaranteed(x) & isguaranteed(y)
-    dec === :default && return _unsafe_interval(r, trv, t)
     return _set_decoration(_unsafe_interval(r, d, t), dec)
 end
 
@@ -119,7 +116,6 @@ function hull(x::Interval, y::Interval, z::Interval, w::Vararg{Interval,N}; dec 
     d = mapreduce(decoration, min, xs)
     d == ill && return nai(numtype(r)) # one of the inputs is an NaI
     t = mapreduce(isguaranteed, &, xs)
-    dec === :default && return _unsafe_interval(r, trv, t)
     return _set_decoration(_unsafe_interval(r, d, t), dec)
 end
 

--- a/test/interval_tests/display.jl
+++ b/test/interval_tests/display.jl
@@ -50,7 +50,7 @@ setprecision(BigFloat, 256) do
 
             @test sprint(show, MIME("text/plain"), emptyinterval(BareInterval{Float64})) == "∅"
 
-            @test sprint(show, MIME("text/plain"), a) == "0.65 ± 0.65"
+            @test sprint(show, MIME("text/plain"), a) == "0.65 ± 0.650001"
             @test sprint(show, MIME("text/plain"), large_expo) ==
                 "(5.0e+123456788 ± 5.0e+123456788)₂₅₆"
         end
@@ -156,9 +156,9 @@ setprecision(BigFloat, 256) do
 
                 @test sprint(show, MIME("text/plain"), a)    == "(1.5 ± 0.5)_com"
                 @test sprint(show, MIME("text/plain"), a_NG) == "(1.5 ± 0.5)_com_NG"
-                @test sprint(show, MIME("text/plain"), b)    == "(0.65 ± 0.65)_com"
-                @test sprint(show, MIME("text/plain"), b32)  == "(0.65f0 ± 0.65f0)_com"
-                @test sprint(show, MIME("text/plain"), b16)  == "(Float16(0.65) ± Float16(0.65))_com"
+                @test sprint(show, MIME("text/plain"), b)    == "(0.65 ± 0.650001)_com"
+                @test sprint(show, MIME("text/plain"), b32)  == "(0.65f0 ± 0.650001f0)_com"
+                @test sprint(show, MIME("text/plain"), b16)  == "(Float16(0.65) ± Float16(0.6504))_com"
                 @test sprint(show, MIME("text/plain"), br)   == "(1//10 ± 6//5)_com"
                 @test sprint(show, MIME("text/plain"), c)    == "(1.79769e+308 ± ∞)_dac"
                 @test sprint(show, MIME("text/plain"), cr)   == "(9223372036854775807//1 ± ∞)_dac"
@@ -174,9 +174,9 @@ setprecision(BigFloat, 256) do
 
                 @test sprint(show, MIME("text/plain"), a)    == "1.5 ± 0.5"
                 @test sprint(show, MIME("text/plain"), a_NG) == "(1.5 ± 0.5)_NG"
-                @test sprint(show, MIME("text/plain"), b)    == "0.65 ± 0.65"
-                @test sprint(show, MIME("text/plain"), b32)  == "0.65f0 ± 0.65f0"
-                @test sprint(show, MIME("text/plain"), b16)  == "Float16(0.65) ± Float16(0.65)"
+                @test sprint(show, MIME("text/plain"), b)    == "0.65 ± 0.650001"
+                @test sprint(show, MIME("text/plain"), b32)  == "0.65f0 ± 0.650001f0"
+                @test sprint(show, MIME("text/plain"), b16)  == "Float16(0.65) ± Float16(0.6504)"
                 @test sprint(show, MIME("text/plain"), br)   == "1//10 ± 6//5"
                 @test sprint(show, MIME("text/plain"), c)    == "1.79769e+308 ± ∞"
                 @test sprint(show, MIME("text/plain"), cr)   == "9223372036854775807//1 ± ∞"


### PR DESCRIPTION
This PR fixes a set of bugs in `src/intervals/interval_operations/`. The regression tests for every item are contributed separately, as part of the test-suite rework #775.

- `midradius` computed the radius with round-to-nearest subtractions, so the enclosure promised by the `radius` docstring could fail. The radius is now rounded upward (Section 12.12.8). Closes #776.

```julia
x = interval(-3.514641998989496e-149, 2.2210542297708545e247)
issubset_interval(x, interval(mid(x), radius(x); format = :midpoint))
# before: false — mid(x) ± radius(x) lost the negative part of x
# after:  true
```
(As a consequence, the midpoint display of e.g. `interval(0, 1.3)` is now the honest `0.65 ± 0.650001` instead of `0.65 ± 0.65`.)

- `cancelminus` and `cancelplus` threw a `MethodError` for every non-degenerate `Rational` interval, and did not propagate NaI when `dec` was given explicitly.

```julia
cancelminus(interval(1//1, 2//1), interval(1//2, 1//1))
# before: MethodError: no method matching prevfloat(::Rational{Int64})
# after:  [1//2, 1//1]_trv

isnai(cancelminus(nai(), interval(1, 2); dec = com))
# before: false, plus a spurious "interval part of NaI" warning
# after:  true, no warning
```

- `interiordiff` returned the wrong piece when `x ⊆ y` and they share one endpoint, and the scalar and vector paths disagreed on identical inputs. Both now return exactly the pieces of `x \ interior(y)`.

```julia
interiordiff(interval(2, 3), interval(1, 3))          # x \ int(y) = {3}
# before: [[2.0, 2.0]_trv] — but 2 is in the interior of y
# after:  [[3.0, 3.0]_trv]

only.(interiordiff([interval(1, 2)], [interval(1, 3)]))  # x \ int(y) = {1}
# before: [[2.0, 2.0]_trv] — and the scalar call returned {1}
# after:  [[1.0, 1.0]_trv]
```

- `interiordiff` produced invalid intervals for unbounded operands, fabricated NaN bounds for NaI inputs, and ignored the `dec` keyword in its disjoint branch.

```julia
interiordiff(interval(-Inf, 3), interval(-Inf, 2))
# before: [[-Inf, -Inf]_trv, [2.0, 3.0]_trv] — the first piece is not a valid interval
# after:  [[2.0, 3.0]_trv]

only(interiordiff(nai(), interval(1, 2)))
# before: an interval with NaN bounds
# after:  NaI

interiordiff(interval(1, 2), interval(3, 4); dec = trv)
# before: [[1.0, 2.0]_com] — keyword ignored
# after:  [[1.0, 2.0]_trv]
```

- `mince` produced invalid intervals (`inf > sup`, decorated `com`) because `LinRange` does not interpolate monotonically, and `mince!` wrote out of bounds under `@inbounds` when given a short vector.

```julia
v = mince(interval(1.0, nextfloat(1.0)), 13)
all(z -> inf(z) ≤ sup(z), v)
# before: false — one piece had inf > sup, decoration com, diam == -2.2e-16
# after:  true

mince!(Vector{BareInterval{Float64}}(undef, 2), bareinterval(0.0, 1.0), 8)
# before: 6 out-of-bounds writes (silent memory corruption; segfault for large n)
# after:  the vector is resized to length 8, like the vector-of-intervals method
```

- `dist` returned NaN (floats) or threw (rationals) for intervals sharing an infinite endpoint. It is now documented and implemented as an upper bound of the Hausdorff distance, with the bound differences rounded upward.

```julia
dist(entireinterval(), entireinterval())
# before: NaN
# after:  0.0

dist(bareinterval(Rational{Int}, -1//0, 1//0), bareinterval(Rational{Int}, -1//0, 1//0))
# before: DivideError
# after:  0//1

dist(bareinterval(-1.0, 4.0), bareinterval(-1.0, 3e-16))
# before: 3.9999999999999996 — underestimates the exact distance 4 - 3e-16
# after:  4.0
```

- `intersect_interval` with `dec = :auto` could attach a decoration the result cannot carry. The `:auto` path now goes through the clamping `setdecoration`, and the four redundant `dec === :default` fast-paths in `intersect_interval`/`hull` were removed (provably equivalent to `_set_decoration`).

```julia
intersect_interval(interval(1, 2), interval(3, 4); dec = :auto)
# before: ∅_com — an empty interval can only be trv or ill (Section 11.5.2)
# after:  ∅_trv
```

- `mid(x, α)` ignored `α` for half-unbounded intervals. `α` now acts as a threshold: the finite bound is returned when `α` selects its side, the Section 12.12.8 clamp otherwise; `mid(x)` and `mid(x, 0.5)` are unchanged.

```julia
mid(interval(-Inf, 0), 1)
# before: -1.7976931348623157e308 — the docstring promises the upper bound
# after:  0.0
```

- `mid`, `radius` and `midradius` threw a raw `MethodError` for unbounded `Rational{BigInt}` intervals. `Rational` bounds mirror the float behaviour; where that is impossible an informative error is thrown.

```julia
mid(bareinterval(Rational{BigInt}, -1//0, 3//1))
# before: MethodError: no method matching typemin(::Type{BigInt})
# after:  ArgumentError: cannot compute the midpoint of unbounded intervals with
#         `Rational{BigInt}` bounds; there is no smallest finite `Rational{BigInt}`

mid(bareinterval(Rational{BigInt}, -1//0, 3//1), 1//1)
# before: MethodError
# after:  3//1 — no clamp is needed when α selects the finite bound
```

- `extended_div` was the only binary operation without a promoting fallback for mixed bound types.

```julia
extended_div(interval(Float32, 1, 2), interval(-4.0, 4.0))
# before: MethodError: no method matching extended_div(::BareInterval{Float32}, ::BareInterval{Float64})
# after:  ((-∞, -0.25]_trv, [0.25, ∞)_trv) — same as the all-Float64 call
```

- `isnai` on a complex interval required both components to be NaI, contradicting `isnan`. Any NaI component now invalidates the pair.

```julia
z = complex(nai(), interval(1))
isnai(z)
# before: false — while isnan(z) == true on the same object
# after:  true
```

- `isstrictsubset` of a real interval in a complex one missed strict growth in the imaginary part. All `isstrictsubset` methods now use the same definitional idiom `issubset_interval(x, y) & !isequal_interval(x, y)`.

```julia
isstrictsubset(interval(0, 1), complex(interval(0, 1), interval(-1, 1)))
# before: false — but [0,1] × {0} is strictly contained in [0,1] × [-1,1]
# after:  true
```

- `isdisjoint_interval` with a mixed Complex/Interval argument asserted disjointness from an NaI component. Any NaI input now yields `false` (Section 12.12.9), like the Interval/Interval method.

```julia
isdisjoint_interval(complex(interval(1, 2), nai()), interval(0, 3))
# before: true
# after:  false
```

- `mag` and `mig` of a complex interval with an empty component returned `-Inf`/`+Inf`. They now follow the real-interval convention for the empty set.

```julia
mag(complex(emptyinterval(), emptyinterval())), mig(complex(emptyinterval(), emptyinterval()))
# before: (-Inf, Inf) — a negative magnitude, with mag < mig
# after:  (NaN, NaN)
```

- Docstring corrections (no behaviour change): `cancelplus` stated the wrong defining equation (`y - z == x` instead of `z - y == x`); `emptyinterval` stated the bound-ordering invariant backwards; `precedes`/`strictprecedes` said "any element" for a universally quantified test; `isweakless` carried a copy-pasted clause from `isstrictless`; the `interiordiff!` signature omitted the destination vector; `extended_div` now notes it corresponds to `mulRevToPair(y, x)` of the standard; plus a few typos.

```julia
x, y = interval(5, 7), interval(1, 2)
z = cancelplus(x, y)                      # [7.0, 8.0]
isequal_interval(z - y, x), isequal_interval(y - z, x)
# (true, false) — the docstring claimed the second identity; it now states the first
```

The full test suite (all `interval_tests`, all ITF1788 conformance files, Aqua) passes with these changes; the values pinned by ITF1788 (e.g. `mid(bareinterval(-Inf, 1.2))`, the `cancelminus` corner cases) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
